### PR TITLE
Add ESLint and Prettier for frontend

### DIFF
--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -1,0 +1,32 @@
+name: Frontend Lint & Format
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+
+jobs:
+  lint:
+    name: ESLint & Prettier
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run format:check

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
     paths:
       - 'frontend/**'
+      - '.github/workflows/frontend-lint.yml'
   pull_request:
     branches: [main]
     paths:
       - 'frontend/**'
+      - '.github/workflows/frontend-lint.yml'
 
 jobs:
   lint:
@@ -23,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: '22'
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+*.min.js
+*.min.css

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,22 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import eslintConfigPrettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+  { ignores: ['dist'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{ts,tsx}'],
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    },
+  },
+  eslintConfigPrettier,
+);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,13 +12,20 @@
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.4",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
+        "eslint": "^9.39.4",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-refresh": "^0.4.26",
         "postcss": "^8.4.49",
+        "prettier": "^3.8.2",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.7.0",
+        "typescript-eslint": "^8.58.1",
         "vite": "^6.0.0"
       }
     },
@@ -759,6 +766,202 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1256,6 +1459,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -1274,6 +1484,301 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
+      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/type-utils": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.58.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
+      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
+      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.1",
+        "@typescript-eslint/types": "^8.58.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
+      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
+      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
+      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
+      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.1",
+        "@typescript-eslint/tsconfig-utils": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
+      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
+      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1295,6 +1800,62 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/any-promise": {
@@ -1324,6 +1885,13 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
@@ -1362,6 +1930,13 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.9",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.9.tgz",
@@ -1386,6 +1961,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
@@ -1435,6 +2021,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -1465,6 +2061,23 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -1504,6 +2117,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1514,12 +2147,34 @@
         "node": ">= 6"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -1558,6 +2213,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -1632,6 +2294,219 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
+      "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=8.40"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -1662,6 +2537,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -1670,6 +2559,19 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -1684,6 +2586,44 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fraction.js": {
       "version": "5.3.4",
@@ -1747,6 +2687,29 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -1758,6 +2721,43 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/is-binary-path": {
@@ -1822,6 +2822,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -1839,6 +2846,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -1852,6 +2872,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -1863,6 +2904,30 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lilconfig": {
@@ -1882,6 +2947,29 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1917,6 +3005,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -1957,6 +3058,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
@@ -1992,6 +3100,89 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-parse": {
@@ -2204,6 +3395,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2298,6 +3525,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/reusify": {
@@ -2396,6 +3633,29 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2404,6 +3664,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sucrase": {
@@ -2427,6 +3700,19 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -2564,12 +3850,38 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -2583,6 +3895,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
+      "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.58.1",
+        "@typescript-eslint/parser": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -2614,6 +3950,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -2729,12 +4075,51 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,20 +6,31 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint src/",
+    "lint:fix": "eslint src/ --fix",
+    "format": "prettier --write src/",
+    "format:check": "prettier --check src/"
   },
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
+    "eslint": "^9.39.4",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.26",
     "postcss": "^8.4.49",
+    "prettier": "^3.8.2",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.0",
+    "typescript-eslint": "^8.58.1",
     "vite": "^6.0.0"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,173 +1,170 @@
-import { useState, useEffect, useCallback } from 'react'
-import type { Bundle, StateSummary, Question, Screen, QuizMode, SessionResult } from './types'
-import { loadI18n, getLang, setLang } from './i18n'
-import { useStore } from './hooks/useStore'
-import LoadingScreen from './components/LoadingScreen'
-import StatePicker from './components/StatePicker'
-import StartScreen from './components/StartScreen'
-import QuizScreen from './components/QuizScreen'
-import ResultsScreen from './components/ResultsScreen'
-import StatsScreen from './components/StatsScreen'
+import { useState, useEffect, useCallback } from 'react';
+import type {
+  Bundle,
+  StateConfig,
+  StateSummary,
+  Question,
+  Screen,
+  QuizMode,
+  SessionResult,
+} from './types';
+import { loadI18n, getLang, setLang } from './i18n';
+import { useStore } from './hooks/useStore';
+import LoadingScreen from './components/LoadingScreen';
+import StatePicker from './components/StatePicker';
+import StartScreen from './components/StartScreen';
+import QuizScreen from './components/QuizScreen';
+import ResultsScreen from './components/ResultsScreen';
+import StatsScreen from './components/StatsScreen';
 
-const BASE = import.meta.env.BASE_URL
+const BASE = import.meta.env.BASE_URL;
 
 function shuffleArray<T>(arr: T[]): T[] {
-  const a = [...arr]
+  const a = [...arr];
   for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1))
-    ;[a[i], a[j]] = [a[j], a[i]]
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
   }
-  return a
+  return a;
 }
 
 export default function App() {
-  const [screen, setScreen] = useState<Screen>('loading')
-  const [bundle, setBundle] = useState<Bundle | null>(null)
-  const [allStates, setAllStates] = useState<StateSummary[]>([])
-  const [currentState, setCurrentState] = useState<StateSummary | null>(null)
-  const [lang, setLangState] = useState(getLang())
-  const [quizMode, setQuizMode] = useState<QuizMode>('random')
-  const [selectedCount, setSelectedCount] = useState(50)
-  const [questions, setQuestions] = useState<Question[]>([])
-  const [currentIdx, setCurrentIdx] = useState(0)
-  const [correctCount, setCorrectCount] = useState(0)
-  const [wrongCount, setWrongCount] = useState(0)
-  const [sessionResults, setSessionResults] = useState<SessionResult[]>([])
+  const [screen, setScreen] = useState<Screen>('loading');
+  const [bundle, setBundle] = useState<Bundle | null>(null);
+  const [allStates, setAllStates] = useState<StateSummary[]>([]);
+  const [currentState, setCurrentState] = useState<StateSummary | null>(null);
+  const [lang, setLangState] = useState(getLang());
+  const [quizMode, setQuizMode] = useState<QuizMode>('random');
+  const [selectedCount, setSelectedCount] = useState(50);
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [currentIdx, setCurrentIdx] = useState(0);
+  const [correctCount, setCorrectCount] = useState(0);
+  const [wrongCount, setWrongCount] = useState(0);
+  const [sessionResults, setSessionResults] = useState<SessionResult[]>([]);
 
-  const store = useStore(currentState?.code ?? null)
+  const store = useStore(currentState?.code ?? null);
 
   // Load bundle and i18n
   useEffect(() => {
-    Promise.all([
-      loadI18n(BASE),
-      fetch(`${BASE}questions_bundle.json`).then(r => r.json()),
-    ]).then(([, bundleData]) => {
-      setBundle(bundleData)
-      const states: StateSummary[] = bundleData.states.map((s: any) => ({
-        code: s.code,
-        name: s.name,
-        agency: s.agency,
-        passing_score_pct: s.passing_score_pct,
-        test_question_count: s.test_question_count,
-        languages: Object.keys(s.languages),
-        total_questions: (s.languages.en || []).length,
-      }))
-      setAllStates(states)
+    Promise.all([loadI18n(BASE), fetch(`${BASE}questions_bundle.json`).then((r) => r.json())]).then(
+      ([, bundleData]) => {
+        setBundle(bundleData);
+        const states: StateSummary[] = bundleData.states.map((s: StateConfig) => ({
+          code: s.code,
+          name: s.name,
+          agency: s.agency,
+          passing_score_pct: s.passing_score_pct,
+          test_question_count: s.test_question_count,
+          languages: Object.keys(s.languages),
+          total_questions: (s.languages.en || []).length,
+        }));
+        setAllStates(states);
 
-      const saved = localStorage.getItem('quiz_state')
-      if (saved) {
-        const s = states.find(st => st.code === saved && st.total_questions > 0)
-        if (s) {
-          setCurrentState(s)
-          setScreen('start')
-          return
+        const saved = localStorage.getItem('quiz_state');
+        if (saved) {
+          const s = states.find((st) => st.code === saved && st.total_questions > 0);
+          if (s) {
+            setCurrentState(s);
+            setScreen('start');
+            return;
+          }
         }
-      }
-      setScreen('state-picker')
-    })
-  }, [])
+        setScreen('state-picker');
+      },
+    );
+  }, []);
 
   const switchLang = useCallback((newLang: string) => {
-    setLang(newLang)
-    setLangState(newLang)
-  }, [])
+    setLang(newLang);
+    setLangState(newLang);
+  }, []);
 
-  const selectState = useCallback((code: string) => {
-    const s = allStates.find(st => st.code === code)
-    if (s) {
-      setCurrentState(s)
-      localStorage.setItem('quiz_state', code)
-      setScreen('start')
-      setQuizMode('random')
-    }
-  }, [allStates])
+  const selectState = useCallback(
+    (code: string) => {
+      const s = allStates.find((st) => st.code === code);
+      if (s) {
+        setCurrentState(s);
+        localStorage.setItem('quiz_state', code);
+        setScreen('start');
+        setQuizMode('random');
+      }
+    },
+    [allStates],
+  );
 
-  const getQuestions = useCallback((stateCode: string, language: string): Question[] => {
-    if (!bundle) return []
-    const sd = bundle.states.find(s => s.code === stateCode)
-    if (!sd) return []
-    return sd.languages[language] || sd.languages['en'] || []
-  }, [bundle])
+  const getQuestions = useCallback(
+    (stateCode: string, language: string): Question[] => {
+      if (!bundle) return [];
+      const sd = bundle.states.find((s) => s.code === stateCode);
+      if (!sd) return [];
+      return sd.languages[language] || sd.languages['en'] || [];
+    },
+    [bundle],
+  );
 
   const startQuiz = useCallback(() => {
-    if (!currentState) return
-    let qs: Question[]
-    const allQs = getQuestions(currentState.code, lang)
+    if (!currentState) return;
+    let qs: Question[];
+    const allQs = getQuestions(currentState.code, lang);
 
     if (quizMode === 'weak') {
-      const storeData = store.load()
+      const storeData = store.load();
       const weakIds = Object.entries(storeData.questions)
         .filter(([, d]) => d.wrong > 0 && d.seen >= 1)
-        .sort((a, b) => (b[1].wrong / b[1].seen) - (a[1].wrong / a[1].seen))
-        .map(([id]) => parseInt(id))
-      const idSet = new Set(weakIds.slice(0, selectedCount))
-      qs = shuffleArray(allQs.filter(q => idSet.has(q.id))).slice(0, selectedCount)
+        .sort((a, b) => b[1].wrong / b[1].seen - a[1].wrong / a[1].seen)
+        .map(([id]) => parseInt(id));
+      const idSet = new Set(weakIds.slice(0, selectedCount));
+      qs = shuffleArray(allQs.filter((q) => idSet.has(q.id))).slice(0, selectedCount);
     } else {
-      qs = shuffleArray(allQs).slice(0, Math.min(selectedCount, allQs.length))
+      qs = shuffleArray(allQs).slice(0, Math.min(selectedCount, allQs.length));
     }
 
-    setQuestions(qs)
-    setCurrentIdx(0)
-    setCorrectCount(0)
-    setWrongCount(0)
-    setSessionResults([])
-    setScreen('quiz')
-  }, [currentState, lang, quizMode, selectedCount, getQuestions, store])
+    setQuestions(qs);
+    setCurrentIdx(0);
+    setCorrectCount(0);
+    setWrongCount(0);
+    setSessionResults([]);
+    setScreen('quiz');
+  }, [currentState, lang, quizMode, selectedCount, getQuestions, store]);
 
-  const recordAnswer = useCallback((result: SessionResult, isCorrect: boolean) => {
-    setSessionResults(prev => [...prev, result])
-    if (isCorrect) setCorrectCount(c => c + 1)
-    else setWrongCount(c => c + 1)
+  const recordAnswer = useCallback(
+    (result: SessionResult, isCorrect: boolean) => {
+      setSessionResults((prev) => [...prev, result]);
+      if (isCorrect) setCorrectCount((c) => c + 1);
+      else setWrongCount((c) => c + 1);
 
-    const storeData = store.load()
-    const qId = String(result.id)
-    if (!storeData.questions[qId]) {
-      storeData.questions[qId] = { seen: 0, wrong: 0, category: '' }
-    }
-    storeData.questions[qId].seen++
-    if (!isCorrect) storeData.questions[qId].wrong++
-    store.save(storeData)
-  }, [store])
-
-  const nextQuestion = useCallback(() => {
-    if (currentIdx + 1 >= questions.length) {
-      // Save result to history
-      const pct = Math.round(((correctCount + (currentIdx + 1 === questions.length ? 0 : 0)) / questions.length) * 100)
-      const storeData = store.load()
-      storeData.history.push({
-        date: new Date().toISOString(),
-        correct: correctCount,
-        total: questions.length,
-        pct,
-        mode: quizMode,
-      })
-      store.save(storeData)
-      setScreen('results')
-    } else {
-      setCurrentIdx(i => i + 1)
-    }
-  }, [currentIdx, questions.length, correctCount, store, quizMode])
+      const storeData = store.load();
+      const qId = String(result.id);
+      if (!storeData.questions[qId]) {
+        storeData.questions[qId] = { seen: 0, wrong: 0, category: '' };
+      }
+      storeData.questions[qId].seen++;
+      if (!isCorrect) storeData.questions[qId].wrong++;
+      store.save(storeData);
+    },
+    [store],
+  );
 
   const finishQuiz = useCallback(() => {
-    const pct = Math.round((correctCount / questions.length) * 100)
-    const storeData = store.load()
+    const pct = Math.round((correctCount / questions.length) * 100);
+    const storeData = store.load();
     storeData.history.push({
       date: new Date().toISOString(),
       correct: correctCount,
       total: questions.length,
       pct,
       mode: quizMode,
-    })
-    store.save(storeData)
-    setScreen('results')
-  }, [correctCount, questions.length, store, quizMode])
+    });
+    store.save(storeData);
+    setScreen('results');
+  }, [correctCount, questions.length, store, quizMode]);
 
   const goHome = useCallback(() => {
-    setScreen('start')
-    setQuizMode('random')
-  }, [])
+    setScreen('start');
+    setQuizMode('random');
+  }, []);
 
-  if (screen === 'loading') return <LoadingScreen />
+  if (screen === 'loading') return <LoadingScreen />;
 
   return (
     <div className="max-w-lg mx-auto px-4 py-4">
@@ -204,7 +201,9 @@ export default function App() {
           store={store}
           basePath={BASE}
           onAnswer={recordAnswer}
-          onNext={currentIdx + 1 >= questions.length ? finishQuiz : () => setCurrentIdx(i => i + 1)}
+          onNext={
+            currentIdx + 1 >= questions.length ? finishQuiz : () => setCurrentIdx((i) => i + 1)
+          }
         />
       )}
       {screen === 'results' && currentState && (
@@ -219,12 +218,8 @@ export default function App() {
         />
       )}
       {screen === 'stats' && currentState && (
-        <StatsScreen
-          state={currentState}
-          store={store}
-          onBack={goHome}
-        />
+        <StatsScreen state={currentState} store={store} onBack={goHome} />
       )}
     </div>
-  )
+  );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,16 +38,24 @@ export default function App() {
   const [selectedCount, setSelectedCount] = useState(50);
   const [questions, setQuestions] = useState<Question[]>([]);
   const [currentIdx, setCurrentIdx] = useState(0);
-  const [correctCount, setCorrectCount] = useState(0);
-  const [wrongCount, setWrongCount] = useState(0);
   const [sessionResults, setSessionResults] = useState<SessionResult[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const correctCount = sessionResults.filter((r) => r.correct).length;
+  const wrongCount = sessionResults.filter((r) => !r.correct).length;
 
   const store = useStore(currentState?.code ?? null);
 
   // Load bundle and i18n
   useEffect(() => {
-    Promise.all([loadI18n(BASE), fetch(`${BASE}questions_bundle.json`).then((r) => r.json())]).then(
-      ([, bundleData]) => {
+    Promise.all([
+      loadI18n(BASE),
+      fetch(`${BASE}questions_bundle.json`).then((r) => {
+        if (!r.ok) throw new Error(`Failed to load questions: ${r.status}`);
+        return r.json();
+      }),
+    ])
+      .then(([, bundleData]) => {
         setBundle(bundleData);
         const states: StateSummary[] = bundleData.states.map((s: StateConfig) => ({
           code: s.code,
@@ -70,8 +78,10 @@ export default function App() {
           }
         }
         setScreen('state-picker');
-      },
-    );
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : 'Failed to load application data');
+      });
   }, []);
 
   const switchLang = useCallback((newLang: string) => {
@@ -121,8 +131,6 @@ export default function App() {
 
     setQuestions(qs);
     setCurrentIdx(0);
-    setCorrectCount(0);
-    setWrongCount(0);
     setSessionResults([]);
     setScreen('quiz');
   }, [currentState, lang, quizMode, selectedCount, getQuestions, store]);
@@ -130,8 +138,6 @@ export default function App() {
   const recordAnswer = useCallback(
     (result: SessionResult, isCorrect: boolean) => {
       setSessionResults((prev) => [...prev, result]);
-      if (isCorrect) setCorrectCount((c) => c + 1);
-      else setWrongCount((c) => c + 1);
 
       const storeData = store.load();
       const qId = String(result.id);
@@ -163,6 +169,21 @@ export default function App() {
     setScreen('start');
     setQuizMode('random');
   }, []);
+
+  if (error) {
+    return (
+      <div className="max-w-lg mx-auto px-4 py-20 text-center">
+        <div className="text-red-600 text-lg font-semibold mb-2">Failed to load</div>
+        <div className="text-gray-600 text-sm mb-4">{error}</div>
+        <button
+          onClick={() => window.location.reload()}
+          className="px-6 py-2 bg-blue-600 text-white rounded-xl text-sm font-semibold cursor-pointer hover:bg-blue-700 transition-colors"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
 
   if (screen === 'loading') return <LoadingScreen />;
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,8 @@ import type {
 } from './types';
 import { loadI18n, getLang, setLang } from './i18n';
 import { useStore } from './hooks/useStore';
+import { shuffleArray } from './utils';
+import { DEFAULT_QUESTION_COUNT } from './constants';
 import LoadingScreen from './components/LoadingScreen';
 import StatePicker from './components/StatePicker';
 import StartScreen from './components/StartScreen';
@@ -19,15 +21,6 @@ import StatsScreen from './components/StatsScreen';
 
 const BASE = import.meta.env.BASE_URL;
 
-function shuffleArray<T>(arr: T[]): T[] {
-  const a = [...arr];
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [a[i], a[j]] = [a[j], a[i]];
-  }
-  return a;
-}
-
 export default function App() {
   const [screen, setScreen] = useState<Screen>('loading');
   const [bundle, setBundle] = useState<Bundle | null>(null);
@@ -35,7 +28,7 @@ export default function App() {
   const [currentState, setCurrentState] = useState<StateSummary | null>(null);
   const [lang, setLangState] = useState(getLang());
   const [quizMode, setQuizMode] = useState<QuizMode>('random');
-  const [selectedCount, setSelectedCount] = useState(50);
+  const [selectedCount, setSelectedCount] = useState(DEFAULT_QUESTION_COUNT);
   const [questions, setQuestions] = useState<Question[]>([]);
   const [currentIdx, setCurrentIdx] = useState(0);
   const [sessionResults, setSessionResults] = useState<SessionResult[]>([]);

--- a/frontend/src/components/LangBar.tsx
+++ b/frontend/src/components/LangBar.tsx
@@ -1,20 +1,20 @@
-import { getAllLangs, getLangLabel } from '../i18n'
+import { getAllLangs, getLangLabel } from '../i18n';
 
 interface LangBarProps {
-  currentLang: string
-  availableLangs?: string[]
-  onSwitch: (lang: string) => void
+  currentLang: string;
+  availableLangs?: string[];
+  onSwitch: (lang: string) => void;
 }
 
 export default function LangBar({ currentLang, availableLangs, onSwitch }: LangBarProps) {
-  const allLangs = getAllLangs()
-  const available = new Set(availableLangs || allLangs)
+  const allLangs = getAllLangs();
+  const available = new Set(availableLangs || allLangs);
 
   return (
     <div className="flex justify-end gap-1 mb-3">
-      {allLangs.map(lang => {
-        const disabled = !available.has(lang)
-        const active = lang === currentLang && !disabled
+      {allLangs.map((lang) => {
+        const disabled = !available.has(lang);
+        const active = lang === currentLang && !disabled;
         return (
           <button
             key={lang}
@@ -26,8 +26,8 @@ export default function LangBar({ currentLang, availableLangs, onSwitch }: LangB
           >
             {getLangLabel(lang)}
           </button>
-        )
+        );
       })}
     </div>
-  )
+  );
 }

--- a/frontend/src/components/LoadingScreen.tsx
+++ b/frontend/src/components/LoadingScreen.tsx
@@ -4,5 +4,5 @@ export default function LoadingScreen() {
       <div className="inline-block w-8 h-8 border-[3px] border-gray-200 border-t-blue-600 rounded-full spinner mb-4" />
       <div>Loading questions...</div>
     </div>
-  )
+  );
 }

--- a/frontend/src/components/QuizScreen.tsx
+++ b/frontend/src/components/QuizScreen.tsx
@@ -1,67 +1,86 @@
-import { useState, useEffect, useCallback } from 'react'
-import type { Question, SessionResult } from '../types'
-import { t } from '../i18n'
-import { useStore } from '../hooks/useStore'
+import { useState, useEffect, useCallback } from 'react';
+import type { Question, SessionResult } from '../types';
+import { t } from '../i18n';
+import { useStore } from '../hooks/useStore';
 
 interface QuizScreenProps {
-  question: Question
-  currentIdx: number
-  totalQuestions: number
-  correctCount: number
-  wrongCount: number
-  store: ReturnType<typeof useStore>
-  basePath: string
-  onAnswer: (result: SessionResult, isCorrect: boolean) => void
-  onNext: () => void
+  question: Question;
+  currentIdx: number;
+  totalQuestions: number;
+  correctCount: number;
+  wrongCount: number;
+  store: ReturnType<typeof useStore>;
+  basePath: string;
+  onAnswer: (result: SessionResult, isCorrect: boolean) => void;
+  onNext: () => void;
 }
 
 export default function QuizScreen({
-  question, currentIdx, totalQuestions,
-  correctCount, wrongCount, store, basePath,
-  onAnswer, onNext,
+  question,
+  currentIdx,
+  totalQuestions,
+  correctCount,
+  wrongCount,
+  store,
+  basePath,
+  onAnswer,
+  onNext,
 }: QuizScreenProps) {
-  const [answered, setAnswered] = useState(false)
-  const [selected, setSelected] = useState<string | null>(null)
+  const [answered, setAnswered] = useState(false);
+  const [selected, setSelected] = useState<string | null>(null);
 
   useEffect(() => {
-    setAnswered(false)
-    setSelected(null)
-    window.scrollTo({ top: 0, behavior: 'smooth' })
-  }, [currentIdx])
+    setAnswered(false);
+    setSelected(null);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [currentIdx]);
 
-  const storeData = store.load()
-  const qStats = storeData.questions[String(question.id)]
-  const missRate = qStats?.wrong && qStats.seen ? Math.round((qStats.wrong / qStats.seen) * 100) : 0
+  const storeData = store.load();
+  const qStats = storeData.questions[String(question.id)];
+  const missRate =
+    qStats?.wrong && qStats.seen ? Math.round((qStats.wrong / qStats.seen) * 100) : 0;
 
-  const handleSelect = useCallback((letter: string) => {
-    if (answered) return
-    setAnswered(true)
-    setSelected(letter)
-    const isCorrect = letter === question.answer
-    onAnswer({
-      id: question.id,
-      question: question.question,
-      yourAnswer: letter,
-      yourAnswerText: question.choices[letter],
-      correctAnswer: question.answer,
-      correctAnswerText: question.choices[question.answer],
-      correct: isCorrect,
-      explanation: question.explanation,
-    }, isCorrect)
-  }, [answered, question, onAnswer])
+  const handleSelect = useCallback(
+    (letter: string) => {
+      if (answered) return;
+      setAnswered(true);
+      setSelected(letter);
+      const isCorrect = letter === question.answer;
+      onAnswer(
+        {
+          id: question.id,
+          question: question.question,
+          yourAnswer: letter,
+          yourAnswerText: question.choices[letter],
+          correctAnswer: question.answer,
+          correctAnswerText: question.choices[question.answer],
+          correct: isCorrect,
+          explanation: question.explanation,
+        },
+        isCorrect,
+      );
+    },
+    [answered, question, onAnswer],
+  );
 
-  const progressPct = (currentIdx / totalQuestions) * 100
-  const letters = ['A', 'B', 'C', 'D'].filter(l => question.choices[l])
+  const progressPct = (currentIdx / totalQuestions) * 100;
+  const letters = ['A', 'B', 'C', 'D'].filter((l) => question.choices[l]);
 
   return (
     <>
       <div className="h-1.5 bg-gray-200 rounded-full mb-4 overflow-hidden">
-        <div className="h-full bg-blue-600 rounded-full transition-all duration-300" style={{ width: `${progressPct}%` }} />
+        <div
+          className="h-full bg-blue-600 rounded-full transition-all duration-300"
+          style={{ width: `${progressPct}%` }}
+        />
       </div>
       <div className="flex justify-between items-center mb-3 text-sm text-gray-500">
-        <span>{currentIdx + 1} / {totalQuestions}</span>
+        <span>
+          {currentIdx + 1} / {totalQuestions}
+        </span>
         <span className="font-semibold">
-          <span className="text-green-600">{correctCount}</span> / <span className="text-red-600">{wrongCount}</span>
+          <span className="text-green-600">{correctCount}</span> /{' '}
+          <span className="text-red-600">{wrongCount}</span>
         </span>
       </div>
       <div>
@@ -78,28 +97,33 @@ export default function QuizScreen({
 
       {question.image && (
         <div className="text-center my-3">
-          <img src={`${basePath}signs/${question.image}`} alt="Road sign" className="max-w-full max-h-60 rounded-lg border border-gray-200 inline-block" />
+          <img
+            src={`${basePath}signs/${question.image}`}
+            alt="Road sign"
+            className="max-w-full max-h-60 rounded-lg border border-gray-200 inline-block"
+          />
         </div>
       )}
 
       <div className="flex flex-col gap-2.5 mb-4">
-        {letters.map(letter => {
-          let btnClass = 'bg-white border-gray-200 hover:border-blue-300 active:scale-[0.98] cursor-pointer'
-          let letterClass = 'bg-gray-100 text-gray-500'
+        {letters.map((letter) => {
+          let btnClass =
+            'bg-white border-gray-200 hover:border-blue-300 active:scale-[0.98] cursor-pointer';
+          let letterClass = 'bg-gray-100 text-gray-500';
 
           if (answered) {
-            const isCorrectAnswer = letter === question.answer
-            const isSelected = letter === selected
+            const isCorrectAnswer = letter === question.answer;
+            const isSelected = letter === selected;
             if (isCorrectAnswer) {
-              btnClass = 'border-green-600 bg-green-50'
-              letterClass = 'bg-green-600 text-white'
+              btnClass = 'border-green-600 bg-green-50';
+              letterClass = 'bg-green-600 text-white';
             } else if (isSelected) {
-              btnClass = 'border-red-600 bg-red-50'
-              letterClass = 'bg-red-600 text-white'
+              btnClass = 'border-red-600 bg-red-50';
+              letterClass = 'bg-red-600 text-white';
             } else {
-              btnClass = 'border-gray-200 bg-white opacity-70'
+              btnClass = 'border-gray-200 bg-white opacity-70';
             }
-            btnClass += ' cursor-default'
+            btnClass += ' cursor-default';
           }
 
           return (
@@ -108,12 +132,14 @@ export default function QuizScreen({
               onClick={() => handleSelect(letter)}
               className={`flex items-start gap-3 p-3.5 border-2 rounded-xl text-base leading-relaxed text-left w-full text-gray-900 transition-all ${btnClass}`}
             >
-              <span className={`shrink-0 w-7 h-7 flex items-center justify-center rounded-full font-bold text-sm ${letterClass}`}>
+              <span
+                className={`shrink-0 w-7 h-7 flex items-center justify-center rounded-full font-bold text-sm ${letterClass}`}
+              >
                 {letter}
               </span>
               <span>{question.choices[letter]}</span>
             </button>
-          )
+          );
         })}
       </div>
 
@@ -131,5 +157,5 @@ export default function QuizScreen({
         </>
       )}
     </>
-  )
+  );
 }

--- a/frontend/src/components/QuizScreen.tsx
+++ b/frontend/src/components/QuizScreen.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import type { Question, SessionResult } from '../types';
 import { t } from '../i18n';
 import { useStore } from '../hooks/useStore';
@@ -35,7 +35,10 @@ export default function QuizScreen({
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }, [currentIdx]);
 
-  const storeData = store.load();
+  // Reload store data when the question changes (currentIdx is intentionally
+  // included to bust the memo after each answer is persisted via store.save).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const storeData = useMemo(() => store.load(), [store, currentIdx]);
   const qStats = storeData.questions[String(question.id)];
   const missRate =
     qStats?.wrong && qStats.seen ? Math.round((qStats.wrong / qStats.seen) * 100) : 0;

--- a/frontend/src/components/ResultsScreen.tsx
+++ b/frontend/src/components/ResultsScreen.tsx
@@ -1,34 +1,48 @@
-import type { SessionResult } from '../types'
-import { t } from '../i18n'
+import type { SessionResult } from '../types';
+import { t } from '../i18n';
 
 interface ResultsScreenProps {
-  correctCount: number
-  totalQuestions: number
-  passingPct: number
-  agency: string
-  sessionResults: SessionResult[]
-  onNewQuiz: () => void
-  onShowStats: () => void
+  correctCount: number;
+  totalQuestions: number;
+  passingPct: number;
+  agency: string;
+  sessionResults: SessionResult[];
+  onNewQuiz: () => void;
+  onShowStats: () => void;
 }
 
 export default function ResultsScreen({
-  correctCount, totalQuestions, passingPct, agency, sessionResults,
-  onNewQuiz, onShowStats,
+  correctCount,
+  totalQuestions,
+  passingPct,
+  agency,
+  sessionResults,
+  onNewQuiz,
+  onShowStats,
 }: ResultsScreenProps) {
-  const pct = Math.round((correctCount / totalQuestions) * 100)
-  const pass = pct >= passingPct
-  const wrongResults = sessionResults.filter(r => !r.correct)
+  const pct = Math.round((correctCount / totalQuestions) * 100);
+  const pass = pct >= passingPct;
+  const wrongResults = sessionResults.filter((r) => !r.correct);
 
   return (
     <div className="text-center pt-[6vh]">
-      <div className={`w-40 h-40 rounded-full flex flex-col items-center justify-center mx-auto mb-6 border-[6px]
-        ${pass ? 'border-green-500 text-green-600' : 'border-red-500 text-red-600'}`}>
+      <div
+        className={`w-40 h-40 rounded-full flex flex-col items-center justify-center mx-auto mb-6 border-[6px]
+        ${pass ? 'border-green-500 text-green-600' : 'border-red-500 text-red-600'}`}
+      >
         <div className="text-[42px] font-bold">{pct}%</div>
         <div className="text-sm font-semibold uppercase">{pass ? t('pass') : t('fail')}</div>
       </div>
-      <div className="text-xl font-bold mb-2">{pass ? t('congratulations') : t('keepPracticing')}</div>
+      <div className="text-xl font-bold mb-2">
+        {pass ? t('congratulations') : t('keepPracticing')}
+      </div>
       <div className="text-gray-500 text-sm mb-6 leading-relaxed">
-        {t('resultDetail', { correct: correctCount, total: totalQuestions, pass_pct: passingPct, agency })}
+        {t('resultDetail', {
+          correct: correctCount,
+          total: totalQuestions,
+          pass_pct: passingPct,
+          agency,
+        })}
       </div>
       <button
         onClick={onNewQuiz}
@@ -51,14 +65,23 @@ export default function ResultsScreen({
         </h3>
         {wrongResults.length > 0 ? (
           <div>
-            {wrongResults.map(r => (
-              <div key={r.id} className="bg-white rounded-xl p-3.5 mb-2.5 border-l-4 border-red-500">
+            {wrongResults.map((r) => (
+              <div
+                key={r.id}
+                className="bg-white rounded-xl p-3.5 mb-2.5 border-l-4 border-red-500"
+              >
                 <div className="font-semibold text-sm mb-1.5">{r.question}</div>
                 <div className="text-xs text-gray-500">
-                  {t('yourAnswer')}: <strong className="text-gray-900">{r.yourAnswer}: {r.yourAnswerText}</strong>
+                  {t('yourAnswer')}:{' '}
+                  <strong className="text-gray-900">
+                    {r.yourAnswer}: {r.yourAnswerText}
+                  </strong>
                 </div>
                 <div className="text-xs text-gray-500">
-                  {t('correct')}: <strong className="text-gray-900">{r.correctAnswer}: {r.correctAnswerText}</strong>
+                  {t('correct')}:{' '}
+                  <strong className="text-gray-900">
+                    {r.correctAnswer}: {r.correctAnswerText}
+                  </strong>
                 </div>
                 <div className="text-xs text-gray-500 mt-1.5 italic">{r.explanation}</div>
               </div>
@@ -69,5 +92,5 @@ export default function ResultsScreen({
         )}
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/components/ScoreChart.tsx
+++ b/frontend/src/components/ScoreChart.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect } from 'react';
 import type { QuizResult } from '../types';
+import { CHART_HEIGHT, MAX_CHART_ENTRIES } from '../constants';
 
 interface ScoreChartProps {
   history: QuizResult[];
@@ -16,19 +17,19 @@ export default function ScoreChart({ history, passingPct }: ScoreChartProps) {
     const dpr = window.devicePixelRatio || 1;
     const rect = canvas.getBoundingClientRect();
     canvas.width = rect.width * dpr;
-    canvas.height = 180 * dpr;
-    canvas.style.height = '180px';
+    canvas.height = CHART_HEIGHT * dpr;
+    canvas.style.height = `${CHART_HEIGHT}px`;
 
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     ctx.scale(dpr, dpr);
 
-    const W = rect.width,
-      H = 180;
+    const W = rect.width;
+    const H = CHART_HEIGHT;
     const pad = { top: 20, right: 16, bottom: 30, left: 36 };
     const plotW = W - pad.left - pad.right;
     const plotH = H - pad.top - pad.bottom;
-    const data = history.slice(-20);
+    const data = history.slice(-MAX_CHART_ENTRIES);
     const n = data.length;
 
     ctx.clearRect(0, 0, W, H);
@@ -110,5 +111,12 @@ export default function ScoreChart({ history, passingPct }: ScoreChartProps) {
     });
   }, [history, passingPct]);
 
-  return <canvas ref={canvasRef} height={180} className="w-full" style={{ height: 180 }} />;
+  return (
+    <canvas
+      ref={canvasRef}
+      height={CHART_HEIGHT}
+      className="w-full"
+      style={{ height: CHART_HEIGHT }}
+    />
+  );
 }

--- a/frontend/src/components/ScoreChart.tsx
+++ b/frontend/src/components/ScoreChart.tsx
@@ -1,113 +1,114 @@
-import { useRef, useEffect } from 'react'
-import type { QuizResult } from '../types'
+import { useRef, useEffect } from 'react';
+import type { QuizResult } from '../types';
 
 interface ScoreChartProps {
-  history: QuizResult[]
-  passingPct: number
+  history: QuizResult[];
+  passingPct: number;
 }
 
 export default function ScoreChart({ history, passingPct }: ScoreChartProps) {
-  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
-    const canvas = canvasRef.current
-    if (!canvas) return
+    const canvas = canvasRef.current;
+    if (!canvas) return;
 
-    const dpr = window.devicePixelRatio || 1
-    const rect = canvas.getBoundingClientRect()
-    canvas.width = rect.width * dpr
-    canvas.height = 180 * dpr
-    canvas.style.height = '180px'
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    canvas.width = rect.width * dpr;
+    canvas.height = 180 * dpr;
+    canvas.style.height = '180px';
 
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
-    ctx.scale(dpr, dpr)
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.scale(dpr, dpr);
 
-    const W = rect.width, H = 180
-    const pad = { top: 20, right: 16, bottom: 30, left: 36 }
-    const plotW = W - pad.left - pad.right
-    const plotH = H - pad.top - pad.bottom
-    const data = history.slice(-20)
-    const n = data.length
+    const W = rect.width,
+      H = 180;
+    const pad = { top: 20, right: 16, bottom: 30, left: 36 };
+    const plotW = W - pad.left - pad.right;
+    const plotH = H - pad.top - pad.bottom;
+    const data = history.slice(-20);
+    const n = data.length;
 
-    ctx.clearRect(0, 0, W, H)
+    ctx.clearRect(0, 0, W, H);
 
     // Grid lines
-    ctx.strokeStyle = '#e5e7eb'
-    ctx.lineWidth = 1
-    ctx.fillStyle = '#9ca3af'
-    ctx.font = '11px system-ui'
-    ctx.textAlign = 'right'
+    ctx.strokeStyle = '#e5e7eb';
+    ctx.lineWidth = 1;
+    ctx.fillStyle = '#9ca3af';
+    ctx.font = '11px system-ui';
+    ctx.textAlign = 'right';
     for (const pct of [0, 25, 50, 75, 100]) {
-      const y = pad.top + plotH - (pct / 100) * plotH
-      ctx.beginPath()
-      ctx.moveTo(pad.left, y)
-      ctx.lineTo(W - pad.right, y)
-      ctx.stroke()
-      ctx.fillText(pct + '%', pad.left - 6, y + 4)
+      const y = pad.top + plotH - (pct / 100) * plotH;
+      ctx.beginPath();
+      ctx.moveTo(pad.left, y);
+      ctx.lineTo(W - pad.right, y);
+      ctx.stroke();
+      ctx.fillText(pct + '%', pad.left - 6, y + 4);
     }
 
     // Passing line
-    const passY = pad.top + plotH - (passingPct / 100) * plotH
-    ctx.strokeStyle = '#16a34a40'
-    ctx.lineWidth = 2
-    ctx.setLineDash([6, 4])
-    ctx.beginPath()
-    ctx.moveTo(pad.left, passY)
-    ctx.lineTo(W - pad.right, passY)
-    ctx.stroke()
-    ctx.setLineDash([])
+    const passY = pad.top + plotH - (passingPct / 100) * plotH;
+    ctx.strokeStyle = '#16a34a40';
+    ctx.lineWidth = 2;
+    ctx.setLineDash([6, 4]);
+    ctx.beginPath();
+    ctx.moveTo(pad.left, passY);
+    ctx.lineTo(W - pad.right, passY);
+    ctx.stroke();
+    ctx.setLineDash([]);
 
     // Data points
     const points = data.map((d, i) => ({
       x: pad.left + (n === 1 ? plotW / 2 : (i / (n - 1)) * plotW),
       y: pad.top + plotH - (d.pct / 100) * plotH,
       pct: d.pct,
-    }))
+    }));
 
     // Line
-    ctx.strokeStyle = '#2563eb'
-    ctx.lineWidth = 2.5
-    ctx.lineJoin = 'round'
-    ctx.beginPath()
-    points.forEach((p, i) => (i === 0 ? ctx.moveTo(p.x, p.y) : ctx.lineTo(p.x, p.y)))
-    ctx.stroke()
+    ctx.strokeStyle = '#2563eb';
+    ctx.lineWidth = 2.5;
+    ctx.lineJoin = 'round';
+    ctx.beginPath();
+    points.forEach((p, i) => (i === 0 ? ctx.moveTo(p.x, p.y) : ctx.lineTo(p.x, p.y)));
+    ctx.stroke();
 
     // Fill
-    ctx.beginPath()
-    points.forEach((p, i) => (i === 0 ? ctx.moveTo(p.x, p.y) : ctx.lineTo(p.x, p.y)))
-    ctx.lineTo(points[points.length - 1].x, pad.top + plotH)
-    ctx.lineTo(points[0].x, pad.top + plotH)
-    ctx.closePath()
-    const grad = ctx.createLinearGradient(0, pad.top, 0, pad.top + plotH)
-    grad.addColorStop(0, 'rgba(37, 99, 235, 0.2)')
-    grad.addColorStop(1, 'rgba(37, 99, 235, 0.02)')
-    ctx.fillStyle = grad
-    ctx.fill()
+    ctx.beginPath();
+    points.forEach((p, i) => (i === 0 ? ctx.moveTo(p.x, p.y) : ctx.lineTo(p.x, p.y)));
+    ctx.lineTo(points[points.length - 1].x, pad.top + plotH);
+    ctx.lineTo(points[0].x, pad.top + plotH);
+    ctx.closePath();
+    const grad = ctx.createLinearGradient(0, pad.top, 0, pad.top + plotH);
+    grad.addColorStop(0, 'rgba(37, 99, 235, 0.2)');
+    grad.addColorStop(1, 'rgba(37, 99, 235, 0.02)');
+    ctx.fillStyle = grad;
+    ctx.fill();
 
     // Dots
-    points.forEach(p => {
-      ctx.beginPath()
-      ctx.arc(p.x, p.y, 4, 0, Math.PI * 2)
-      ctx.fillStyle = p.pct >= passingPct ? '#16a34a' : '#dc2626'
-      ctx.fill()
-      ctx.strokeStyle = '#fff'
-      ctx.lineWidth = 2
-      ctx.stroke()
-    })
+    points.forEach((p) => {
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, 4, 0, Math.PI * 2);
+      ctx.fillStyle = p.pct >= passingPct ? '#16a34a' : '#dc2626';
+      ctx.fill();
+      ctx.strokeStyle = '#fff';
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    });
 
     // Labels
-    ctx.fillStyle = '#9ca3af'
-    ctx.font = '10px system-ui'
-    ctx.textAlign = 'center'
-    const startNum = history.length - data.length + 1
-    const step = n <= 10 ? 1 : 2
+    ctx.fillStyle = '#9ca3af';
+    ctx.font = '10px system-ui';
+    ctx.textAlign = 'center';
+    const startNum = history.length - data.length + 1;
+    const step = n <= 10 ? 1 : 2;
     points.forEach((p, i) => {
       if (i % step === 0 || i === n - 1) {
-        ctx.fillText('#' + (startNum + i), p.x, H - pad.bottom + 16)
+        ctx.fillText('#' + (startNum + i), p.x, H - pad.bottom + 16);
       }
-    })
-  }, [history, passingPct])
+    });
+  }, [history, passingPct]);
 
-  return <canvas ref={canvasRef} height={180} className="w-full" style={{ height: 180 }} />
+  return <canvas ref={canvasRef} height={180} className="w-full" style={{ height: 180 }} />;
 }

--- a/frontend/src/components/StartScreen.tsx
+++ b/frontend/src/components/StartScreen.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useMemo } from 'react';
 import type { StateSummary, QuizMode } from '../types';
 import { t } from '../i18n';
 import { useStore } from '../hooks/useStore';
+import { calcPassStreak, calcAverageScore } from '../utils';
+import { QUESTION_COUNT_OPTIONS, DEFAULT_QUESTION_COUNT } from '../constants';
 import LangBar from './LangBar';
 
 interface StartScreenProps {
@@ -40,23 +42,17 @@ export default function StartScreen({
 
   const counts = useMemo(() => {
     const total = state.total_questions;
-    const c = [10, 25, 50, 100].filter((n) => n <= total);
+    const c = QUESTION_COUNT_OPTIONS.filter((n) => n <= total);
     if (!c.includes(total)) c.push(total);
     return c;
   }, [state.total_questions]);
 
   useEffect(() => {
-    onSetCount(Math.min(50, state.total_questions));
+    onSetCount(Math.min(DEFAULT_QUESTION_COUNT, state.total_questions));
   }, [state.total_questions, onSetCount]);
 
-  const avg = history.length
-    ? Math.round(history.reduce((s, r) => s + r.pct, 0) / history.length)
-    : 0;
-  let streak = 0;
-  for (let i = history.length - 1; i >= 0; i--) {
-    if (history[i].pct >= state.passing_score_pct) streak++;
-    else break;
-  }
+  const avg = calcAverageScore(history);
+  const streak = calcPassStreak(history, state.passing_score_pct);
 
   const startDisabled = quizMode === 'weak' && weakCount === 0;
 

--- a/frontend/src/components/StartScreen.tsx
+++ b/frontend/src/components/StartScreen.tsx
@@ -1,68 +1,88 @@
-import { useEffect, useMemo } from 'react'
-import type { StateSummary, QuizMode } from '../types'
-import { t } from '../i18n'
-import { useStore } from '../hooks/useStore'
-import LangBar from './LangBar'
+import { useEffect, useMemo } from 'react';
+import type { StateSummary, QuizMode } from '../types';
+import { t } from '../i18n';
+import { useStore } from '../hooks/useStore';
+import LangBar from './LangBar';
 
 interface StartScreenProps {
-  state: StateSummary
-  lang: string
-  quizMode: QuizMode
-  selectedCount: number
-  store: ReturnType<typeof useStore>
-  onSetMode: (mode: QuizMode) => void
-  onSetCount: (count: number) => void
-  onStart: () => void
-  onChangeState: () => void
-  onShowStats: () => void
-  onSwitchLang: (lang: string) => void
+  state: StateSummary;
+  lang: string;
+  quizMode: QuizMode;
+  selectedCount: number;
+  store: ReturnType<typeof useStore>;
+  onSetMode: (mode: QuizMode) => void;
+  onSetCount: (count: number) => void;
+  onStart: () => void;
+  onChangeState: () => void;
+  onShowStats: () => void;
+  onSwitchLang: (lang: string) => void;
 }
 
 export default function StartScreen({
-  state, lang, quizMode, selectedCount, store,
-  onSetMode, onSetCount, onStart, onChangeState, onShowStats, onSwitchLang,
+  state,
+  lang,
+  quizMode,
+  selectedCount,
+  store,
+  onSetMode,
+  onSetCount,
+  onStart,
+  onChangeState,
+  onShowStats,
+  onSwitchLang,
 }: StartScreenProps) {
-  const storeData = store.load()
-  const history = storeData.history
+  const storeData = store.load();
+  const history = storeData.history;
 
   const weakCount = useMemo(() => {
-    return Object.values(storeData.questions).filter(d => d.wrong > 0 && d.seen >= 1).length
-  }, [storeData])
+    return Object.values(storeData.questions).filter((d) => d.wrong > 0 && d.seen >= 1).length;
+  }, [storeData]);
 
   const counts = useMemo(() => {
-    const total = state.total_questions
-    const c = [10, 25, 50, 100].filter(n => n <= total)
-    if (!c.includes(total)) c.push(total)
-    return c
-  }, [state.total_questions])
+    const total = state.total_questions;
+    const c = [10, 25, 50, 100].filter((n) => n <= total);
+    if (!c.includes(total)) c.push(total);
+    return c;
+  }, [state.total_questions]);
 
   useEffect(() => {
-    onSetCount(Math.min(50, state.total_questions))
-  }, [state.total_questions, onSetCount])
+    onSetCount(Math.min(50, state.total_questions));
+  }, [state.total_questions, onSetCount]);
 
-  const avg = history.length ? Math.round(history.reduce((s, r) => s + r.pct, 0) / history.length) : 0
-  let streak = 0
+  const avg = history.length
+    ? Math.round(history.reduce((s, r) => s + r.pct, 0) / history.length)
+    : 0;
+  let streak = 0;
   for (let i = history.length - 1; i >= 0; i--) {
-    if (history[i].pct >= state.passing_score_pct) streak++
-    else break
+    if (history[i].pct >= state.passing_score_pct) streak++;
+    else break;
   }
 
-  const startDisabled = quizMode === 'weak' && weakCount === 0
+  const startDisabled = quizMode === 'weak' && weakCount === 0;
 
   return (
     <>
       <LangBar currentLang={lang} availableLangs={state.languages} onSwitch={onSwitchLang} />
       <div className="text-center pt-[4vh]">
         <h1 className="text-2xl font-bold text-blue-600 mb-2">
-          {t('title', { state: state.code.toUpperCase(), state_name: state.name, agency: state.agency, pass_pct: state.passing_score_pct })}
+          {t('title', {
+            state: state.code.toUpperCase(),
+            state_name: state.name,
+            agency: state.agency,
+            pass_pct: state.passing_score_pct,
+          })}
         </h1>
         <p className="text-gray-500 text-sm mb-1 leading-relaxed">
-          {t('subtitle', { state: state.code.toUpperCase(), state_name: state.name, agency: state.agency })}
+          {t('subtitle', {
+            state: state.code.toUpperCase(),
+            state_name: state.name,
+            agency: state.agency,
+          })}
         </p>
         <p className="text-gray-400 text-xs mb-5">
           {t('passingScore', {
             pass_pct: state.passing_score_pct,
-            pass_count: Math.ceil(state.test_question_count * state.passing_score_pct / 100),
+            pass_count: Math.ceil((state.test_question_count * state.passing_score_pct) / 100),
             test_count: state.test_question_count,
           })}
         </p>
@@ -74,18 +94,27 @@ export default function StartScreen({
             <div className="flex gap-4">
               <div className="text-center">
                 <div className="text-xl font-bold">{history.length}</div>
-                <div className="text-[11px] text-gray-500 uppercase tracking-wide">{t('quizzes')}</div>
+                <div className="text-[11px] text-gray-500 uppercase tracking-wide">
+                  {t('quizzes')}
+                </div>
               </div>
               <div className="text-center">
                 <div className="text-xl font-bold">{avg}%</div>
-                <div className="text-[11px] text-gray-500 uppercase tracking-wide">{t('avgScore')}</div>
+                <div className="text-[11px] text-gray-500 uppercase tracking-wide">
+                  {t('avgScore')}
+                </div>
               </div>
               <div className="text-center">
                 <div className="text-xl font-bold">{streak}</div>
-                <div className="text-[11px] text-gray-500 uppercase tracking-wide">{t('passStreak')}</div>
+                <div className="text-[11px] text-gray-500 uppercase tracking-wide">
+                  {t('passStreak')}
+                </div>
               </div>
             </div>
-            <button onClick={onShowStats} className="text-blue-600 text-sm font-semibold cursor-pointer whitespace-nowrap">
+            <button
+              onClick={onShowStats}
+              className="text-blue-600 text-sm font-semibold cursor-pointer whitespace-nowrap"
+            >
               {t('viewStats')}
             </button>
           </div>
@@ -93,8 +122,8 @@ export default function StartScreen({
       )}
 
       <div className="flex gap-2 mb-4">
-        {(['random', 'weak'] as const).map(mode => {
-          const active = quizMode === mode
+        {(['random', 'weak'] as const).map((mode) => {
+          const active = quizMode === mode;
           return (
             <button
               key={mode}
@@ -102,24 +131,28 @@ export default function StartScreen({
               className={`flex-1 py-3 px-2 border-2 rounded-xl text-sm font-semibold cursor-pointer text-center transition-colors
                 ${active ? 'border-blue-500 bg-blue-50 text-blue-600' : 'border-gray-200 bg-white'}`}
             >
-              <span className="text-xl block mb-1">{mode === 'random' ? '\u{1F3B2}' : '\u{1F3AF}'}</span>
+              <span className="text-xl block mb-1">
+                {mode === 'random' ? '\u{1F3B2}' : '\u{1F3AF}'}
+              </span>
               <span>{t(mode === 'random' ? 'modeRandom' : 'modeWeak')}</span>
               {mode === 'weak' && weakCount > 0 && (
-                <span className="inline-block bg-red-600 text-white text-[11px] px-1.5 rounded-full ml-1 font-bold">{weakCount}</span>
+                <span className="inline-block bg-red-600 text-white text-[11px] px-1.5 rounded-full ml-1 font-bold">
+                  {weakCount}
+                </span>
               )}
               <span className="text-[11px] font-normal text-gray-500 block">
                 {t(mode === 'random' ? 'modeRandomDesc' : 'modeWeakDesc')}
               </span>
             </button>
-          )
+          );
         })}
       </div>
 
       <p className="font-semibold mb-2 text-sm">{t('numQuestions')}</p>
       <div className="flex gap-2 justify-center mb-5 flex-wrap">
-        {counts.map(n => {
-          const label = n === state.total_questions ? 'All' : String(n)
-          const active = n === selectedCount
+        {counts.map((n) => {
+          const label = n === state.total_questions ? 'All' : String(n);
+          const active = n === selectedCount;
           return (
             <button
               key={n}
@@ -129,7 +162,7 @@ export default function StartScreen({
             >
               {label}
             </button>
-          )
+          );
         })}
       </div>
 
@@ -147,5 +180,5 @@ export default function StartScreen({
         {t('changeState')}
       </button>
     </>
-  )
+  );
 }

--- a/frontend/src/components/StartScreen.tsx
+++ b/frontend/src/components/StartScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import type { StateSummary, QuizMode } from '../types';
 import { t } from '../i18n';
 import { useStore } from '../hooks/useStore';
@@ -31,7 +31,7 @@ export default function StartScreen({
   onShowStats,
   onSwitchLang,
 }: StartScreenProps) {
-  const storeData = store.load();
+  const [storeData] = useState(() => store.load());
   const history = storeData.history;
 
   const weakCount = useMemo(() => {

--- a/frontend/src/components/StatePicker.tsx
+++ b/frontend/src/components/StatePicker.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react'
-import type { StateSummary } from '../types'
-import { t } from '../i18n'
-import LangBar from './LangBar'
+import { useState } from 'react';
+import type { StateSummary } from '../types';
+import { t } from '../i18n';
+import LangBar from './LangBar';
 
 const COUNTRIES: Record<string, { name: string; flag: string }> = {
   us: { name: 'United States', flag: '\u{1F1FA}\u{1F1F8}' },
@@ -11,36 +11,46 @@ const COUNTRIES: Record<string, { name: string; flag: string }> = {
   nz: { name: 'New Zealand', flag: '\u{1F1F3}\u{1F1FF}' },
   ie: { name: 'Ireland', flag: '\u{1F1EE}\u{1F1EA}' },
   sg: { name: 'Singapore', flag: '\u{1F1F8}\u{1F1EC}' },
-}
+};
 
 function getCountry(code: string): string {
-  if (code.startsWith('ca-')) return 'ca'
-  if (code.startsWith('au-')) return 'au'
-  if (['uk', 'nz', 'ie', 'sg'].includes(code)) return code
-  return 'us'
+  if (code.startsWith('ca-')) return 'ca';
+  if (code.startsWith('au-')) return 'au';
+  if (['uk', 'nz', 'ie', 'sg'].includes(code)) return code;
+  return 'us';
 }
 
 interface StatePickerProps {
-  states: StateSummary[]
-  lang: string
-  onSelectState: (code: string) => void
-  onSwitchLang: (lang: string) => void
+  states: StateSummary[];
+  lang: string;
+  onSelectState: (code: string) => void;
+  onSwitchLang: (lang: string) => void;
 }
 
-export default function StatePicker({ states, lang, onSelectState, onSwitchLang }: StatePickerProps) {
-  const [query, setQuery] = useState('')
-  const q = query.toLowerCase().trim()
+export default function StatePicker({
+  states,
+  lang,
+  onSelectState,
+  onSwitchLang,
+}: StatePickerProps) {
+  const [query, setQuery] = useState('');
+  const q = query.toLowerCase().trim();
 
-  const groups: Record<string, StateSummary[]> = {}
+  const groups: Record<string, StateSummary[]> = {};
   for (const s of states) {
-    const country = getCountry(s.code)
-    if (!groups[country]) groups[country] = []
-    if (q && !s.name.toLowerCase().includes(q) && !s.code.includes(q)) continue
-    groups[country].push(s)
+    const country = getCountry(s.code);
+    if (!groups[country]) groups[country] = [];
+    if (q && !s.name.toLowerCase().includes(q) && !s.code.includes(q)) continue;
+    groups[country].push(s);
   }
 
-  const order = ['us', ...Object.keys(groups).filter(c => c !== 'us').sort()]
-  let totalShown = 0
+  const order = [
+    'us',
+    ...Object.keys(groups)
+      .filter((c) => c !== 'us')
+      .sort(),
+  ];
+  let totalShown = 0;
 
   return (
     <>
@@ -50,31 +60,42 @@ export default function StatePicker({ states, lang, onSelectState, onSwitchLang 
         <p className="text-gray-500 text-sm mb-4">{t('selectStateDesc')}</p>
       </div>
       <div className="relative mb-4">
-        <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        <svg
+          className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400 pointer-events-none"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
         </svg>
         <input
           type="text"
           value={query}
-          onChange={e => setQuery(e.target.value)}
+          onChange={(e) => setQuery(e.target.value)}
           placeholder="Search states..."
           className="w-full pl-10 pr-4 py-3 border-2 border-gray-200 rounded-xl text-base bg-white text-gray-900 outline-none focus:border-blue-500 transition-colors"
         />
       </div>
       <div>
-        {order.map(country => {
-          const countryStates = groups[country]
-          if (!countryStates?.length) return null
-          totalShown += countryStates.length
-          const info = COUNTRIES[country] || { name: country.toUpperCase(), flag: '' }
+        {order.map((country) => {
+          const countryStates = groups[country];
+          if (!countryStates?.length) return null;
+          totalShown += countryStates.length;
+          const info = COUNTRIES[country] || { name: country.toUpperCase(), flag: '' };
           return (
             <div key={country} className="mb-5">
               <div className="flex items-center gap-2 text-xs font-bold text-gray-500 uppercase tracking-wider px-1 pb-2 border-b border-gray-200 mb-2">
-                <span className="text-lg">{info.flag}</span> {info.name} <span className="font-normal">({countryStates.length})</span>
+                <span className="text-lg">{info.flag}</span> {info.name}{' '}
+                <span className="font-normal">({countryStates.length})</span>
               </div>
               <div className="flex flex-col gap-2">
-                {countryStates.map(s => {
-                  const hasQ = s.total_questions > 0
+                {countryStates.map((s) => {
+                  const hasQ = s.total_questions > 0;
                   return (
                     <div
                       key={s.code}
@@ -85,26 +106,33 @@ export default function StatePicker({ states, lang, onSelectState, onSwitchLang 
                       <div>
                         <div className="text-base font-semibold">{s.name}</div>
                         <div className="text-xs text-gray-500 mt-0.5">
-                          {s.agency} &middot; {t('passingScore', {
+                          {s.agency} &middot;{' '}
+                          {t('passingScore', {
                             pass_pct: s.passing_score_pct,
-                            pass_count: Math.ceil(s.test_question_count * s.passing_score_pct / 100),
+                            pass_count: Math.ceil(
+                              (s.test_question_count * s.passing_score_pct) / 100,
+                            ),
                             test_count: s.test_question_count,
                           })}
                         </div>
                       </div>
                       <div className="text-right">
                         {hasQ ? (
-                          <div className="text-xs text-blue-600 font-semibold">{t('questionsAvailable', { count: s.total_questions })}</div>
+                          <div className="text-xs text-blue-600 font-semibold">
+                            {t('questionsAvailable', { count: s.total_questions })}
+                          </div>
                         ) : (
-                          <span className="text-[11px] text-gray-400 bg-gray-100 px-2 py-0.5 rounded-full">{t('comingSoon')}</span>
+                          <span className="text-[11px] text-gray-400 bg-gray-100 px-2 py-0.5 rounded-full">
+                            {t('comingSoon')}
+                          </span>
                         )}
                       </div>
                     </div>
-                  )
+                  );
                 })}
               </div>
             </div>
-          )
+          );
         })}
         {totalShown === 0 && (
           <div className="text-gray-400 text-sm py-10 text-center">
@@ -113,5 +141,5 @@ export default function StatePicker({ states, lang, onSelectState, onSwitchLang 
         )}
       </div>
     </>
-  )
+  );
 }

--- a/frontend/src/components/StatePicker.tsx
+++ b/frontend/src/components/StatePicker.tsx
@@ -50,7 +50,7 @@ export default function StatePicker({
       .filter((c) => c !== 'us')
       .sort(),
   ];
-  let totalShown = 0;
+  const totalShown = order.reduce((sum, country) => sum + (groups[country]?.length ?? 0), 0);
 
   return (
     <>
@@ -85,7 +85,6 @@ export default function StatePicker({
         {order.map((country) => {
           const countryStates = groups[country];
           if (!countryStates?.length) return null;
-          totalShown += countryStates.length;
           const info = COUNTRIES[country] || { name: country.toUpperCase(), flag: '' };
           return (
             <div key={country} className="mb-5">

--- a/frontend/src/components/StatsScreen.tsx
+++ b/frontend/src/components/StatsScreen.tsx
@@ -2,6 +2,8 @@ import { useState, useMemo } from 'react';
 import type { StateSummary } from '../types';
 import { t } from '../i18n';
 import { useStore } from '../hooks/useStore';
+import { calcPassStreak, calcAverageScore } from '../utils';
+import { MAX_WEAK_DISPLAY, GOOD_ACCURACY_PCT, FAIR_ACCURACY_PCT } from '../constants';
 import ScoreChart from './ScoreChart';
 
 interface StatsScreenProps {
@@ -14,17 +16,10 @@ export default function StatsScreen({ state, store, onBack }: StatsScreenProps) 
   const [storeData] = useState(() => store.load());
   const history = storeData.history;
 
-  const avg = history.length
-    ? Math.round(history.reduce((s, r) => s + r.pct, 0) / history.length)
-    : 0;
+  const avg = calcAverageScore(history);
   const best = history.length ? Math.max(...history.map((r) => r.pct)) : 0;
   const seen = Object.keys(storeData.questions).length;
-
-  let streak = 0;
-  for (let i = history.length - 1; i >= 0; i--) {
-    if (history[i].pct >= state.passing_score_pct) streak++;
-    else break;
-  }
+  const streak = calcPassStreak(history, state.passing_score_pct);
 
   const catStats = useMemo(() => {
     const stats: Record<string, { seen: number; correct: number }> = {};
@@ -121,7 +116,12 @@ export default function StatsScreen({ state, store, onBack }: StatsScreenProps) 
           <h4 className="text-sm font-semibold mb-3">{t('accuracyByCategory')}</h4>
           {catStats.map(([cat, data]) => {
             const pct = Math.round((data.correct / data.seen) * 100);
-            const color = pct >= 80 ? '#16a34a' : pct >= 60 ? '#ea580c' : '#dc2626';
+            const color =
+              pct >= GOOD_ACCURACY_PCT
+                ? '#16a34a'
+                : pct >= FAIR_ACCURACY_PCT
+                  ? '#ea580c'
+                  : '#dc2626';
             return (
               <div key={cat} className="flex items-center gap-2.5 mb-2 text-xs">
                 <span className="w-28 shrink-0 capitalize truncate">{cat.replace(/_/g, ' ')}</span>
@@ -143,7 +143,7 @@ export default function StatsScreen({ state, store, onBack }: StatsScreenProps) 
       {weakIds.length > 0 && (
         <div className="mb-6">
           <h4 className="text-sm font-semibold mb-3">{t('mostMissed')}</h4>
-          {weakIds.slice(0, 15).map((w) => (
+          {weakIds.slice(0, MAX_WEAK_DISPLAY).map((w) => (
             <div
               key={w.id}
               className="bg-white rounded-xl py-3 px-3.5 mb-2 border border-gray-200 border-l-4 border-l-orange-500"

--- a/frontend/src/components/StatsScreen.tsx
+++ b/frontend/src/components/StatsScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import type { StateSummary } from '../types';
 import { t } from '../i18n';
 import { useStore } from '../hooks/useStore';
@@ -11,7 +11,7 @@ interface StatsScreenProps {
 }
 
 export default function StatsScreen({ state, store, onBack }: StatsScreenProps) {
-  const storeData = store.load();
+  const [storeData] = useState(() => store.load());
   const history = storeData.history;
 
   const avg = history.length

--- a/frontend/src/components/StatsScreen.tsx
+++ b/frontend/src/components/StatsScreen.tsx
@@ -1,57 +1,70 @@
-import { useMemo } from 'react'
-import type { StateSummary } from '../types'
-import { t } from '../i18n'
-import { useStore } from '../hooks/useStore'
-import ScoreChart from './ScoreChart'
+import { useMemo } from 'react';
+import type { StateSummary } from '../types';
+import { t } from '../i18n';
+import { useStore } from '../hooks/useStore';
+import ScoreChart from './ScoreChart';
 
 interface StatsScreenProps {
-  state: StateSummary
-  store: ReturnType<typeof useStore>
-  onBack: () => void
+  state: StateSummary;
+  store: ReturnType<typeof useStore>;
+  onBack: () => void;
 }
 
 export default function StatsScreen({ state, store, onBack }: StatsScreenProps) {
-  const storeData = store.load()
-  const history = storeData.history
+  const storeData = store.load();
+  const history = storeData.history;
 
-  const avg = history.length ? Math.round(history.reduce((s, r) => s + r.pct, 0) / history.length) : 0
-  const best = history.length ? Math.max(...history.map(r => r.pct)) : 0
-  const seen = Object.keys(storeData.questions).length
+  const avg = history.length
+    ? Math.round(history.reduce((s, r) => s + r.pct, 0) / history.length)
+    : 0;
+  const best = history.length ? Math.max(...history.map((r) => r.pct)) : 0;
+  const seen = Object.keys(storeData.questions).length;
 
-  let streak = 0
+  let streak = 0;
   for (let i = history.length - 1; i >= 0; i--) {
-    if (history[i].pct >= state.passing_score_pct) streak++
-    else break
+    if (history[i].pct >= state.passing_score_pct) streak++;
+    else break;
   }
 
   const catStats = useMemo(() => {
-    const stats: Record<string, { seen: number; correct: number }> = {}
+    const stats: Record<string, { seen: number; correct: number }> = {};
     for (const data of Object.values(storeData.questions)) {
-      const cat = data.category || 'unknown'
-      if (!stats[cat]) stats[cat] = { seen: 0, correct: 0 }
-      stats[cat].seen += data.seen
-      stats[cat].correct += data.seen - data.wrong
+      const cat = data.category || 'unknown';
+      if (!stats[cat]) stats[cat] = { seen: 0, correct: 0 };
+      stats[cat].seen += data.seen;
+      stats[cat].correct += data.seen - data.wrong;
     }
-    return Object.entries(stats).sort((a, b) => (a[1].correct / a[1].seen) - (b[1].correct / b[1].seen))
-  }, [storeData])
+    return Object.entries(stats).sort(
+      (a, b) => a[1].correct / a[1].seen - b[1].correct / b[1].seen,
+    );
+  }, [storeData]);
 
   const weakIds = useMemo(() => {
     return Object.entries(storeData.questions)
       .filter(([, d]) => d.wrong > 0 && d.seen >= 1)
-      .map(([id, d]) => ({ id: parseInt(id), missRate: d.wrong / d.seen, wrong: d.wrong, seen: d.seen, category: d.category }))
-      .sort((a, b) => b.missRate - a.missRate || b.wrong - a.wrong)
-  }, [storeData])
+      .map(([id, d]) => ({
+        id: parseInt(id),
+        missRate: d.wrong / d.seen,
+        wrong: d.wrong,
+        seen: d.seen,
+        category: d.category,
+      }))
+      .sort((a, b) => b.missRate - a.missRate || b.wrong - a.wrong);
+  }, [storeData]);
 
   const handleClear = () => {
     if (confirm(t('resetConfirm', { state_name: state.name }))) {
-      store.clear()
-      onBack()
+      store.clear();
+      onBack();
     }
-  }
+  };
 
   return (
     <div className="pt-4">
-      <button onClick={onBack} className="inline-flex items-center gap-1.5 text-blue-600 text-sm font-semibold cursor-pointer mb-5 bg-transparent border-none">
+      <button
+        onClick={onBack}
+        className="inline-flex items-center gap-1.5 text-blue-600 text-sm font-semibold cursor-pointer mb-5 bg-transparent border-none"
+      >
         <span>&larr;</span> <span>{t('back')}</span>
       </button>
       <div className="text-xl font-bold mb-5">{t('yourProgress')}</div>
@@ -59,26 +72,36 @@ export default function StatsScreen({ state, store, onBack }: StatsScreenProps) 
       <div className="grid grid-cols-3 gap-2.5 mb-6">
         <div className="bg-white rounded-xl py-4 px-3 text-center border border-gray-200">
           <div className="text-2xl font-bold text-blue-600">{history.length}</div>
-          <div className="text-[11px] text-gray-500 uppercase tracking-wide mt-1">{t('quizzes')}</div>
+          <div className="text-[11px] text-gray-500 uppercase tracking-wide mt-1">
+            {t('quizzes')}
+          </div>
         </div>
         <div className="bg-white rounded-xl py-4 px-3 text-center border border-gray-200">
           <div className="text-2xl font-bold text-green-600">{avg}%</div>
-          <div className="text-[11px] text-gray-500 uppercase tracking-wide mt-1">{t('avgScore')}</div>
+          <div className="text-[11px] text-gray-500 uppercase tracking-wide mt-1">
+            {t('avgScore')}
+          </div>
         </div>
         <div className="bg-white rounded-xl py-4 px-3 text-center border border-gray-200">
           <div className="text-2xl font-bold">{seen}</div>
-          <div className="text-[11px] text-gray-500 uppercase tracking-wide mt-1">{t('qsSeen')}</div>
+          <div className="text-[11px] text-gray-500 uppercase tracking-wide mt-1">
+            {t('qsSeen')}
+          </div>
         </div>
       </div>
 
       <div className="grid grid-cols-2 gap-2.5 mb-6">
         <div className="bg-white rounded-xl py-4 px-3 text-center border border-gray-200">
           <div className="text-2xl font-bold text-green-600">{streak}</div>
-          <div className="text-[11px] text-gray-500 uppercase tracking-wide mt-1">{t('passStreak')}</div>
+          <div className="text-[11px] text-gray-500 uppercase tracking-wide mt-1">
+            {t('passStreak')}
+          </div>
         </div>
         <div className="bg-white rounded-xl py-4 px-3 text-center border border-gray-200">
           <div className="text-2xl font-bold">{best}%</div>
-          <div className="text-[11px] text-gray-500 uppercase tracking-wide mt-1">{t('bestScore')}</div>
+          <div className="text-[11px] text-gray-500 uppercase tracking-wide mt-1">
+            {t('bestScore')}
+          </div>
         </div>
       </div>
 
@@ -97,17 +120,22 @@ export default function StatsScreen({ state, store, onBack }: StatsScreenProps) 
         <div className="mb-6">
           <h4 className="text-sm font-semibold mb-3">{t('accuracyByCategory')}</h4>
           {catStats.map(([cat, data]) => {
-            const pct = Math.round((data.correct / data.seen) * 100)
-            const color = pct >= 80 ? '#16a34a' : pct >= 60 ? '#ea580c' : '#dc2626'
+            const pct = Math.round((data.correct / data.seen) * 100);
+            const color = pct >= 80 ? '#16a34a' : pct >= 60 ? '#ea580c' : '#dc2626';
             return (
               <div key={cat} className="flex items-center gap-2.5 mb-2 text-xs">
                 <span className="w-28 shrink-0 capitalize truncate">{cat.replace(/_/g, ' ')}</span>
                 <div className="flex-1 h-2.5 bg-gray-200 rounded-full overflow-hidden">
-                  <div className="h-full rounded-full" style={{ width: `${pct}%`, background: color }} />
+                  <div
+                    className="h-full rounded-full"
+                    style={{ width: `${pct}%`, background: color }}
+                  />
                 </div>
-                <span className="w-9 text-right font-semibold" style={{ color }}>{pct}%</span>
+                <span className="w-9 text-right font-semibold" style={{ color }}>
+                  {pct}%
+                </span>
               </div>
-            )
+            );
           })}
         </div>
       )}
@@ -115,12 +143,18 @@ export default function StatsScreen({ state, store, onBack }: StatsScreenProps) 
       {weakIds.length > 0 && (
         <div className="mb-6">
           <h4 className="text-sm font-semibold mb-3">{t('mostMissed')}</h4>
-          {weakIds.slice(0, 15).map(w => (
-            <div key={w.id} className="bg-white rounded-xl py-3 px-3.5 mb-2 border border-gray-200 border-l-4 border-l-orange-500">
+          {weakIds.slice(0, 15).map((w) => (
+            <div
+              key={w.id}
+              className="bg-white rounded-xl py-3 px-3.5 mb-2 border border-gray-200 border-l-4 border-l-orange-500"
+            >
               <div className="text-sm font-semibold mb-1">Q{w.id}</div>
               <div className="text-xs text-gray-500">
-                {t('missed')} <span className="text-red-600 font-semibold">{w.wrong}/{w.seen} ({Math.round(w.missRate * 100)}%)</span>
-                {' '}&middot; {(w.category || '').replace(/_/g, ' ')}
+                {t('missed')}{' '}
+                <span className="text-red-600 font-semibold">
+                  {w.wrong}/{w.seen} ({Math.round(w.missRate * 100)}%)
+                </span>{' '}
+                &middot; {(w.category || '').replace(/_/g, ' ')}
               </div>
             </div>
           ))}
@@ -136,5 +170,5 @@ export default function StatsScreen({ state, store, onBack }: StatsScreenProps) 
         </button>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,0 +1,7 @@
+export const DEFAULT_QUESTION_COUNT = 50;
+export const QUESTION_COUNT_OPTIONS = [10, 25, 50, 100];
+export const CHART_HEIGHT = 180;
+export const MAX_CHART_ENTRIES = 20;
+export const MAX_WEAK_DISPLAY = 15;
+export const GOOD_ACCURACY_PCT = 80;
+export const FAIR_ACCURACY_PCT = 60;

--- a/frontend/src/hooks/useStore.ts
+++ b/frontend/src/hooks/useStore.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { QuizStore } from '../types';
 
 export function useStore(stateCode: string | null) {
@@ -26,5 +26,5 @@ export function useStore(stateCode: string | null) {
     if (key) localStorage.removeItem(key);
   }, [key]);
 
-  return { load, save, clear };
+  return useMemo(() => ({ load, save, clear }), [load, save, clear]);
 }

--- a/frontend/src/hooks/useStore.ts
+++ b/frontend/src/hooks/useStore.ts
@@ -1,25 +1,30 @@
-import { useCallback } from 'react'
-import type { QuizStore } from '../types'
+import { useCallback } from 'react';
+import type { QuizStore } from '../types';
 
 export function useStore(stateCode: string | null) {
-  const key = stateCode ? `quiz_${stateCode}` : null
+  const key = stateCode ? `quiz_${stateCode}` : null;
 
   const load = useCallback((): QuizStore => {
-    if (!key) return { history: [], questions: {} }
+    if (!key) return { history: [], questions: {} };
     try {
-      const raw = localStorage.getItem(key)
-      if (raw) return JSON.parse(raw)
-    } catch {}
-    return { history: [], questions: {} }
-  }, [key])
+      const raw = localStorage.getItem(key);
+      if (raw) return JSON.parse(raw);
+    } catch {
+      // Ignore corrupted localStorage data
+    }
+    return { history: [], questions: {} };
+  }, [key]);
 
-  const save = useCallback((store: QuizStore) => {
-    if (key) localStorage.setItem(key, JSON.stringify(store))
-  }, [key])
+  const save = useCallback(
+    (store: QuizStore) => {
+      if (key) localStorage.setItem(key, JSON.stringify(store));
+    },
+    [key],
+  );
 
   const clear = useCallback(() => {
-    if (key) localStorage.removeItem(key)
-  }, [key])
+    if (key) localStorage.removeItem(key);
+  }, [key]);
 
-  return { load, save, clear }
+  return { load, save, clear };
 }

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,43 +1,43 @@
-type I18nData = Record<string, Record<string, string>>
+type I18nData = Record<string, Record<string, string>>;
 
-let i18nData: I18nData = {}
-let currentLang = localStorage.getItem('quiz_lang') || 'en'
+let i18nData: I18nData = {};
+let currentLang = localStorage.getItem('quiz_lang') || 'en';
 
 const LANG_LABELS: Record<string, string> = {
   en: 'EN',
   ja: '\u65E5\u672C\u8A9E',
   es: 'ES',
   fr: 'FR',
-}
+};
 
 export function getLang() {
-  return currentLang
+  return currentLang;
 }
 
 export function setLang(lang: string) {
-  currentLang = lang
-  localStorage.setItem('quiz_lang', lang)
+  currentLang = lang;
+  localStorage.setItem('quiz_lang', lang);
 }
 
 export function getAllLangs() {
-  return Object.keys(i18nData)
+  return Object.keys(i18nData);
 }
 
 export function getLangLabel(lang: string) {
-  return LANG_LABELS[lang] || lang.toUpperCase()
+  return LANG_LABELS[lang] || lang.toUpperCase();
 }
 
 export async function loadI18n(basePath: string) {
-  const res = await fetch(`${basePath}i18n.json`)
-  i18nData = await res.json()
+  const res = await fetch(`${basePath}i18n.json`);
+  i18nData = await res.json();
 }
 
 export function t(key: string, vars?: Record<string, string | number>): string {
-  let s = i18nData[currentLang]?.[key] || i18nData['en']?.[key] || key
+  let s = i18nData[currentLang]?.[key] || i18nData['en']?.[key] || key;
   if (vars) {
     for (const [k, v] of Object.entries(vars)) {
-      s = s.replaceAll(`{${k}}`, String(v))
+      s = s.replaceAll(`{${k}}`, String(v));
     }
   }
-  return s
+  return s;
 }

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -29,6 +29,7 @@ export function getLangLabel(lang: string) {
 
 export async function loadI18n(basePath: string) {
   const res = await fetch(`${basePath}i18n.json`);
+  if (!res.ok) throw new Error(`Failed to load i18n: ${res.status}`);
   i18nData = await res.json();
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,7 +3,9 @@
 @tailwind utilities;
 
 @keyframes spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 .spinner {
   animation: spin 0.8s linear infinite;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>,
-)
+);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -41,7 +41,7 @@ export interface QuizResult {
   correct: number;
   total: number;
   pct: number;
-  mode: string;
+  mode: QuizMode;
 }
 
 export interface QuestionStats {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,65 +1,65 @@
 export interface Question {
-  id: number
-  category: string
-  question: string
-  choices: Record<string, string>
-  answer: string
-  explanation: string
-  image?: string
+  id: number;
+  category: string;
+  question: string;
+  choices: Record<string, string>;
+  answer: string;
+  explanation: string;
+  image?: string;
 }
 
 export interface StateConfig {
-  code: string
-  name: string
-  agency: string
-  passing_score_pct: number
-  test_question_count: number
-  languages: Record<string, Question[]>
+  code: string;
+  name: string;
+  agency: string;
+  passing_score_pct: number;
+  test_question_count: number;
+  languages: Record<string, Question[]>;
 }
 
 export interface Bundle {
-  states: StateConfig[]
+  states: StateConfig[];
 }
 
 export interface StateSummary {
-  code: string
-  name: string
-  agency: string
-  passing_score_pct: number
-  test_question_count: number
-  languages: string[]
-  total_questions: number
+  code: string;
+  name: string;
+  agency: string;
+  passing_score_pct: number;
+  test_question_count: number;
+  languages: string[];
+  total_questions: number;
 }
 
 export interface QuizStore {
-  history: QuizResult[]
-  questions: Record<string, QuestionStats>
+  history: QuizResult[];
+  questions: Record<string, QuestionStats>;
 }
 
 export interface QuizResult {
-  date: string
-  correct: number
-  total: number
-  pct: number
-  mode: string
+  date: string;
+  correct: number;
+  total: number;
+  pct: number;
+  mode: string;
 }
 
 export interface QuestionStats {
-  seen: number
-  wrong: number
-  category: string
+  seen: number;
+  wrong: number;
+  category: string;
 }
 
 export interface SessionResult {
-  id: number
-  question: string
-  yourAnswer: string
-  yourAnswerText: string
-  correctAnswer: string
-  correctAnswerText: string
-  correct: boolean
-  explanation: string
+  id: number;
+  question: string;
+  yourAnswer: string;
+  yourAnswerText: string;
+  correctAnswer: string;
+  correctAnswerText: string;
+  correct: boolean;
+  explanation: string;
 }
 
-export type Screen = 'loading' | 'state-picker' | 'start' | 'quiz' | 'results' | 'stats'
-export type QuizMode = 'random' | 'weak'
+export type Screen = 'loading' | 'state-picker' | 'start' | 'quiz' | 'results' | 'stats';
+export type QuizMode = 'random' | 'weak';

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,0 +1,24 @@
+import type { QuizResult } from './types';
+
+export function calcPassStreak(history: QuizResult[], passingPct: number): number {
+  let streak = 0;
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (history[i].pct >= passingPct) streak++;
+    else break;
+  }
+  return streak;
+}
+
+export function calcAverageScore(history: QuizResult[]): number {
+  if (!history.length) return 0;
+  return Math.round(history.reduce((s, r) => s + r.pct, 0) / history.length);
+}
+
+export function shuffleArray<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}


### PR DESCRIPTION
## Summary

- Add ESLint 9 (flat config) with TypeScript, React Hooks, and React Refresh plugins, plus eslint-config-prettier to avoid rule conflicts
- Add Prettier with singleQuote, trailing commas, and 100-char print width
- Add `lint`, `lint:fix`, `format`, and `format:check` scripts to `frontend/package.json`
- Format all source files with Prettier and fix all ESLint errors (removed unused `nextQuestion` function, replaced `any` with `StateConfig` type, added comment to empty catch block)
- Add `.github/workflows/frontend-lint.yml` CI workflow that runs lint and format checks on push/PR

## Test plan

- [ ] Verify `npm run lint` passes with no errors in `frontend/`
- [ ] Verify `npm run format:check` passes with no errors in `frontend/`
- [ ] Verify `npm run build` still succeeds in `frontend/`
- [ ] Verify the CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)