### PR TITLE
fix(wa): re-extract full PDF + drop TOC questions

### DIFF
--- a/data/states/wa/config.json
+++ b/data/states/wa/config.json
@@ -2,7 +2,7 @@
   "code": "wa",
   "name": "Washington",
   "agency": "DOL",
-  "manual_url": "https://www.dol.wa.gov/driverslicense/docs/driverguide-en.pdf",
+  "manual_url": "https://dol.wa.gov/media/pdf/4745/driver-guidepdf/download",
   "passing_score_pct": 80,
   "test_question_count": 25,
   "source": "2025 Washington Driver Guide (dol.wa.gov)"

--- a/data/states/wa/manual.pdf
+++ b/data/states/wa/manual.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:23aaa7163f10b7b6d8dbcfffd99eb76a7d2e3fe8b8397441d54a3288ce4c3300
-size 325084
+oid sha256:e4972693250cfd01f8fe5586fefb288d32939cd89067d42962b78fd1fa3405b4
+size 33083457

--- a/data/states/wa/manual_provenance.json
+++ b/data/states/wa/manual_provenance.json
@@ -3,22 +3,22 @@
   "code": "wa",
   "name": "Washington",
   "agency": "DOL",
-  "manual_url": "https://dol.wa.gov/media/pdf/4740/washington-state-driver-guide-plain-textpdf/download",
+  "manual_url": "https://dol.wa.gov/media/pdf/4745/driver-guidepdf/download",
   "edition": "2025",
-  "source_description": "Washington State Driver Guide (plain-text) (dol.wa.gov)",
+  "source_description": "Washington Driver Guide (dol.wa.gov)",
   "downloaded_at": "2026-04-29T12:00:00Z",
   "extracted_with": "PyMuPDF 1.27.2",
   "pdf": {
     "filename": "manual.pdf",
-    "size_bytes": 325084,
-    "sha256": "23aaa7163f10b7b6d8dbcfffd99eb76a7d2e3fe8b8397441d54a3288ce4c3300",
-    "page_count": 81,
-    "recovered": true
+    "size_bytes": 33083457,
+    "sha256": "e4972693250cfd01f8fe5586fefb288d32939cd89067d42962b78fd1fa3405b4",
+    "page_count": 191,
+    "recovered": false
   },
   "text": {
     "filename": "manual_text.txt",
-    "char_count": 173065,
-    "sha256": "49f39b415a1ed905fd71c32f5f7c1534a37fafbdae7d53e416124d35c03bfa69"
+    "char_count": 222096,
+    "sha256": "4c117803fc6ab28dd07b9c5ff0109de95f422fb45bce5d8ac8c2c6ee4f18dc1a"
   },
   "sources": []
 }

--- a/data/states/wa/manual_text.txt
+++ b/data/states/wa/manual_text.txt
@@ -1,2834 +1,5130 @@
-Washington Driver Guide (text-only) 
-This plain-text format is provided for individuals who would prefer to review the information in 
-the Driver Guide without images and other graphic elements. The content on this page can also 
-be downloaded as a text-only PDF document. 
-Chapter 1: Licenses 
-1.0: Deciding to drive 
-Becoming a driver is both a privilege and a responsibility. It’s something that will stay with you 
-for most of your life. Take time to develop your driving knowledge and skills. They will help you 
-form healthy habits and set a foundation for a lifetime of driving. 
-1.1: Assigned WA Number (WDL Number) 
-All Washington licenses, permits, and ID cards have an assigned Washington number. This 
-number is specific to you. It often starts with the letters WDL. 
-1.2: License Express  
-If you do not have a WDL number, you can get one at a driver licensing office or by creating a 
-new customer account on License Express. License Express is the secure website where you 
-can access many of DOL’s services. The License Express link can be found on the dol.wa.gov 
-homepage. Sign up with a username and password that is easy for you to remember. New 
-drivers need to set up their own account. You can’t get services for yourself by using someone 
-else’s account. The account must belong to you. 
-In License Express, you can: 
-Make an appointment at a driver licensing office. 
-Pre-apply for an instruction permit. 
-Schedule your Driving Skills Exam. 
-Renew your driver license. 
-Manage your vehicle tabs. 
-Update your address. 
-If you don’t remember your WDL number or have questions about your License Express 
-account, call DOL driver licensing customer service at 360-902-3900. 
-1.3: Licensing and vehicle offices 
-Staff at driver licensing offices can help you get your driver license or ID card. Visit a vehicle 
-licensing office for help related to vehicle licensing and registration. Be sure to contact the 
-appropriate office for the service you need. 
-1.4: Washington state residents 
-You are a Washington resident if any of the following are true: 
-You maintain a residence in Washington for personal use. 
+Helping every Washington resident live, work, drive, & thrive.
+WASHINGTON
+DRIVER GUIDEA
+For all
+Services!Scannable QR code
+Scan meThe Washington State Department of Licensing (dol) logo appears above a dol.wa.gov website in the right corner of the image.
+dol.wa.gov
 
-You are registered to vote in Washington. 
-You use a Washington address for federal or state taxes. 
-You receive benefits under one of Washington’s public assistance programs. 
-You are attending school in this state and paying tuition as a Washington resident or are a 
-custodial parent with a child attending a public school in this state. 
-You live in a motor home or vessel not permanently attached to any property, previously lived in 
-Washington, and don’t have a permanent residence in any other state. 
-1.5: New residents 
-New residents: 18+ years old 
-New residents that are licensed in another state have 30 days to obtain a Washington State 
-driver license. If your out-of-state license is expired, you’ll need to pass both the Driving 
-Knowledge Exam and Driving Skills Exam before getting a Washington license. Some licenses 
-can transfer without you having to retake the exams. Search driver training and testing on 
-dol.wa.gov for exam information that relates to your specific situation. 
-New residents: 16-17 years old 
-If you’re under 18 and have your license from another state, you’ll need to apply for a 
-Washington Intermediate Driver License. The DOL will need to approve your out-of-state driver 
-education and verify you had your instruction permit for at least 6 months. If you have questions 
-about transferring your driver training coursework to Washington, please email the driver 
-training school program at tse@dol.wa.gov.  
-Your identity 
-To get an instruction permit, driver license, or identification card, you’ll need to provide 
-documentation that proves your identity. 
-Search identification requirements brochure this site to see what documents you need. 
-Bring original copies of all necessary documents with you to the driver licensing office. 
-DOL2GO services 
-First-time Washington driver license or ID card, including enhanced 
-Out-of-state transfers 
-Driver license, permit or ID card renewals 
-Driver record 
-Reinstatement letters 
-Document review for proof of identity 
-Help for the unhoused 
+An image with a dark blue backg
+round and cartoonish illustrate
+d animals.
+A bear talking to a
+ pigeon saying the words “A
+RE YOU READY?”, next t
+o a racoon holding a driv
+er license.
+Below the pig
+eon, there’s a driver lic
+ense and a paragraph that say
+s “REAL ID is a law that re
+quires drive
+r licens
+es and
+ IDs to meet certain s
+ecurity standards in o
+rder to be accepted for dom
+estic air travel or to acce
+ss some federal facilities. Standard driver licenses and IDs do not qualify.
+The Washington State Department of Licensing (dol) logo appears in the bottom left corner of the image, next to a scannable QR code and to a paragraph that says “Enhanced licenses and IDs are among several REAL ID-compliant options. Do you have what you need? Scan the QR code or go to REALIDwa.com to find out.”
 
-If you are experiencing homelessness, you’re eligible for a no-cost ID or a reduced-fee ID. 
-People receiving public assistance might also be eligible for an ID card at a reduced cost. To get 
-help, contact your local Department of Social and Health Service (DSHS) community services 
-office. Go to dshs.wa.gov and use the office locator to find local services. 
-1.6: Identification and driver licenses 
-Standard driver license and ID 
-Suitable for: 
-Identification 
-Operating a motor vehicle (driver license only) 
-Not suitable for: 
-Domestic air travel 
-International air travel 
+An I
+nfog
+raph
+ic i
+mage with
+ the titl
+e: “Everyone ge
+ts h
+ome 
+safe
+” wi
+th cars d
+riving in a highway that h
+as written the text 
+“Move over” and “Slow down
+ 10 MPH” on it.
+In the
+ left cor
+ner t
+here’s a sign with text that says “State Law. Move Over. Slow Down.”
+At the bottom, there is a sign that says “emergency sign ahead”. Next to it there is a text that says “Move over 200 feet before and after the scene. Slow down to 10 mph below the posted speed limit.”
+
+An
+ illustrated image with mountains in the 
+background and 3 cars driving on a road.
+ One of the cars has 
+a “Studen
+t Driver” sign.
+T
+he text in the 
+image reads “Car 
+crashes are a l
+eading cause
+ of death and
+ injury f
+or young dri
+vers in America. KNOW THE C
+RASH RISKS for ages 16 t
+o 25.
+ Wet Roads. Inexperience.
+ No Seatbelts. Night D
+riving. Speed – 
+Fatigue. Drugs and Alcohol. Teen Passengers. Distracted Driving. How many people are killed on America’s roads each year? What should Washington’s Traffic death goal be?”
+In the bottom right corner, a “target zero” logo appears. It is above the Washington State Department of Licensing (dol) logo, the dol.wa.gov website and the “520-400 (R/4/25) English” text.
+
+W
+
+TABLE OF CONTENTS
+We are Washington
+Introduction
+Contents
+Equity for all customers
+Contact Information  |  dol.wa.gov
+1  |  Licenses
+Deciding to Drive...............................................................1.0
+Assigned WA Number (WDL Number)..........................1.1
+License Express..................................................................1.2
+Licensing and Vehicle Offices........................................1.3
+Washington state Residents ..........................................1.4
+New residents.....................................................................1.5
+New residents 18+ years old...............................................................1.5
+New residents: 16 to 17 years old.....................................................1.5
+Your identity .................................................................................................1.5
+Help for the unhoused...........................................................................1.5
+Identification and driver licenses..................................1.6
+Real ID...................................................................................1.7
+Getting a Personal Driver License.................................1.8
+Instruction permit.....................................................................................1.8
+Getting your personal driver license: ages 16 to 17.............1.8
+Getting your personal driver license: ages 18+.....................1.8
+Intermediate driver license.................................................................1.8
+Agricultural permits ................................................................................1.8
+Early warning letters................................................................................1.8
+
+Health....................................................................................1.9
+Vision screenings......................................................................................1.9
+Organ donor ................................................................................................1.9
+Medical designations.............................................................................1.9
+Endorsements.....................................................................1.10
+Older drivers........................................................................1.11
+Personal Driver License Exams.......................................1.12
+Two exams.....................................................................................................1.12
+Taking the exams.......................................................................................1.12
+Driver Training Education................................................1.13
+Over 18..............................................................................................................1.13
+For Guardians of New Drivers.........................................1.14
+Maintaining your license..................................................1.15
+Replacing your driver license............................................................1.15
+Renewing your driver license............................................................1.15
+Expired license ..........................................................................................1.15
+Losing your driving privileges...........................................................1.15
+Alcohol, drugs, and firearms violations ......................................1.15
+Driving under the influence (DUI)..................................................1.15
+Open container law ................................................................................1.15
+Additional Services...........................................................1.16
+Change of address or name .............................................................1.16
+Voter registration.......................................................................................1.16
+Selective service registration............................................................1.16
+Twin registry..................................................................................................1.16
+2  |  Vehicles
+Vehicle Services.................................................................2.0
+Certificate of ownership (Title)........................................................2.0
+Registration...................................................................................................2.0
+Vehicle address..........................................................................................2.0
+
+Report of sale......................................................................2.1
+Individual to individual...........................................................................2.1
+Dealership to individual........................................................................2.1
+Vehicle license plates ......................................................2.2
+Insurance required............................................................2.3
+Know your vehicle..............................................................2.4
+Functions........................................................................................................2.4
+Adjustments..................................................................................................2.4
+Vehicle safety technology...................................................................2.4
+Vehicle Maintenance .......................................................2.5
+Tires....................................................................................................................2.5
+Glass surfaces.............................................................................................2.5
+Headlights......................................................................................................2.5
+Brake lights....................................................................................................2.5
+Turn signals ..................................................................................................2.5
+Hand signals.................................................................................................2.5
+Hazard warning lights.............................................................................2.5
+Driver’s seat..................................................................................................2.5
+Occupant Protection.........................................................2.6
+Seat belts and occupant protection............................................2.6
+Child seats.....................................................................................................2.6
+Airbags.............................................................................................................2.6
+Steering................................................................................2.7
+Hand-to-hand steering (Pull/Push)..............................................2.7
+Hand-over-hand steering ..................................................................2.7
+One-hand steering .................................................................................2.7
+Braking..................................................................................2.8
+Braking pressure........................................................................................2.8
+Antilock braking systems......................................................................2.8
+Accelerating .......................................................................2.9
+Balanced weight ................................................................2.10
+
+Pitch...................................................................................................................2.10
+Roll......................................................................................................................2.10
+Yaw......................................................................................................................2.10
+Vehicle reference points..................................................2.11
+Your blind zones.................................................................2.12
+Other vehicles' blind zones ............................................2.13
+Observational scans................................................................................2.13
+Before you go .....................................................................2.14
+3  |  Drivers
+You Behind the Wheel................................................. 3.0
+Health...............................................................................................................3.0
+Physical health............................................................................................3.0
+Vision.................................................................................................................3.0
+Seeing at night............................................................................................3.0
+Hearing............................................................................................................3.0
+Impaired Driving........................................................... 3.1
+Alcohol and driving ................................................................................3.1
+Cannabis and driving.............................................................................3.1
+Medications and driving.......................................................................3.1
+Polydrug use and driving.....................................................................3.1
+Fatigue and drowsy driving................................................................3.1
+Mental health...............................................................................................3.1
+Aggressive driving....................................................................................3.1
+Racing and street demonstrations................................................3.1
+Road rage.......................................................................................................3.1
+If you are experiencing road rage..................................................3.1
+If you are the victim of road rage ...................................................3.1
+Reporting road rage................................................................................3.1
+Informed Decisions on the road................................. 3.2
+Why informed decisions matter.......................................................3.2
+
+Make good decisions.............................................................................3.2
+Problem Solving on the Road..................................... 3.3
+Avoiding Distracted Driving....................................... 3.4
+Washington’s distracted driving laws..........................................3.4
+Smart Drivers................................................................. 3.5
+Pay attention................................................................................................3.5
+Visually search and scan......................................................................3.5
+Respect and responsibility......................................... 3.6
+Traffic advisories........................................................................................3.6
+Litter...................................................................................................................3.6
+The environment.......................................................................................3.6
+Self-evaluation ..........................................................................................3.6
+4  |  Roads
+Awareness and cooperation....................................... 4.0
+Sharing with people..................................................... 4.1
+Sharing with school buses.......................................... 4.2
+When you are behind the bus..........................................................4.2
+When you are in front of the bus ...................................................4.2
+Sharing with transit buses........................................... 4.3
+Sharing with large vehicles......................................... 4.4
+Snowplows.....................................................................................................4.4
+Sharing with motorcycles .......................................... 4.5
+Following.........................................................................................................4.5
+Lanes.................................................................................................................4.5
+Turning.............................................................................................................4.5
+Road surface................................................................................................4.5
+Lights.................................................................................................................4.5
+
+Sharing with bicyclists................................................. 4.6
+General guidance.....................................................................................4.6
+Passing a bicyclist ...................................................................................4.6
+Bike lanes.......................................................................................................4.6
+Sharing the road with trains....................................... 4.7
+Important safety reminders................................................................4.7
+When to call For help.............................................................................4.7
+Light Rail..........................................................................................................4.7
+Sharing with agricultural vehicles............................. 4.8
+Sharing with emergency vehicles ............................. 4.9
+Rules of the road
+Traffic laws..................................................................... 4.10
+General driving guidance ..................................................................4.10
+Traffic control devices............................................................................4.10
+Broken lights or signals.........................................................................4.10
+Traffic light signals....................................................... 4.11
+Freeway ramp meters.............................................................................4.11
+Signs............................................................................... 4.12
+Common signs............................................................................................4.12
+Work Zone signs.........................................................................................4.12
+Service Signs...............................................................................................4.12
+Recreation signs........................................................................................4.12
+Destination signs.......................................................................................4.12
+Other traffic signs ....................................................................................4.12
+Common intersections................................................ 4.13
+Turning........................................................................... 4.14
+U-turns.............................................................................................................4.14
+
+Other intersections...................................................... 4.15
+Roundabouts...............................................................................................4.15
+Diverging diamonds................................................................................4.15
+Uncontrolled Intersection ..................................................................4.15
+Road markings............................................................... 4.16
+Lanes.................................................................................................................4.16
+HOV / carpool..............................................................................................4.16
+Reversible lanes.........................................................................................4.16
+Reserved lanes...........................................................................................4.16
+Toll lanes.........................................................................................................4.16
+Other road markings...............................................................................4.16
+Zones.............................................................................. 4.17
+School zone..................................................................................................4.17
+Work zone.......................................................................................................4.17
+Emergency zone........................................................................................4.17
+Parking........................................................................... 4.18
+General parking rules.............................................................................4.18
+Perpendicular and angled parking................................................4.18
+Parallel parking...........................................................................................4.18
+Parking on a hill..........................................................................................4.18
+Reserved disabled parking.................................................................4.18
+Electric vehicle charging station parking.................................4.18
+Transporting.................................................................. 4.19
+Towing..............................................................................................................4.19
+Secure your load........................................................................................4.19
+Animals.............................................................................................................4.19
+Maritime......................................................................... 4.20
+Ferries...............................................................................................................4.20
+Beaches..........................................................................................................4.20
+
+5  |  Risks
+Dangers of driving........................................................ 5.0
+Risk awareness............................................................................................5.0
+Hazard perception....................................................................................5.0
+Situational awareness.............................................................................5.0
+Hazard management .............................................................................5.0
+Speed.............................................................................. 5.1
+Excessive speeds......................................................................................5.1
+Speed limits..................................................................................................5.1
+Adjusting speed for conditions........................................................5.1
+Space.............................................................................. 5.2
+Merging.......................................................................... 5.3
+Zipper merging...........................................................................................5.3
+Time................................................................................ 5.4
+Count seconds...........................................................................................5.4
+Turning in front of approaching vehicles...................................5.4
+Focus.............................................................................. 5.5
+Attention.........................................................................................................5.5
+Field of vision...............................................................................................5.5
+Path of travel.................................................................................................5.5
+Line of sight...................................................................................................5.5
+Information gathering............................................................................5.5
+Road and driving conditions...................................... 5.6
+Night driving.................................................................................................5.6
+Curves .............................................................................................................5.6
+Slippery roads..............................................................................................5.6
+Skidding...........................................................................................................5.6
+Hydroplaning...............................................................................................5.6
+Vehicle failures............................................................. 5.7
+Tires....................................................................................................................5.7
+Power................................................................................................................5.7
+
+Headlight........................................................................................................5.7
+Accelerator....................................................................................................5.7
+Communicating risks................................................... 5.8
+Collisions....................................................................... 5.9
+Crashing a vehicle....................................................................................5.9
+Reporting a crash.....................................................................................5.9
+Reporting an injury...................................................................................5.9
+Calling 911.......................................................................................................5.9
+Encountering power lines ..................................................................5.9
+Witnessing a crash ..................................................................................5.9
+Emergency kit..............................................................................................5.9
+Law enforcement ......................................................... 5.10
+Getting pulled over..................................................................................5.10
+Getting a ticket...........................................................................................5.10
+Resources
+Conclusion
+Glossary
+Accessibility and Accommodations
+Disclaimer
+
+We are Washington
+This guide reflects shared Washingtonian values: 
+•	
+We take care of ourselves and others by following the rules 
+of the road. 
+•	
+We look out for vulnerable road users. 
+•	
+We are attentive, intentional, and level-headed behind 
+the wheel. 
+•	
+We want everyone to get where they’re going safely.Outline of Washington state 
+ 
+CONTENTS 
+The Washington State Department of Licensing (DOL) produces 
+the official Washington State Driver Guide. This guide refers to 
+many Washington laws and provides safety advice that might 
+not be in the laws. All information is as accurate as possible at 
+the time of publication. However, the guide might not reflect 
+the most recent changes made by the Washington Legislature. 
+You can find the most current version of this guide on the 
+DOL website: dol.wa.gov. 
+
+EQUITY FOR ALL CUSTOMERS 
+The Department of Licensing (DOL) is committed to building 
+a culture of belonging through our values: diversity, equity, 
+inclusion, trust, and respect. Wherever possible, we provide 
+equitable access and eliminate barriers for our customers. We 
+provide reasonable accommodations upon request to those 
+customers who need them to access our facilities and services. 
+We offer language services to customers whose primary 
+language is not English. DOL is dedicated to Pro-Equity Anti-
+Racism (PEAR). The agency has a robust and active PEAR team 
+of community partners, employees, and leaders collaborating 
+to create a service environment responsive to community input. 
+For more information about accommodations and accessibility 
+please see the final page of the guide. 
+CONTACT INFORMATION  |  DOL.WA.GOVLaptop and a smartphone displ
+Driver licensing 
+customer service: 
+360-902-3900
+Vehicle licensing 
+customer service: 
+360-902-3770
+Company icon for Facebook
+Facebook.com/WashingtonDOLCompany icon for Instagram
+Instagram.com/wa_licensingCompany icon for LinkedIn
+LinkedIn.com/company/Washington-
+state-department-of-licensingCompany icon for Threads
+Threads.net/@wa_licensingCompany icon for X
+X.com/WA_DOLCompany icon for YouTube
+Youtube.com/WALicensing
+
+Chapter 1
+ Licenses image with cityscape, Space Needle, car, and speed limit sign.
+
+1.0  |  DECIDING TO DRIVE
+Becoming a driver is both a privilege and a responsibility. It’s 
+something that will stay with you for most of your life. Take time 
+to develop your driving knowledge and skills. They will help you 
+form healthy habits and set a foundation for a lifetime of driving.
+1.1  |  ASSIGNED WA NUMBER (WDL NUMBER)
+All Washington licenses, permits, and ID cards have an assigned 
+Washington number. This number is specific to you. It often 
+starts with the letters WDL.
+1.2  |  LICENSE EXPRESS
+If you do not have a WDL number, you can get one at a driver 
+licensing office or by creating a new customer account on 
+License Express. License Express is the secure website where 
+you can access many of DOL’s services. The License Express 
+link can be found on the dol.wa.gov homepage. Sign up with a 
+username and password that is easy for you to remember. New 
+drivers need to set up their own account. You can’t get services 
+for yourself by using someone else’s account. The account 
+must belong to you.
+In License Express, you can:
+•	
+Make an appointment at a driver licensing office.
+•	
+Pre-apply for an instruction permit.
+•	
+Schedule your Driving Skills Exam.
+•	
+Renew your driver license.
+•	
+Manage your vehicle tabs.
+•	
+Update your address.
+If you don’t remember your WDL number or have questions 
+about your License Express account, call DOL driver licensing 
+customer service at 360-902-3900.
+
+1.3  |  LICENSING AND VEHICLE OFFICES
+Staff at driver licensing offices can help you get your driver 
+license or ID card. Visit a vehicle licensing office for help related 
+to vehicle licensing and registration. Be sure to contact the 
+appropriate office for the service you need.Sign that reads "WELCOME TO WASHINGTON THE E
+1.4  |  WASHINGTON STATE RESIDENTS 
+You are a Washington resident if any of the following are true:
+•	
+You maintain a residence in Washington for personal use.
+•	
+You are registered to vote in Washington.
+•	
+You use a Washington address for federal or state taxes.
+•	
+You receive benefits under one of Washington’s public 
+assistance programs.
+•	
+You are attending school in this state and paying tuition as 
+a Washington resident or are a custodial parent with a child 
+attending a public school in this state. 
+•	
+You live in a motor home or vessel not permanently attached 
+to any property, previously lived in Washington, and 
+don’t have a permanent residence in any other state.
+
+1.5  |  NEW RESIDENTSBrochure cover for new residents in Washington State with a lighthouse image and licensing information.
+NEW RESIDENTS 18+ YEARS OLD
+New residents who are licensed in 
+another state have 30 days to obtain 
+a Washington State driver license. If 
+your out-of-state license is expired, 
+you’ll need to pass both the Driving 
+Knowledge Exam and Driving Skills Exam 
+before getting a Washington license. 
+Some licenses can transfer without you 
+having to retake the exams. Search driver 
+training and testing on dol.wa.gov for 
+exam information that relates to your 
+specific situation.
+NEW RESIDENTS: 16 TO 17 YEARS OLD
+If you’re under 18 and have your license from another state, 
+you’ll need to apply for a Washington Intermediate Driver 
+License. The DOL will need to approve your out-of-state driver 
+education and verify you had your instruction permit for at least 
+6 months. If you have questions about transferring your driver 
+training coursework to Washington, please email the driver 
+training school program at tse@dol.wa.gov. 
+YOUR IDENTITY 
+To get an instruction permit, driver license, or identification card, 
+you’ll need to provide documentation that proves your identity. 
+•	
+Search identification requirements brochure on 
+dol.wa.gov to see what documents you need.
+•	
+Bring original copies of all necessary documents with you to 
+the driver licensing office.
+
+Graphic for "DOL 2 GO," a mobile service provided by the Washington State Department of Licensing.  A series of services offered is listed above a van decorated with an illustration of the Seattle skyline.
+SERVICES
+•	
+First-time Washington driver 
+license or ID card, including 
+enhanced
+•	
+Out-of-state transfers
+•	
+Driver license, permit or ID 
+card renewals
+•	
+Driver record
+•	
+Reinstatement letters
+•	
+Document review
+for proof of
+identity
+HELP FOR THE UNHOUSED
+If you are experiencing homelessness, you’re eligible for a no-
+cost ID or a reduced-fee ID. People receiving public assistance 
+might also be eligible for an ID card at a reduced cost. To 
+get help, contact your local Department of Social and Health 
+Services (DSHS) community services office. Go to dshs.wa.gov 
+and use the office locator to find local services. 
+
+1.6  |  IDENTIFICATION AND DRIVER LICENSESStandard driver licenses/IDs with the la
+IdentificationGreen check mark
+Operating a motor vehicle (driver license only)Red cro
+Domestic air travelRed cross
+International air travelRed cross
+International border crossing by land or seaRed cross
+Access to federal facilitiesRed cross
+Meets REAL ID standards
+
+1.6  |  IDENTIFICATION AND DRIVER LICENSESAnother image of standard driver licenses/ID
+IdentificationGreen check mark
+Operating a motor vehicle (driver license only)Green check 
+Domestic air travelRed cross
+International air travelGreen check mark
 International border crossing by land or sea 
-Access to federal facilities 
-Standard licenses and IDs do not meet REAL ID standards. 
-Enhanced driver license and ID 
-Suitable for: 
-Identification 
-Operating a motor vehicle (driver license only) 
-Domestic air travel 
-International border crossing by land or sea 
-Access to federal facilities 
-Not suitable for: 
-International air travel 
-Enhanced licenses and IDs meet REAL ID standards. 
-1.7: REAL ID 
-REAL ID is a law, not an actual piece of ID.  
-An enhanced driver license or ID is among several options that meet REAL ID requirements. 
-Standard driver licenses will no longer be an acceptable form of identification for airport security 
-checkpoints, U.S. border crossings, or accessing secure federal buildings. 
-Visit realidwa.com to view informational videos, take a quiz to determine which ID you need, 
-and learn more about REAL ID. 
+(Canada, Mexico, Caribbean)Green check mark
+Access to federal facilitiesGreen check mark
+Meets REAL ID standards
 
-1.8: Getting a personal driver license 
-Instruction permit 
-Before applying for an instruction permit, you need to have a WDL number. 
-If you are enrolling in a driver training course:  
-You can apply for your permit as early as 15 years old. Apply at a driver licensing office or online 
-1 to 10 days before your course starts. Be prepared to give your WDL number to your driving 
-school for record keeping.   
-If you are not enrolling in a driver training course:  
-You can take the knowledge exam after you turn 15½. Once you pass, you’ll get your permit. 
-However, you need to wait until you’re 18 to take the skills exam and get your license.  
-Your permit is valid for 1 year (can be renewed for a fee). Your knowledge exam score is only 
-valid for 2 years. If you wait too long to take your skills exam, you may have to take the 
-knowledge exam again. 
-There are a variety of IDs, licenses, and endorsements for Washington residents. 
-Getting your personal driver license: Ages 16 to 17 
-To get your first driver license, you must: 
+1.7  |  REAL ID
+REAL ID is a law, not an actual piece of ID.
+  
+An enhanced driver license or ID is among several options 
+that meet REAL ID requirements. Standard driver licenses will 
+no longer be an acceptable form of identification for airport 
+security checkpoints, U.S. border crossings, or accessing secure 
+federal buildings. 
+Visit REALIDwa.com to view informational videos, take a quiz to 
+determine which ID you need, and learn more about REAL ID.Illustration o
+
+Three Washington State IDs on a blue background.
+1.8  |  GETTING A PERSONAL DRIVER LICENSE
+INSTRUCTION PERMIT
+Before applying for an instruction permit, you need to have a 
+WDL number.
+If you are enrolling in a driver training course
+You can apply for your permit as early as 15 years old. Apply at a 
+driver licensing office or online 1 to 10 days before your course 
+starts. Be prepared to give your WDL number to your driving 
+school for record keeping. 
+If you are not enrolling in a driver training course
+You can take the knowledge exam after you turn 15½. Once 
+you pass, you’ll get your permit. However, you need to wait until 
+you’re 18 to take the skills exam and get your license.
+ 
+Your permit is valid for 1 year (can be renewed for a fee). Your 
+knowledge exam score is valid for 2 years. If you wait too long 
+to take your skills exam, you may have to take the knowledge 
+exam again.
+ 
+There are a variety of IDs, licenses, and endorsements for 
+Washington residents.
+
+GETTING YOUR PERSONAL DRIVER LICENSE:
+AGES 16 TO 17
+To get your first driver license, you must:
+•	
 Have your instruction permit for at least 6 months. 
-Be at least 16 years old and a Washington resident. 
-Complete a traffic safety course at an approved driver training school. 
-Ensure a traffic safety course completed in another state meets Washington’s minimum 
-requirement (30 hours of classroom and 6 hours of behind-the-wheel instruction). 
-Pass both the Driving Knowledge Exam and Driving Skills Exam. 
-Complete at least 40 hours of day driving and 10 hours of night driving with a licensed driver 
-who has 3 or more years of experience. (Parents, guardians, or responsible adults must attest 
-to this.) 
-Be without any traffic violations or convictions for 6 months prior to applying for the license. 
-Have no alcohol or drug offenses while driving with your instruction permit. 
-Decide if you’d like to register as an organ, eye, and tissue donor. 
-To get your license in person you’ll need to: 
-Make an appointment at a driver licensing office. You can do this through License Express or by 
-calling DOL licensing customer service at 360-902-3900. 
-Bring your parent or guardian with you to the licensing office to sign the parental authorization 
-form. This form gives you permission to apply, certifies you have at least 50 hours of driving 
-experience, and confirms you haven’t had any traffic infractions or violations in the last 6 
+•	
+Be at least 16 years old and a Washington resident.
+•	
+Complete a traffic safety course at an approved driver 
+training school.
+•	
+Ensure a traffic safety course completed in another state 
+meets Washington’s minimum requirement (30 hours of 
+classroom and 6 hours of behind-the-wheel instruction).
+•	
+Pass both the Driving Knowledge Exam and Driving Skills 
+Exam. 
+•	
+Complete at least 40 hours of day driving and 10 hours of 
+night driving with a licensed driver who has 3 or more years 
+of experience. (Parents, guardians, or responsible adults 
+must attest to this.)
+•	
+Be without any traffic violations or convictions for 6 months 
+prior to applying for the license.
+•	
+Have no alcohol or drug offenses while driving with your 
+instruction permit.
+•	
+Decide if you’d like to register as an organ, eye, and 
+tissue donor. 
+To get your license in person you’ll need to:
+•	
+Make an appointment at a driver licensing office. You can 
+do this through License Express or by calling DOL licensing 
+customer service at 360-902-3900.
+•	
+Bring your parent or guardian with you to the licensing office 
+to sign the parental authorization form. This form gives you 
+permission to apply, certifies you have at least 50 hours of 
+driving experience, and confirms you haven’t had any traffic 
+infractions or violations in the last 6 months. Your parent or 
 
-months. Your parent or guardian must show proof of identity and their relationship to you. If your 
-last names are different, bring documents that show your relationship. 
-Wait for your driver training school to enter your course completion and exam scores. Your 
-driver training school has 24 hours to enter your scores in the system once you’ve passed each 
-exam. If your driver training school has permanently closed and you need assistance, email the 
-driver training school program at tse@dol.wa.gov. 
-Provide your Social Security number or sign a declaration if you don’t have one. 
-Show proof of identity. 
-Pass a vision screening. 
-Have your photo taken. 
-Pay any licensing fees. 
-Before leaving the office, you’ll receive a temporary license that is good for 45 days. Your official 
-license will be mailed to you. 
-To get your license online you’ll need to: 
-Have a Washington photo instruction permit. 
-Get permission from your parent or guardian. 
-Ensure your driver training school has entered your course completion and exam scores. 
-Pay any licensing fees. 
-Print the receipt. (This is your temporary license. It won’t include your photo, so it’s not valid for 
-identification.) 
-Your official license will have the same photo as your instruction permit or Washington ID card. 
-Getting your personal driver license: Ages 18+ 
-If you are 18 or over, you have four options for getting your first Washington driver license. You 
-can: 
-Transfer your license from another state. 
-Pass the knowledge and skills exams. 
-Pass the knowledge exam, get a permit, practice driving with a licensed driver who has 5 or 
-more years of experience, and then pass the skills exam. 
-Get an exam waiver to get your permit, take a driver training course, then pass the knowledge 
-and skills exams after you complete the course. 
-Intermediate driver license 
-Washington teens ages 16 and 17 move through two restricted phases of licensing before being 
-granted an unrestricted driver license: 1) the instruction permit and 2) the intermediate driver 
-license.  Driving with an intermediate driver license means you have to follow the laws below. 
+guardian must show proof of identity and their relationship 
+to you. If your last names are different, bring documents that 
+show your relationship.
+•	
+Wait for your driver training school to enter your course 
+completion and exam scores. Your driver training school 
+has 24 hours to enter your scores in the system once 
+you’ve passed each exam. If your driver training school has 
+permanently closed and you need assistance, email the 
+driver training school program at tse@dol.wa.gov.
+•	
+Provide your Social Security number or sign a declaration if 
+you don’t have one.
+•	
+Show proof of identity.
+•	
+Pass a vision screening.
+•	
+Have your photo taken.
+•	
+Pay any licensing fees.
+Before leaving the office, you’ll receive a temporary 
+license that is good for 45 days. Your official license will 
+be mailed to you.
+ 
+To get your license online you’ll need to:
+•	
+Have a Washington photo instruction permit.
+•	
+Get permission from your parent or guardian.
+•	
+Ensure your driver training school has entered your course 
+completion and exam scores.
+•	
+Pay any licensing fees.
+•	
+Print the receipt. (This is your temporary license. It won’t 
+include your photo, so it’s not valid for identification.)
+Your official license will have the same photo as your instruction 
+permit or Washington ID card.
 
-From Issue Date to 6 Months 
-No passengers under age 20 except immediate family members 
-No driving between 1 a.m. and 5 a.m. unless accompanied by a parent, guardian, or licensed 
-driver at least age 25 
-From 6 months to age 18 or one year (whichever comes first) 
-No more than 3 passengers under age 20 except immediate family members 
-Nighttime restrictions expire after one year of safe driving 
-Intermediate license laws also restrict the use of cell phones and wireless communication 
-devices while you’re driving, even with hands-free technology. You can only use your phone to 
-report an emergency. 
-The penalties for traffic violations and at-fault collisions are listed below. 
-1st Violation: Current restrictions apply until you’re 18. 
-2nd Violation: License is suspended for 6 months or until you turn 18, whichever comes first. 
-3rd Violation: License is suspended until you’re 18. 
-Exceptions: 
-Agricultural purposes. Intermediate driver license holders may drive at any hour, with 
-passengers, for agricultural purposes. 
-One year of safe driving. Intermediate driver license holders may drive at any hour, with 
-passengers, if they haven’t been involved in a crash or committed a traffic offense. 
-You don’t need to get a new license when you turn 18. Intermediate driver license restrictions 
-are automatically lifted. You can wait until you renew your license to get an updated physical 
-copy of your driver license. 
-Agricultural permits 
-Agricultural permits allow drivers under 18 years old to drive within a specific area for farm work. 
-There’s no minimum age requirement for a juvenile agricultural permit. 
-An agricultural permit isn’t a substitution for an instruction permit. You still have to get an 
-instruction permit and meet all driving practice requirements before you can get your first driver 
-license. An agricultural permit doesn’t waive the requirements for getting your first Washington 
-driver license. 
-Early warning letters 
-The DOL sends letters to all drivers ages 18 to 21 who receive their first moving violation. A 
-driver’s chances of crashing doubles after receiving their first violation. Parents and guardians of 
-intermediate driver license holders receive similar letters after violations or crashes. The goal of 
-the letter is to help young drivers realize the risks associated with continued violations and 
-reduce repeat offenses. 
+GETTING YOUR PERSONAL DRIVER LICENSE: 
+AGES 18+
+If you are 18 or over, you have four options for getting your first 
+Washington driver license. You can:
+1.	 Transfer your license from another state.
+2.	 Pass the knowledge and skills exams.
+3.	 Pass the knowledge exam, get a permit, practice driving with 
+a licensed driver who has 5 or more years of experience, and 
+then pass the skills exam.
+4.	 Get an exam waiver to get your permit, take a driver training 
+course, then pass the knowledge and skills exams after you 
+complete the course.
+INTERMEDIATE DRIVER LICENSE
+Washington teens ages 16 and 17 move through two restricted 
+phases of licensing before being granted an unrestricted driver 
+license: 1) the instruction permit and 2) the intermediate driver 
+license. Driving with an intermediate driver license means you 
+have to follow the laws below.
+Restrictions
+From Issue Date 
+to 6 Months
+From 6 months to
+age 18 or one year
+(whichever comes first)
+Passengers
+No passengers 
+under age 20 
+except immediate 
+family members
+No more than 
+3 passengers under 
+age  20 except immediate 
+family members
+Hours of 
+driving
+No driving 
+between 1 a.m. 
+and 5 a.m. unless 
+accompanied by a 
+parent, guardian, or 
+licensed driver at 
+least age 25
+Nighttime restrictions 
+expire after one year of 
+safe driving
 
-1.9: Health 
-Vision screenings 
-DOL will check your vision before issuing your license. If you use corrective glasses or contact 
-lenses, this will be recorded on your license. 
-Remember to always wear your glasses or contacts while driving. 
-Have your eyes checked regularly by an eye doctor. 
-Organ donor  
-When you get your license, you’ll be asked if you want to become an organ donor. If you chose 
-to, the donor heart symbol will appear on your license, and your information will be given to the 
-donor registry. Contact LifeCenter Northwest at lcnw.org or visit the registry website, 
+Intermediate license laws also restrict the use of cell phones 
+and wireless communication devices while you’re driving, even 
+with hands-free technology. You can only use your phone to 
+report an emergency.
+The penalties for traffic violations and at-fault collisions are 
+listed below.
+Violation
+Penalty
+1st
+Current restrictions apply until you’re 18.
+2nd
+License is suspended for 6 months or until 
+you turn 18, whichever comes first.
+3rd
+License is suspended until you’re 18.
+ 
+Exceptions
+•	
+Agricultural purposes. Intermediate driver license holders 
+may drive at any hour, with passengers, for agricultural 
+purposes. 
+•	
+One year of safe driving. Intermediate driver license 
+holders may drive at any hour, with passengers, if they 
+haven’t been involved in a crash or committed a traffic 
+offense.
+You don’t need to get a new license when you turn 18. 
+Intermediate driver license restrictions are automatically lifted. 
+You can wait until you renew your license to get an updated 
+physical copy of your driver license.
+AGRICULTURAL PERMITS 
+Agricultural permits allow drivers under 18 years old to drive 
+within a specific area for farm work. There’s no minimum age 
+requirement for a juvenile agricultural permit.
+
+An agricultural permit isn’t a substitution for an instruction 
+permit. You still have to get an instruction permit and meet 
+all driving practice requirements before you can get your 
+first driver license. An agricultural permit doesn’t waive the 
+requirements for getting your first Washington driver license.
+EARLY WARNING LETTERS
+The DOL sends letters to all drivers ages 18 to 21 who receive 
+their first moving violation. A driver’s chances of crashing 
+doubles after receiving their first violation. Parents and 
+guardians of intermediate driver license holders receive similar 
+letters after violations or crashes. The goal of the letter is to 
+help young drivers realize the risks associated with continued 
+violations and reduce repeat offenses.
+1.9  |  HEALTH
+VISION SCREENINGS
+DOL will check your vision before issuing your license. If you use 
+corrective glasses or contact lenses, this will be recorded on 
+your license.
+•	
+Remember to always wear your glasses or contacts while 
+driving. 
+•	
+Have your eyes checked regularly by an eye doctor.
+ORGAN DONOR 
+When you get your license, you’ll be asked if you want to 
+become an organ donor. If you choose to, the donor heart 
+symbol 
+ will appear on your license, and your information will 
+be given to the donor registry. Logo promoting "donate life today" for LifeCenter Northwest.
+Contact LifeCenter Northwest at lcnw.org 
+or visit the registry website, 
 donatelifetoday.com, for more information. 
-Medical designations 
-You have the option to add or remove disability and medical designations on your driver license 
-or ID card. In an emergency, these designations give first responders information about how you 
-communicate or inform them you have conditions that could impact a health emergency. 
-You can add one or more of the designations below to your record. 
-Developmental disability 
-Deaf or hard of hearing 
-Medical alert 
-1.10: Endorsements 
-To drive motorcycles or commercial motor vehicles, you need to get an additional endorsement 
-added to your personal driver license. More information can be found by searching 
-endorsement at dol.wa.gov and scrolling to the type you want. 
-1.11: Older drivers 
-Decisions about your driving ability shouldn’t be based on age alone. However, changes in 
-vision, physical fitness, and reflexes could cause safety concerns. By accurately assessing age-
-related changes, you can change your driving habits to remain safe on the road or choose other 
-kinds of transportation. 
-If you’ve noticed changes in your vision, physical fitness, attention, or ability to quickly react to 
-sudden changes, it’s important to understand how these changes might be affecting your ability 
-to drive safely. Driving Safely While Aging Gracefully is a resource developed by the USAA 
-Educational Foundation, the National Highway Traffic Safety Administration, and AARP. It can 
-help you recognize warning signs and provide useful tips on what you can do to remain a safe 
-driver. To download the guide, go to nhtsa.gov and search driving safely in the search bar at the 
-top of the home page. 
-1.12: Personal driver license exams 
 
-Before you can be a licensed driver, you have to pass two exams.  
-Two exams 
-The Driving Knowledge Exam 
-The Driving Knowledge Exam assesses your understanding of Washington’s rules of the road. 
-You must first pass the knowledge exam before you can take the Driving Skills Exam. 
-After you pass the knowledge exam, you have two years to complete the skills exam. 
-The Driving Skills Exam 
-The Driving Skills Exam assesses your ability to apply Washington’s rules of the road. 
-You and the examiner are the only people allowed in the vehicle during the exam. We make 
-exceptions for service animals and sign language interpreters. 
-A legally licensed and registered vehicle must be used for the driving exam. The vehicle needs 
-to have proof of current liability insurance (showing the policy holder’s name or the vehicle’s 
-description) and be in safe operating condition. Brake lights, signal lights, and seat belts must 
-work. Your examiner will verify all requirements before the exam begins. 
-Taking the exams 
-There are two ways you can take your driver license exams. 
-Find a driver training school exam location by searching approved driver training school at 
-dol.wa.gov. 
-Schedule an appointment at a driver licensing office in License Express. 
-1.13: Driver training education 
-Driver training schools approved to offer courses for new drivers under 18 will have classroom 
-instruction and behind-the-wheel training from a licensed instructor. 
-School options include private driver training schools and select school districts. A map of 
-approved schools and their services can be found on dol.wa.gov. 
-OVER 18 
-Drivers over 18 who haven’t completed a driver training course face an increased crash risk. To 
-address this, some driver training schools also offer adult traffic safety courses for new drivers 
-over the age of 18. You can take these classes as a novice driver, as someone new to the 
-United States, or as a refresher. Proper training and skill review is good for any age. 
-1.14: For guardians of new drivers 
-Experienced driving mentors can be a great resource for new drivers. Modeling safe driving 
-behaviors and clear communication are two ways mentors can get involved in a young driver’s 
-learning.  
+MEDICAL DESIGNATIONS
+You have the option to add or remove disability and medical 
+designations on your driver license or ID card. In an emergency, 
+these designations give first responders information about how 
+you communicate or inform them you have conditions that 
+could impact a health emergency.
+You can add one or more of the designations below to your 
+record.A sample ID card from Washington with three icons highlighted.
+Developmental 
+disabilityCircular icon representing Developmental Disability.
+Deaf or hard of 
+hearingCircular icon representing Deaf or Hard of Hearing.
+Medical alertCircular icon repr
+1.10  |  ENDORSEMENTS
+To drive motorcycles or commercial motor vehicles, you need 
+to get an additional endorsement added to your personal 
+driver license. More information can be found by searching 
+endorsement at dol.wa.gov and scrolling to the type you want.
 
-Driver training courses for students under age 18 are required to offer a parent orientation class. 
-Attending these sessions will familiarize mentors with the program and further explain the 40 
-hours of daylight and 10 hours of night driving requirement. 
-Additional resources can be found by searching teen safe driving agreement at dol.wa.gov. 
-1.15: Maintaining your license 
-Replacing your driver license 
-If your license is lost, stolen, destroyed, or illegible, you can apply for a replacement online. You 
-can also request a duplicate in person at any driver licensing office.  
-Renewing your driver license 
-Your expiration date can be found near the bottom of your license. You can renew your license 
-up to one year before it expires. 
-Renew online through License Express, or at a driver licensing office. 
-Expired license 
-If you renew your license after it has expired, you might need to pay an additional fee. 
-If your license is 8 or more years expired, you’ll need to retake the skills and knowledge test. 
-Losing your driving privileges 
-Driving is a big responsibility. You should drive safely at all times. Drivers can lose driving 
-privileges for several reasons, include the ones listed below. 
-Violating intermediate license restrictions 
-Being a minor in possession of alcohol, drugs, or firearms 
+1.11  |  OLDER DRIVERS
+Decisions about your driving ability shouldn’t be based on age 
+alone. However, changes in vision, physical fitness, and reflexes 
+could cause safety concerns. By accurately assessing 
+age-related changes, you can change your driving habits to 
+remain safe on the road or choose other kinds of transportation.
+If you’ve noticed changes in your vision, physical fitness, 
+attention, or ability to quickly react to sudden changes, it’s 
+important to understand how these changes might be affecting 
+your ability to drive safely. Driving Safely While Aging Gracefully 
+is a resource developed by the USAA Educational Foundation, 
+the National Highway Traffic Safety Administration, and AARP. It 
+can help you recognize warning signs and provide useful tips on 
+what you can do to remain a safe driver. To download the guide, 
+go to nhtsa.gov and search driving safely in the search bar at 
+the top of the home page.
+1.12  |  PERSONAL DRIVER LICENSE EXAMS
+TWO EXAMS
+Before you can be a licensed driver, you have to pass 
+two exams. 
+The Driving Knowledge Exam
+•	
+The Driving Knowledge Exam assesses your understanding
+of Washington’s rules of the road.
+•	
+You must first pass the knowledge exam before you can take
+the Driving Skills Exam. 
+•	
+After you pass the knowledge exam, you have two years to
+complete the skills exam.
+The Driving Skills Exam
+•	
+The Driving Skills Exam assesses your ability to apply
+Washington’s rules of the road.
+
+•	
+You and the examiner are the only people allowed in the 
+vehicle during the exam. We make exceptions for service 
+animals and sign language interpreters. 
+•	
+A legally licensed and registered vehicle must be used for 
+the driving exam. The vehicle needs to have proof of current 
+liability insurance (showing the policy holder’s name or the 
+vehicle’s description) and be in safe operating condition. 
+Brake lights, signal lights, and seat belts must work. Your 
+examiner will verify all requirements before the exam begins.
+Image of 
+TAKING THE EXAMS
+There are two ways you can take your driver license exams.
+•	
+Find a driver training school exam location by searching 
+approved driver training school at dol.wa.gov.
+•	
+Schedule an appointment at a driver licensing office in 
+License Express.
+
+Driving school car, instructor and student inside, "DRIVING SCHOOL" sign above, Washington state ID, car key, and key fob below.
+1.13 |  DRIVER TRAINING EDUCATION
+Driver training schools approved to offer courses for new drivers 
+under 18 will have classroom instruction and behind-the-
+wheel training from a licensed instructor.
+School options include private driver training schools and 
+select school districts. A map of approved schools and their 
+services can be found by searching driver training school at 
+dol.wa.gov.
+OVER 18
+Drivers over 18 who haven’t completed a driver training course 
+face an increased crash risk. To address this, some driver 
+training schools also offer adult traffic safety courses for new 
+drivers over the age of 18. You can take these classes as a 
+novice driver, as someone new to the United States, or as a 
+refresher. Proper training and skill review is good for any age.
+•	
+
+1.14  |  FOR GUARDIANS OF NEW DRIVERS
+Experienced driving mentors can be a great resource for 
+new drivers. Modeling safe driving behaviors and clear 
+communication are two ways mentors can get involved in a 
+young driver’s learning. 
+Driver training courses for students under age 18 are required 
+to offer a parent orientation class. Attending these sessions will 
+familiarize mentors with the program and further explain the 
+40 hours of daylight and 10 hours of night driving requirement.
+Additional resources can be found by searching teen safe 
+driving agreement at dol.wa.gov. 
+1.15  |  MAINTAINING YOUR LICENSE
+REPLACING YOUR DRIVER LICENSE
+If your license is lost, stolen, destroyed, or illegible, you can 
+apply for a replacement online at dol.wa.gov. You can also 
+request a duplicate in person at any driver licensing office.
+RENEWING YOUR DRIVER LICENSE
+•	
+Your expiration date can be found near the bottom of your 
+license. You can renew your license up to one year before it 
+expires. 
+•	
+Renew online through License Express, or at a driver 
+licensing office.
+EXPIRED LICENSE 
+•	
+If you renew your license after it has expired, you might need 
+to pay an additional fee.
+•	
+If your license is 8 or more years expired, you’ll need to 
+retake the skills and knowledge exams.
+
+LOSING YOUR DRIVING PRIVILEGES
+Driving is a big responsibility. You should drive safely at all times. 
+Drivers can lose driving privileges for several reasons, including 
+the ones listed below.
+•	
+Violating intermediate license restrictions
+•	
+Being a minor in possession of alcohol, drugs, or firearms
+•	
 Having an accumulation of moving violations 
-Driving with a suspended or revoked license 
+•	
+Driving with a suspended or revoked license
+•	
 Running from law enforcement 
+•	
 Driving under the influence 
-Racing or driving recklessly 
-Putting a construction or emergency worker in danger 
-Accumulating unresolved traffic citations 
-Committing vehicular assault, vehicular homicide, or hit and run 
+•	
+Racing or driving recklessly
+•	
+Putting a construction or emergency worker in danger
+•	
+Accumulating unresolved traffic citations
+•	
+Committing vehicular assault, vehicular homicide, or hit and 
+run
+•	
 Committing a felony involving a motor vehicle 
-Driving without insurance 
-Failing a competency evaluation 
-For more information, visit our license suspensions page on dol.wa.gov. 
+•	
+Driving without insurance
+•	
+Failing a competency evaluation
+For more information, search license suspensions at 
+dol.wa.gov.
+ALCOHOL, DRUGS, AND FIREARMS VIOLATIONS 
+Minors who receive an alcohol, drug, or firearm offense run the 
+risk of delaying their license until they are 17. 
+When you are eligible to get your driver license back, you must 
+take the driving knowledge and skills exams (even if you’ve 
+already taken them). You’ll also need to pay a reissue fee in 
+addition to the usual testing and licensing fees. If you’re under 
+18 years old, you’ll also need to have the consent of a parent or 
+guardian.
 
-Alcohol, drugs, and firearms violations 
-Minors who receive an alcohol, drug, or firearm offense run the risk of delaying their license until 
-they are 17 years of age.  
-When you are eligible to get your driver license back, you must take the driving knowledge and 
-skills exams (even if you’ve already taken them). You’ll also need to pay a reissue fee in 
-addition to the usual testing and licensing fees. If you’re under 18 years old, you’ll also need to 
-have the consent of a parent or guardian. 
-Driving under the influence (DUI) 
-In Washington, it is illegal to drive under the influence of alcohol or drugs (RCW 46.61.502). 
-Driving under the influence has life-threatening and legal consequences. 
-DUI also applies to being in control of a vehicle, even if it’s parked (RCW 46.61.503). If you 
-have the ability to take control of a vehicle’s engine or operation, you are considered in physical 
-control of the vehicle. 
-Under The Implied Consent Law (RCW 46.20.308), everyone who drives in Washington agrees 
-to be tested if an officer suspects they are under the influence of alcohol or drugs. 
+DRIVING UNDER THE INFLUENCE (DUI)
+In Washington, it is illegal to drive 
+under the influence of alcohol or drugs 
+(RCW 46.61.502). Driving under the 
+influence has life-threatening and legal 
+consequences.
+DUI also applies to being in control 
+of a vehicle, even if it’s parked 
+(RCW 46.61.503). If you have the ability 
+to take control of a vehicle’s engine 
+or operation, you are considered in 
+physical control of the vehicle.
+Under The Implied Consent Law 
+(RCW 46.20.308), everyone who drives in Washington agrees 
+to be tested if an officer suspects they are under the influence 
+of alcohol or drugs.Sign prohibiting drinking and driving.
 Blood Alcohol Concentration (BAC) 
-A BAC test measures how much alcohol is in your system. For drivers age 21 and older, having 
-a BAC of .08% or higher is considered a DUI and can result in legal consequences. Drivers 
-under age 21 have the same potential consequences for having a BAC of 0.02%. 
-Tetrahydrocannabinol (THC) Cannabis Concentration 
-A THC test measures how much THC is in your system. For drivers age 21 and older, having 
-more than 5 nanograms of active THC per milliliter of blood in their system is considered a DUI 
-and can result in legal consequences. Drivers under age 21 have the same potential 
-consequences for anything more than 0 nanograms of active THC per milliliter of blood in their 
-system. 
-If you refuse to be tested, you could lose your driving privilege for 90 to 730 days, or until you 
-reach age 21, whichever is longer. The length of time of your suspension depends on many 
-factors, including how many violations you’ve committed. 
-Adults (21 and over): 
-BAC of 0.08% or more  
-THC of 5.00 ng or more 
-Minors (under 21): 
-BAC of 0.02% or more  
-THC above 0.00 ng 
-Even experienced drivers cannot drive safely after drinking alcohol and/or using drugs. Save 
-lives by making the choice to never drive under the influence! 
+A BAC test measures how much alcohol is in your system. For 
+drivers age 21 and older, having a BAC of .08% or higher is 
+considered a DUI and can result in legal consequences. Drivers 
+under age 21 have the same potential consequences for having 
+a BAC of 0.02%.
+Tetrahydrocannabinol (THC) Cannabis Concentration
+A THC test measures how much THC is in your system. For 
+drivers age 21 and older, having more than 5 nanograms of 
+active THC per milliliter of blood in their system is considered a 
+DUI and can result in legal consequences. Drivers under age 21 
+have the same potential consequences for anything more than 
+0 nanograms of active THC per milliliter of blood in their system.
+If you refuse to be tested, you could lose your driving privilege 
+for 90 to 730 days, or until you reach age 21, whichever is longer. 
+The length of time of your suspension depends on many factors, 
+including how many violations you’ve committed.
 
-Alcohol- and drug-related offenses appear on your driving record for life. If you are arrested for 
-driving under the influence, the penalties are severe: loss of license, heavy fines, criminal 
-penalties, jail, and higher insurance rates.  
-Convictions can also include a combination of the following: 
-Driving privileges suspended for 90 days to 4 years 
-Probationary license 
-Ignition interlock device to drive vehicle 
-Required proof of financial responsibility 
-Alcohol assessment and treatment report 
-Reapply for license, retake knowledge and skills tests, and pay the reissue fee 
-Open container law 
-Under the open container law, it is a traffic infraction if any person in a vehicle on the road: 
-Drinks alcohol or consumes cannabis. 
-Possesses alcohol containers or cannabis products that have been opened, have a broken seal, 
-or are partially consumed. 
-Hides alcohol or cannabis in unlabeled or mislabeled containers. 
-Open alcohol and cannabis products can only be transported in a trunk or truck bed. Alcohol or 
-cannabis containers cannot be kept in storage compartments accessible to the driver. 
-1.16: Additional services 
-Change of address or name 
-If your address changes, update your information in License Express within 10 days of the 
-change. Name changes must be made in a driver licensing office. 
-Voter registration 
-You can register to vote on the Secretary of State website, sos.wa.gov, or you can register at 
-any driver licensing office. Residents who are 16 and 17 years old can opt to pre-register to vote 
-when applying for a driver license or ID card. 
-Selective service registration 
-You can register with the United States Selective Service System when applying for a license or 
-ID card. There is more information available on the Washington State Office of the Attorney 
-General website: atg.wa.gov. 
-Twin registry 
-When you apply for your license, you’ll be asked if you are a twin. The Washington State Twin 
-Registry is for twins interested in participating in research studies. Universities might contact 
+Adults (21 and over)
+Minors (under 21)
+BAC of 0.08% or more
+THC of 5.00 ng or more
+BAC of 0.02% or more
+THC above 0.00 ng
+Even experienced drivers cannot drive safely after 
+drinking alcohol and/or using drugs. Save lives by 
+making the choice to never drive under the influence!
+Alcohol- and drug-related offenses appear on your driving 
+record for life. If you are arrested for driving under the influence, 
+the penalties are severe: loss of license, heavy fines, criminal 
+penalties, jail, and higher insurance rates. 
+Convictions can also include a combination of the following:
+•	
+Driving privileges suspended for 90 days to 4 years
+•	
+Probationary license
+•	
+Ignition interlock device to drive vehicle
+•	
+Required proof of financial responsibility
+•	
+Alcohol assessment and treatment report
+•	
+Reapply for license, retake knowledge and skills tests, and 
+pay the reissue fee
+OPEN CONTAINER LAW 
+Under the open container law, it is a traffic infraction if any 
+person in a vehicle on the road:
+•	
+Drinks alcohol or consumes cannabis.
+•	
+Possesses alcohol containers or cannabis products that 
+have been opened, have a broken seal, or are partially 
+consumed.
+•	
+Hides alcohol or cannabis in unlabeled or mislabeled 
+containers.
 
-people who identify as a twin with the Department of Licensing. If you have questions, please 
-visit wstwinregistry.org. 
- 
-Chapter 2: Vehicles 
-2.0: Vehicle services 
-As a licensed driver, you need to follow the rules of the road. You also need to understand the 
-requirements of the vehicle you’re driving. Many services needed to maintain your vehicle can 
-be found in License Express. The link to License Express can be found in the top right corner of 
-the dol.wa.gov home page. (The direct address is secure.dol.wa.gov/home/.) You can also visit 
-a vehicle licensing office to conduct business in person.   
-Certificate of ownership (title) 
-The Department of Licensing will issue a Certificate of Ownership (also known as the title) for 
-most vehicles. The title shows the registered and legal owner(s) of the vehicle, the Vehicle 
-Identification Number (VIN), and bank information (if there is a loan). This is an important 
-document! Keep it in a safe place but not in the vehicle. 
-Registration 
-All vehicles must be registered with the Department of Licensing. Before you can register a 
-vehicle in Washington, you need to have a driver license (unless you are exempt by law). 
-Customers who claim an exemption can complete a Vehicle Registration Driver License 
-Exemption form. New residents have 30 days to complete their vehicle registration. Vehicles 
-purchased in another state should be registered in Washington immediately. 
-To register your vehicle, you’ll need: 
+Open alcohol and cannabis products can only be transported 
+in a trunk or truck bed. Alcohol or cannabis containers cannot 
+be kept in storage compartments accessible to the driver.
+1.16  |  ADDITIONAL SERVICES
+CHANGE OF ADDRESS OR NAME 
+If your address changes, update your information in License 
+Express within 10 days of the change. Name changes must be 
+made in a driver licensing office.
+VOTER REGISTRATION
+You can register to vote on the Secretary of State website, 
+sos.wa.gov, or when you get your license at a driver licensing 
+office. Residents who are 16 and 17 years old can opt to pre-
+register to vote when applying for a driver license or ID card.
+SELECTIVE SERVICE REGISTRATION
+You can register with the United States Selective Service 
+System when applying for a license or ID card. There is more 
+information available on the Washington State Office of the 
+Attorney General website: atg.wa.gov.
+TWIN REGISTRY
+When you apply for your license, you’ll be asked if you are a 
+twin. The Washington State Twin Registry is for twins interested 
+in participating in research studies. Universities might contact 
+people who identify as a twin with the Department of Licensing. 
+If you have questions, please visit wstwinregistry.org.
+
+Chapter 2 Vehic
+les 
+ima
+ge 
+rear 
+view of a 
+green car
+ with Washington license plate "VEHICLES"
+
+2.0  |  VEHICLE SERVICES
+As a licensed driver, you need to follow the rules of the road. 
+You also need to understand the requirements of the vehicle 
+you’re driving. Many services needed to maintain your vehicle 
+can be found in License Express. The link to License Express 
+can be found in the top right corner of the dol.wa.gov home 
+page. (The direct address is secure.dol.wa.gov/home.) You 
+can also visit a vehicle licensing office to conduct business in 
+person. 
+CERTIFICATE OF OWNERSHIP (TITLE)
+The Department of Licensing will issue a Certificate of 
+Ownership (also known as the title) for most vehicles. The title 
+shows the registered and legal owner(s) of the vehicle, the 
+Vehicle Identification Number (VIN), and bank information (if 
+there is a loan). This is an important document! Keep it in a safe 
+place but not in the vehicle.
+REGISTRATION
+All vehicles must be registered with the Department of 
+Licensing. Before you can register a vehicle in Washington, you 
+need to have a driver license (unless you are exempt by law). 
+Customers who claim an exemption can complete a Vehicle 
+Registration Driver License Exemption form. New residents 
+have 30 days to complete their vehicle registration. Vehicles 
+purchased in another state should be registered in Washington 
+immediately.
+To register your vehicle, you’ll need:
+•	
 Current Certificate of Ownership (title). 
-If you lose your vehicle’s title, ask the state where it was issued for a replacement. 
-Washington driver license for all registered owners. 
-A new registration document will be given each year, when you renew your tabs. Sign each new 
-registration and keep it in your vehicle. 
-Vehicle address 
-Changing your address on your driver license does not change your vehicle address. You can 
-change your address online through License Express or in person at a vehicle licensing office. 
-2.1: Report of sale 
-Individual to individual 
-If you sell, trade, gift, or dispose of your vehicle, file a Vehicle Report of Sale form within five 
-days. Remove the license plates from the vehicle, pay the fee, and file your report of sale at a 
-vehicle licensing office, or search report of sale at dol.wa.gov. A report of sale does not transfer 
-ownership. When selling a vehicle, the title must be signed and dated by the owner(s) and given 
+(If you lose your vehicle’s title, ask the state where it was 
+issued for a replacement.) 
+•	
+Washington driver license for all registered owners.
 
-to the purchaser. The purchaser must bring the signed title to a licensing office to transfer 
-ownership within 15 days to avoid penalty fees.  
-Dealership to individual 
-If the vehicle is sold by a dealer, the dealership might file a report of sale on your behalf, but 
-they are not required to. It’s in your best interest to file the report of sale yourself. 
-2.2: Vehicle license plates 
-License plates must be clearly displayed on the front and rear of motor vehicles registered in 
-Washington. They must be clean and easy to read. You can have a license plate frame, but it 
-cannot cover or obstruct the letters, numbers, or tabs on the plate. 
-2.3: Insurance required 
-You must keep proof of insurance with you or in your vehicle. Washington State requires you to 
-have and carry proof of liability insurance. It should provide the following: 
-$25,000 or more, payable for the bodily injury or death of one person in a collision in which only 
-one person was injured or killed 
-$50,000 or more, payable for the bodily injury or death of two or more persons in any one 
-collision 
-$10,000 or more, payable for injury to or destruction of property of others in any one collision 
-2.4: Know your vehicle 
-Each vehicle has its own set of characteristics. They differ in size, engine, safety devices, 
-accessories, technology, and handling characteristics. It’s important to read the manual for 
-every vehicle you drive. Take time to familiarize yourself with the basic vehicle components.  
-Functions 
-From the moment you get in a vehicle, you can tell if it has an automatic or manual 
-transmission. Operating each one requires familiarity and practice. Read the owner’s manual to 
-understand the systems, devices, gauges, and instruments unique to the vehicle. Familiarize 
-yourself with your vehicle’s mechanics before you drive, so your focus can be on the road.   
-Adjustments 
-Every time you get into a vehicle, you’ll need to make adjustments to meet your safety, control, 
-and comfort needs. Adjust the steering wheel, seat, and mirrors so you have good visibility. You 
-should be able to reach the pedals and instruments easily. 
-Vehicle safety technology 
-Innovation and advancement in the vehicle industry has led to the development of safety 
-systems that help reduce the negative outcomes of human error and unsafe behavior. Vehicle 
-Safety Technology (VST) and Advanced Driver Assistance Systems (ADAS) reduce the impact 
-of crashes by trying to prevent them from happening. They can give you advanced or additional 
-warnings that improve your response time. They are meant to assist your already-healthy 
-driving habits, not replace them. You are still fully responsible for the operation of your vehicle.  
+A new registration document will be given each year when you 
+renew your tabs. Sign each new registration and keep it in your 
+vehicle.
+VEHICLE ADDRESS
+Changing your address on your driver license does not change 
+your vehicle address. You can change your address online 
+through License Express or in person at a vehicle licensing 
+office. 
+2.1  |  REPORT OF SALE
+INDIVIDUAL TO INDIVIDUAL
+If you sell, trade, gift, or dispose of your vehicle, file a Vehicle 
+Report of Sale form within 5 days. Remove the license plates 
+from the vehicle, pay the fee, and file your report of sale at a 
+vehicle licensing office, or search report of sale at dol.wa.gov. 
+A report of sale does not transfer ownership. When selling a 
+vehicle, the title must be signed and dated by the owner(s) and 
+given to the purchaser. The purchaser must bring the signed 
+title to a licensing office to transfer ownership within 15 days to 
+avoid penalty fees. 
+DEALERSHIP TO INDIVIDUAL
+If the vehicle is sold by a dealer, the dealership might file a 
+report of sale on your behalf, but it's not required to. It’s in your 
+best interest to file the report of sale yourself.
 
-Even with VST and ADAS, you still need to use your hazard awareness skills and knowledge of 
-the rules of the road because these systems do have limitations. For example, these systems 
-can alert you if there is a vehicle in your blind spot; however, they can’t detect if there is a 
-vehicle two lanes over that is also preparing to merge. Also, your vehicle’s detection 
-technologies might not recognize the presence of people walking, rolling, or riding near your 
-vehicle. It is your responsibility to yield according to state law. Additionally, sensors can get dirty 
-or road marking can fade, making it difficult for the technology to function properly. 
-It’s important you are familiar with the features and technologies of any vehicle you drive. Leave 
-them on unless weather conditions are so severe that the notifications become a distraction. 
-Ensure you can use these features effectively.  
-To learn more about the safety technologies your vehicle has, read your vehicle manual, ask a 
-car dealership, or visit mycardoeswhat.org. 
-Here are some key components and features of VST and ADAS: 
-Collision avoidance systems. Detects obstacles and provides warnings to prevent collisions. 
-These include features like automatic emergency braking (AEB), forward collision warning, and 
-lane departure warning. 
-Adaptive cruise control (ACC). Maintains a set speed but adjusts it based on the distance to the 
-vehicle in front, ensuring a safe following distance. ACC enhances comfort during long drives by 
-reducing the need for constant speed adjustments. 
-Lane keeping assistance. Monitors lane markings and provides steering input or alerts if the 
-vehicle drifts out of its lane. This feature also enhances safety by preventing unintended lane 
-departures. 
-Blind spot detection. Uses sensors to monitor the vehicle’s blind spots and alerts the driver if 
-there’s a vehicle in the adjacent lane. This feature also aims to reduce the risk of collisions 
-during lane changes. 
-Parking assistance. Utilizes sensors and cameras to help with parking by providing visual and/or 
-auditory guidance. This can include features like automatic parallel parking. 
-Traffic sign recognition. Uses cameras to identify and interpret traffic signs, displaying relevant 
-information to the driver. This feature assists in maintaining awareness of speed limits and other 
-road regulations. 
-Driver monitoring systems. Monitors the driver’s behavior and alerts them if signs of drowsiness 
-or distraction are detected. This feature enhances safety by promoting driver attentiveness. 
-Cross traffic alert. Warns drivers of approaching traffic from the side, such as when backing out 
-of parking spaces. This feature reduces the risk of collisions in situations with limited visibility. 
-Automatic high beam control. Adjusts headlight brightness based on oncoming traffic and 
-surrounding conditions. This feature enhances visibility without causing discomfort to other 
-drivers. 
+Image depicting some of the personalized vehicle plates available for Washington residents. They include images of the Seattle Seahawks, Kraken, Sounders, as well as San Juan Islands and Mount Ranier.
+2.2  |  VEHICLE LICENSE PLATES 
+License plates must be clearly displayed on the front and rear 
+of motor vehicles registered in Washington. They must be clean 
+and easy to read. You can have a license plate frame, but it's 
+illegal to cover the letters, numbers, or tabs on the plate. 
+2.3  |  INSURANCE REQUIRED
+You must keep proof of insurance with you or in your vehicle. 
+Washington State requires you to have and carry proof of liability 
+insurance. It should provide the following:
+•	
+$25,000 or more, payable for the bodily injury or death 
+of one person in a collision in which only one person was 
+injured or killed
+•	
+$50,000 or more, payable for the bodily injury or death of 
+two or more persons in any one collision
+•	
+$10,000 or more, payable for injury to or destruction of 
+property of others in any one collision
 
-Collision mitigation systems. Minimizes the impact if a collision is unavoidable. This component 
-goes beyond collision avoidance and can include features like pre-crash seatbelt tensioning and 
-post-collision braking. 
-Technology can assist you, but it doesn't take the place of focused driving. You’ll need to be 
-familiar with the VST and ADAS features of any vehicle you drive but still be able to rely on your 
-intentional driving habits. 
-2.5: Vehicle maintenance 
-Making sure your vehicle is safe to drive is your responsibility. It doesn’t take long for a small 
-problem to turn into a bigger (more expensive, more dangerous) one, so pay attention to your 
-vehicle’s warnings. Consult your vehicle owner’s manual for suggested routine maintenance 
-and take action if your indicator lights turn on. 
-Tire tread 
-Worn tires can cause slipping and sliding, especially if the road is wet. Tire tread shouldn't be 
+2.4  |  KNOW YOUR VEHICLECar dashboard showi
+Each vehicle has its own set of characteristics. They differ 
+in size, engine, safety devices, accessories, technology, and 
+handling characteristics. It’s important to read the manual for 
+every vehicle you drive. Take time to familiarize yourself with the 
+basic vehicle components.
+FUNCTIONS
+From the moment you get in a vehicle, you can tell if it has an 
+automatic or manual transmission. Operating each one requires 
+familiarity and practice. Read the owner’s manual to understand 
+the systems, devices, gauges, and instruments unique to the 
+vehicle. Familiarize yourself with your vehicle’s mechanics 
+before you drive, so your focus can be on the road. 
+ADJUSTMENTS
+Every time you get into a vehicle, you’ll need to make 
+adjustments to meet your safety, control, and comfort needs. 
+Adjust the steering wheel, seat, and mirrors so you have 
+good visibility. You should be able to reach the pedals and 
+instruments easily. 
+
+VEHICLE SAFETY TECHNOLOGY
+Innovation and advancement in the vehicle industry has led 
+to the development of safety systems that help reduce the 
+negative outcomes of human error and unsafe behavior. Vehicle 
+Safety Technology (VST) and Advanced Driver Assistance 
+Systems (ADAS) reduce the impact of crashes by trying to 
+prevent them from happening. They can give you advanced or 
+additional warnings that improve your response time. They are 
+meant to assist your already-healthy driving habits, not replace 
+them. You are still fully responsible for the operation of your 
+vehicle. 
+Even with VST and ADAS, you still need to use your hazard 
+awareness skills and knowledge of the rules of the road 
+because these systems do have limitations. For example, 
+these systems can alert you if there is a vehicle in your blind 
+spot; however, they can’t detect if there is a vehicle two lanes 
+over that is also preparing to merge. Also, your vehicle’s 
+detection technologies might not recognize the presence of 
+people walking, rolling, or riding near your vehicle. It is your 
+responsibility to yield according to state law. Additionally, 
+sensors can get dirty or road markings can fade, making it 
+difficult for the technology to function properly.
+It’s important you are familiar with the features and technologies 
+of any vehicle you drive. Leave them on unless weather 
+conditions are so severe that the notifications become a 
+distraction. Ensure you can use these features effectively. 
+To learn more about the safety technologies your vehicle 
+has, read your vehicle manual, ask a car dealership, or visit 
+mycardoeswhat.org.
+
+Here are some key components and features of VST and ADAS:
+1.	 Collision avoidance systems. Detects obstacles and 
+provides warnings to prevent collisions. These include 
+features like automatic emergency braking (AEB), forward 
+collision warning, and lane departure warning.
+2.	 Adaptive cruise control (ACC). Maintains a set speed 
+but adjusts it based on the distance to the vehicle in front, 
+ensuring a safe following distance. ACC enhances comfort 
+during long drives by reducing the need for constant 
+speed adjustments.
+3.	 Lane keeping assistance. Monitors lane markings and 
+provides steering input or alerts if the vehicle drifts out of 
+its lane. This feature also enhances safety by preventing 
+unintended lane departures.
+4.	 Blind spot detection. Uses sensors to monitor the 
+vehicle’s blind spots and alerts the driver if there’s a 
+vehicle in the adjacent lane. This feature also aims to 
+reduce the risk of collisions during lane changes.
+5.	 Parking assistance. Utilizes sensors and cameras to help 
+with parking by providing visual and/or auditory guidance. 
+This can include features like automatic parallel parking.
+6.	 Traffic sign recognition. Uses cameras to identify and 
+interpret traffic signs, displaying relevant information to 
+the driver. This feature assists in maintaining awareness of 
+speed limits and other road regulations.
+7.	 Driver monitoring systems. Monitors the driver’s 
+behavior and alerts them if signs of drowsiness or 
+distraction are detected. This feature enhances safety by 
+promoting driver attentiveness.
+8.	 Cross traffic alert. Warns drivers of approaching traffic 
+from the side, such as when backing out of parking 
+spaces. This feature reduces the risk of collisions in 
+situations with limited visibility.
+
+9.	 Automatic high beam control. Adjusts headlight 
+brightness based on oncoming traffic and surrounding 
+conditions. This feature enhances visibility without causing 
+discomfort to other drivers.
+10.	Collision mitigation systems. Minimizes the impact if a 
+collision is unavoidable. This component goes beyond 
+collision avoidance and can include features like 
+pre-crash seatbelt tensioning and post-collision braking.
+Technology can assist you, but it doesn't take the place of 
+focused driving. You’ll need to be familiar with the VST and 
+ADAS features of any vehicle you drive but still be able to rely 
+on your intentional driving habits.Illustration of mechanics working on a
+2.5  |  VEHICLE MAINTENANCE 
+Making sure your vehicle is safe to drive is your responsibility. 
+It doesn’t take long for a small problem to turn into a bigger 
+(more expensive, more dangerous) one, so pay attention to 
+your vehicle’s warnings. Consult your vehicle owner’s manual 
+for suggested routine maintenance, and take action if your 
+indicator lights turn on.
+
+TIRES
+Tire 
+tread
+Worn tires can cause slipping and sliding, 
+especially if the road is wet. Tire tread shouldn't be 
 less than 2/32 of an inch. 
-Tire pressure 
-Low tire pressure can affect your car handling and speed. 
-The proper inflation pressure for your tires can be found on the Tire and Loading Information 
-label on the driver’s side door edge or in your owner’s manual. 
-Glass surfaces 
-Keep the windshield and windows clean — inside and outside. 
+Tire 
+pressure
+Low tire pressure can affect your car handling and 
+speed. 
+The proper inflation pressure for your tires can be 
+found on the Tire and Loading Information label 
+on the driver’s side door edge or in your owner’s 
+manual.
+GLASS SURFACES
+•	
+Keep the windshield and windows clean — inside and 
+outside. 
+•	
 Keep your window washer fluid full. 
-Completely clear snow, ice, or frost from all windows before driving. 
-Don't hang things from your mirror or clutter your windows with decals or items that block your 
-view. 
-Follow your vehicle manufacturer’s recommendations for replacing your wipers. 
-Headlights 
-Washington law says you need to have your headlights on a half hour after sunset to a half hour 
-before sunrise. However, it might be easier to remember to have your headlights on: 
-All the time. 
-When it’s dark. 
-When it’s rainy, snowy, foggy, or smoky. 
-Headlights help you see, but they also help people see you! 
-Some vehicles have daytime running lights that come on when you start the car. However, 
-daytime running lights aren’t as bright as headlights, and they don’t activate your taillights.  
+•	
+Completely clear snow, ice, or frost from all windows before 
+driving.
+•	
+Don't hang things from your mirror or clutter your windows 
+with decals or items that block your view. 
+•	
+Follow your vehicle manufacturer’s recommendations for 
+replacing your wipers.
 
-Make sure all lights are clean, bright, pointing the right direction, and operating properly. If your 
-dashboard shows a “lamp out” symbol, it’s time to replace the bulbs. 
-You can use your high beams on open roads without streetlights, but remember to switch back 
-to regular headlights when you are: 
-500 feet in front of an oncoming vehicle. 
-300 feet when you’re behind. 
-Brake lights 
-Brake lights tell the person behind you to slow down and prepare to stop. Your brake lights are 
-red and must be clearly visible from 100 feet away. 
-If your brake lights aren't working, use hand signals. Put your left arm out the driver-side 
-window, and point your fingers to the ground. This will tell the vehicle behind you to slow down 
-and prepare to stop. 
-Turn signals 
-Create a habit of always signaling before you change direction, even when you don’t see 
-anyone else around. 
-Signal 100 feet before you make your move. 
-Make sure your signal stops blinking after you make the turn. 
-Hand signals 
-If one or both signals aren't working, use hand signals to let other drivers know what you’re 
-doing. 
-Stop. Put your left arm out the driver-side window. Point your fingers to the ground. This will tell 
-the person behind you to slow down and prepare to stop. 
-Left turn. Put your left arm out the window. Point your fingers straight out to the left. 
-Right turn. Put your left arm out the window. Bend your arm so your fingers point to the sky. 
-Hazard warning lights 
-If your car malfunctions or you need to make an emergency stop, turn on your flashing hazard 
-lights. This alerts other drivers of your situation and allows them to safely go around you.  
-Driver's seat 
-Adjust your seat so you can see clearly out of the windshield and easily reach the pedals. 
-Adjust the back of your seat so you are sitting comfortably straight. Your chest should be at least 
-10 inches from the steering wheel to leave space for the airbag. 
-Adjust the steering wheel so you can grip the wheel with a gentle bend in your elbow. 
-Protect yourself from whiplash by making sure the headrest is even with your ears. 
-
-Anytime you get behind the wheel after someone else has been driving, make adjustments that 
-keep you comfortable and safe. 
-2.6: Occupant protection 
-Seat belts and occupant protection 
-Buckling up correctly is the most effective thing you can do to protect yourself. Wearing your 
-seat belt dramatically drops your risk of fatal injury in a crash. Always fasten your seat belt and 
-make sure all passengers are using seat belts, child safety restraints, or booster seats correctly. 
-Your seat belt should go across the middle of your chest. Never put it behind your back or under 
-your arm. The shoulder belt should lie snug across the shoulder and chest, and not cross the 
-neck or face. The lap belt should securely and snugly restrain the hips, below the stomach. 
-Every person in a moving vehicle must wear a seat belt or be securely fastened into an 
-approved child restraint device. 
-It is illegal to drive or ride in a vehicle without wearing a seat belt or using child safety restraints 
-RCW 46.61.687 and RCW 46.61.688. 
-Be sure your seatbelt is not twisted, the lap belt rests on your upper thigh, and the cross-body 
-strap falls across your mid-shoulder. Your knees should bend at the edge of the seat, your feet 
-should touch the floor, and your headrest should be in line with your ears. 
-Child seats 
-Protect child passengers by using the correct seat for their age and size every time you (or 
-others) travel with a child.  
-Child restraint systems must comply with Federal Motor Vehicle Safety Standards and be 
-secured in the vehicle according to vehicle and child restraint system manufacturer instructions. 
-You can have a certified child passenger safety technician check the installation of your child 
-restraint system installation. 
-Find more information and safety check locations at wacarseats.com. 
-A child should remain in each stage of restraint as long as the seat allows for the best 
-protection.   
-Rear-facing 
-Children up to age 2 must ride in a rear-facing car seat. 
-Age: Birth - 2 years 
-Forward-facing 
-Ages 2 to 4 years must ride in a car seat with a rear- or forward-facing harness. 
-Age: 2 to 4 years 
-Booster 
-
-Ages 4 and older must ride in a car or booster seat until the vehicle lap and shoulder seat belts 
-fit properly— typically, between the ages of 8 and 12 years of age. 
-Age and size: 4 years to 4’9” 
-Seat belt  
-All occupants old and tall enough to wear a seat belt must have a properly fitting belt. 
-Size: Over 4’9” 
-Airbags 
-Airbags and seat belts work together to keep you safe in the event of a crash. If you are not 
-wearing your seatbelt when an airbag deploys, you risk serious injury or death. Airbags are also 
-why children under the age of 13 should never ride in the front seat. They could be seriously 
-injured or killed if an airbag deploys. 
-2.7: Steering 
-Place your hands outside the wheel, on the top half of the steering wheel. This will give you the 
-best control. 
-Imagine that the steering wheel is a clock. Each hour represents a location for you to hold the 
-wheel. In the image above, the driver’s hands are at 9:00 and 3:00. 
-There are three turning methods that can provide smooth, continuous steering control. 
-Hand-to-hand steering (pull/push) 
-When using this method, your hands should be at 9 and 3 or 10 and 2.  
-Keep your hands in this position when you turn. 
-Since your hands never cross over the steering wheel, there is less chance of an injury to the 
-face, hands, or arms if the airbag deploys. 
-Your hands never leave the wheel and each hand stays on its own side. One hand grips the 
-wheel and steers. The other hand slides and remains opposite of the steering hand. 
-Hand-to-hand technique keeps both hands on the wheel, allows you to instantly make 
-necessary changes, and keeps your arms away from the airbag area. 
-Hand-over-hand steering 
-Use this method of steering when turning at low speeds, with limited visibility, at an intersection, 
-when parking the vehicle, or when recovering from a skid.  
-When using this method, your hands should start at 9 and 3 or 10 and 2. 
-When turning, reach one arm across the other to grasp the wheel, and pull the wheel as 
-appropriate.  
-Release the hand underneath so that you can reposition it on the wheel. 
-Straighten the steering wheel as you smoothly complete the turn. 
-
-One-hand steering 
-Use one-hand steering when backing or operating vehicle controls (wipers, flashers, lights, etc.) 
-that require you to reach from the steering wheel.  
-The placement of one hand on the steering wheel is critical to vehicle balance and controlled 
-steering when in reverse. 
-The 12 position is recommended only when backing a vehicle. In this situation, turn your body to 
-see the path of travel behind you. 
-2.8: Braking 
-Good vehicle handling depends on your ability to accurately and smoothly manage speed and 
-space at all times. 
-Braking pressure 
-Determining the amount of braking pressure you need is an important skill. It will develop as you 
-practice and get more familiar with the vehicle you drive. 
-There are four levels of braking: 
-Light 
-Medium 
-Firm 
-Emergency 
-Ideally, you’ll only need to use light and medium braking, but you can always use firm or 
-emergency braking if you need to. As a braking technique, imagine having a cup of water in 
-your lap that you don’t want to spill. 
-Keep the people behind you in mind, also. Unnecessary firm or emergency braking could 
-surprise the people behind you who were anticipating a smooth stop.  
-Antilock Braking Systems (ABS) 
-A vehicle’s Antilock Brake System (ABS) offers an important safety advantage by allowing 
-drivers to steer during an emergency braking situation. An ABS does not shorten your stopping 
-distance, but it will allow you to keep better steering control. When engaged, you can feel your 
-vehicle shake a bit. 
-Practice firm or emergency braking in a large, open, and paved space. Hit the brakes hard, and 
-feel the ABS keep the wheels from locking up. 
-2.9: Accelerating 
-To drive smoothly, you’ll want to be familiar and comfortable with different levels of acceleration. 
-There could be times you’re in stop-and-go traffic where the only acceleration you need is to 
-release the brake pedal. There could be times you’ll need to accelerate quickly to avoid a 
-hazard. Your accelerating technique should be like braking — imagine there’s a cup of water in 
-your lap and accelerate without spilling the water. 
-
-2.10: Balanced weight 
-It’s natural for your vehicle’s balance to shift a bit when it starts to move. To maintain stability of 
-your vehicle, keep the weight evenly balanced across the tires. Regular maintenance, correct 
-tire pressure, and alignment checks will help you do this. 
-Pitch 
-Lay your hand flat on a table. Lift your fingers and feel the pressure increases pressure on your 
-wrist. Now put your fingers on the table and lift your wrist. This forward and backward motion is 
-called pitch. 
-When you accelerate, the weight of the vehicle shifts to the back and increases pressure on the 
-rear of the vehicle. If you stop abruptly, the weight shifts forward, increasing pressure on the 
-front of the vehicle. 
-Roll 
-Lay your hand flat on a table. Rotate your hand so your little finger is stuck to the table, but your 
-thumbnail is pointed toward the sky. Now reverse so your thumb is on the table. This side-to-
-side motion of a vehicle is called roll. 
-When you make a left turn, centrifugal force transfers the weight down on the outside or right 
-side of your vehicle. The body of the vehicle rolls to one side. 
-Yaw 
-Keep your hand flat on a table. Move your fingers to the left and let your wrist move to the right. 
-Now wiggle it back and forth like you’re waving at the table. This is called yaw. 
-When you turn the steering wheel sharply from side to side, the front and back of your car don’t 
-stay perfectly lined up. The front wheels turn in the direction you’re steering, while the back 
-might slide a bit, creating a zig-zag motion. 
-2.11: Vehicle reference points 
-Reference points depend on the vehicle you’re driving and the road you’re traveling. Familiarity 
-with your vehicle reference points will help you judge distance when you park, turn, back, and 
-stop. 
-Examples of vehicle reference points: 
-Left headlight 
-Center of hood 
-Side view mirrors 
-Rear bumper 
-At an intersection, stopping when the stop line is under your side mirror means you are about 3 
-to 6 inches from the line. This reference point will help you determine the position of the front 
-end of your vehicle.   
-To determine your lane position, check that the center of your hood is in line with lane markings. 
-If they're in line, you're approximately 3 to 6 inches from the edge of the lane. 
-
-2.12: Your blind zones 
-Blind zones are the areas around a vehicle you can’t see from the driver’s seat. These areas 
-are dangerous because they can hide another vehicle, motorcyclist, or bicyclist completely. It's 
-your responsibility to be aware of everything in your blind zones. 
-One way you can reduce your blind zone is by adjusting your mirrors. 
-Adjust your rearview mirror so you can see out the back window without having to stretch. 
-There are a couple methods to adjust your side mirrors to minimize your blind zones: traditional 
-or enhanced. Either way, you need to do a full visual search of the space around your vehicle. 
-Move your head, neck, and body so that both eyes can see if your blind zones are clear. Note: 
-When turning your head to look, keep the steering wheel straight. 
-Some vehicle safety technology systems have features that alert you if there is someone in your 
-blind zone. This assistance is helpful, but make a habit of using your eyes to check for yourself. 
-2.13: Other vehicles' blind zones 
-To stay aware of your surroundings, regularly check: 
-The area in front of you. 
-Your rearview mirror. 
-Your side mirrors. 
-Over your shoulder. 
-Observation scans 
-You also need to be aware of other vehicles’ blind zones. Do your best to stay out of them. You 
-can speed up or slow down so the driver can clearly see you.  
-Pay special attention to large vehicles like buses, motorhomes, and commercial motor vehicles. 
-They have bigger blind zones, sometimes called “no zones.” This is because there should be no 
-vehicles traveling in that zone.  
-Be thoughtful and alert traveling around large vehicles. Remember: if you can’t see their mirrors, 
-the driver can’t see you. 
-Stay Alert 
-You need to be aware of everything going on around you. Constantly check your mirrors for any 
-changes to your driving situation. 
-Optimize 
-Adjust your mirrors to eliminate as much of your blind zones as possible. Recheck your mirrors 
-every time you get behind the wheel. 
-2.13: Before you go 
-When you're getting ready to drive, a good routine is to: 
-
-Check outside your vehicle. 
-Are there foreign objects in the tires, broken glass in the area, or fluid leaks under the vehicle? 
-Are there other obstructions, children, pets, or weather-related obstacles? 
-Check inside your vehicle. 
-Are there any warnings on the instrument panel? 
-Are all windows clear of obstructions? 
-Are loose items safely secured? 
-Check all internal adjustments. 
-Are your mirrors set? 
-Are the seat and steering wheel in the right place? 
-Is your seatbelt buckled? 
-Is your phone silenced and put away? 
-Check in with yourself. 
-Do you feel healthy and clear-headed? 
-Are you ready to focus your attention on driving? 
-Are your emotions under control so that you can make wise choices behind the wheel? 
+Two vehicles on a road with driving advice text stating, "If you are going to stop or slow down at a place where another driver does not expect it, tap your brake pedal three or four times quickly to alert drivers behind you."
+PRO
+TIP!
+If you are stopping 
+or slowing down at a 
+place where the person 
+behind you might not 
+expect it, tap your 
+brake pedal three or 
+four times quickly to 
+alert them.
+HEADLIGHTS
+Washington law says you need to have your headlights on a half hour 
+after sunset to a half hour before sunrise. However, it might be easier 
+to remember to have your headlights on:
+•	
+All the time.
+•	
+When it’s dark.
+•	
+When it’s rainy, snowy, foggy, or smoky.
+Headlights help you see, but they also help people see you!
  
-Chapter 3: Drivers 
-3.0: You behind the wheel 
-As a driver, you are part of a community that includes a variety of vehicles, roads, and people. 
-The harmony of this community relies on drivers interacting with their environment and each 
-other safely and responsibly. There are a lot of personal factors that influence your driving, but 
-most people have the same goal: to get where they are going safely. 
-To be a good driver, you need to be: 
-Mindful of yourself, others, and your impact on the community. 
-Responsible for the rules of the road. 
-Familiar with how your vehicle works and takes up space. 
-Patient and level-headed. 
-Your long-term success as a driver will depend on the habits you create as you learn. Be 
-intentional when you practice. Develop smart and safe habits, like always looking over your 
-shoulder to check your blind zones, that will become automatic. This will allow you to focus 
+Some vehicles have daytime running lights that come on when 
+you start the car. However, daytime running lights aren’t as 
+bright as headlights, and they don’t activate your taillights. 
+Make sure all lights are clean, bright, pointing the right 
+direction, and operating properly. If your dashboard shows a 
+“lamp out” symbol, it’s time to replace the bulbs. 
 
-more on the ever-changing driving environment. It can feel overwhelming at first, but the more 
-experience you have behind the wheel, the better driver you’ll be. 
-Health 
-Driving requires you to be physically and mentally fit.   
-Daily stressors can easily impact your health. A bad cold can slow your mental processes and 
-cause body soreness. A headache or tension in your shoulders could reduce your ability to 
-handle the vehicle. Stress can impact your ability to make wise decisions behind the wheel. 
-Many health conditions can impact your driving. Talk to your doctor if you’re concerned about 
-conditions that might affect your driving ability. 
-Before starting the engine, take a moment to check in with yourself. Are you healthy in a way 
-that supports wise decision-making, self-control, and situational awareness? Take a few deep 
-breaths and concentrate on driving. If you’re not feeling well but need to go somewhere, please 
-let someone else drive. 
-Physical health 
-Your physical health is a priority. It directly impacts your ability to be a safe and effective driver. 
-Before getting behind the wheel, ensure you’re in good health and not impaired by alcohol or 
-other drugs. 
-Vision 
-Good vision is so important for safe driving that the law requires you to pass a vision test before 
-you get your driver license. If you can’t see clearly, you will have trouble identifying traffic 
-hazards and responding to problems. Seeing well is important to safe driving.  
-If you are required to wear corrective lenses: 
-Always wear them when driving. 
-Avoid using dark or tinted corrective lenses at night. 
-Important aspects of vision are: 
-Peripheral vision. You can spot vehicles and other potential trouble out of the corner of your eye 
-while you’re still looking ahead. 
-Judging distance and speed. Being able to see well helps you determine how far away you are 
-from other vehicles, pedestrians, and other hazards. 
-Seeing at night 
-While driving in the dark, some drivers are bothered by the glare from oncoming headlights. If 
-you have problems seeing at night, don’t drive more than is necessary, and be very careful 
-when you do. 
-Make sure your headlights are on. 
-Avoid the glare of oncoming lights by watching the right edge of the road and using it as a 
-steering guide. 
+You can use your high beams on open roads without streetlights, but 
+remember to switch back to regular headlights when you are:
+•	
+500 feet in front of an oncoming vehicle.
+•	
+300 feet when you’re behind.
+BRAKE LIGHTS
+Brake lights tell the person behind you to slow down and 
+prepare to stop. Your brake lights are red and must be clearly 
+visible from 100 feet away.
+If your brake lights aren't working, use hand signals. Put your left 
+arm out the driver-side window, and point your fingers to the 
+ground. This will tell the vehicle behind you to slow down and 
+prepare to stop.
+ 
+TURN SIGNALS
+Create a habit of always signaling before you change direction, even 
+when you don’t see anyone else around.
+•	
+Signal 100 feet before you make your move.  
+•	
+Make sure your signal stops blinking after you make the turn. Three illustrations of a green pick
 
-Ensure headlights are properly aimed. Misaimed headlights could make it difficult for other 
-drivers to see and will reduce your ability to see the road. 
-Reduce your speed and increase your following distances. You should be able to stop inside the 
-lit area created by your headlights. 
-Hearing 
-The sound of horns, sirens, or screeching tires can provide direction or warn you of danger. Like 
-eyesight, hearing problems can progress slowly, so they’re often difficult to detect. Drivers who 
-are deaf or hard of hearing can often adjust by learning to rely more on vision and staying more 
-alert.  
-It is against the law to drive a vehicle while wearing earbuds, earphones, headphones, or 
-headsets that broadcast sound or cancel noise. 
-You can use a hands-free device in one ear if it complies with Washington Administrative Code 
-statute 204-10-045. 
-Remember: If you have an instruction permit or intermediate license, you cannot use a cell 
-phone or any mobile electronic device while driving, even if it is hands-free. 
-3.1: Impaired driving 
-Impaired driving happens when anything makes it hard for you to think straight, respond quickly, 
-or control your car. This includes things like alcohol, drugs, or being tired. All of these can put 
-you, your passengers, and others on the road at risk. 
-The penalties for impaired driving under the influence of alcohol or drugs are very tough: 
-expensive fines, higher insurance rates, license suspension or withdrawal, and even jail 
-sentences. 
-Even an experienced driver cannot drive safely after drinking alcohol or using drugs. Making the 
-choice to never drive under the influence will save lives: yours and others.   
-Alcohol and driving  
-Alcohol is the most common impairing substance involved in impaired driving crashes. Be alert 
-for impaired driving behavior of others and give them lots of room. 
-Alcohol can affect drivers by causing: 
-Feelings of relaxation and drowsiness. 
-Blurry vision or limited eyesight. 
-Reduced reaction times, concentration, and ability to scan the environment. 
-Difficulty in understanding what’s happening. 
-Difficulty doing multiple tasks at once, like staying in a lane and avoiding other traffic. 
-Inability to obey the rules of the road. 
-Overconfidence, which can lead to risky driving behavior. 
+HAND SIGNALS
+If one or both signals aren't working, use hand signals to let 
+other drivers know what you’re doing.
+ 
+Stop
+Put your left arm out the driver-side window. Point your fingers 
+to the ground. This will tell the person behind you to slow down 
+and prepare to stop.
+Left turn
+Put your left arm out the window. Point your fingers straight out 
+to the left.
+Right turn
+Put your left arm out the window. Bend your arm so your fingers 
+point to the sky.
+ 
+HAZARD WARNING LIGHTS
+If your car malfunctions or you need to make an emergency 
+stop, turn on your flashing hazard lights. This alerts other drivers 
+of your situation and allows them to safely go around you.
+DRIVER’S SEAT
+•	
+Adjust your seat so you can see clearly out of the windshield 
+and easily reach the pedals.
+•	
+Adjust the back of your seat so you are sitting comfortably 
+straight. Your chest should be at least 10 inches from the 
+steering wheel to leave space for the airbag. 
+•	
+Adjust the steering wheel so you can grip the wheel with a 
+gentle bend in your elbow.
+•	
+Protect yourself from whiplash by making sure the headrest 
+is even with your ears.
+Anytime you get behind the wheel after someone else has been 
+driving, make adjustments that keep you comfortable and safe.
 
-Please: 
-Do not drive any vehicle if you have consumed impairing substances. 
-Do not ride with a driver who has had any kind or amount of impairing substances. 
-Do not let friends or family drive if they have been drinking alcohol or using drugs. 
-Plan for a sober driver. 
-Cannabis and driving 
-Recreational use of marijuana, THC, and other cannabis products (edibles, patches, vapes, 
-tinctures, and topicals) is legal for those 21 years or over, but driving after consuming any 
+2.6  |  OCCUPANT PROTECTION
+SEAT BELTS AND OCCUPANT PROTECTION
+Buckling up correctly is the most effective thing you can do 
+to protect yourself. Wearing your seat belt dramatically drops 
+your risk of fatal injury in a crash. Always fasten your seat belt 
+and make sure all passengers are using seat belts, child safety 
+restraints, or booster seats correctly.
+ Image with seat belt fastening with "click it" promotional message.Illustration of 
+Your seat belt should go across 
+the middle of your chest. Never 
+put it behind your back or under 
+your arm. The shoulder belt should 
+lie snug across the shoulder and 
+chest, and not cross the neck or 
+face. The lap belt should securely 
+and snugly restrain the hips, below 
+the stomach.
+Every person in a moving vehicle 
+must wear a seat belt or be 
+securely fastened into an approved 
+child restraint device.
+It is illegal to drive or ride in a vehicle without 
+wearing a seat belt or using child safety restraints. 
+RCW 46.61.687 and RCW 46.61.688
+
+Be sure your seat belt is not twisted, the lap belt rests on your 
+upper thigh, and the cross-body strap falls across your mid-
+shoulder. Your knees should bend at the edge of the seat, your 
+feet should touch the floor, and your headrest should be in line 
+with your ears.
+ 
+CHILD SEATSIllustration of a child in a front-facing car seat with a properly secured seatbelt.
+Protect child passengers by using 
+the correct seat for their age and 
+size every time you (or others) travel 
+with a child. 
+Child restraint systems must comply 
+with Federal Motor Vehicle Safety 
+Standards and be secured in the 
+vehicle according to vehicle and 
+child restraint system manufacturer 
+instructions.
+You can have a certified child passenger safety technician 
+check the installation of your child restraint system.
+Find more information and safety check locations at 
+wacarseats.com.
+A child should remain in each stage of restraint as long as the 
+seat allows for the best protection. Illustration of rear-facing baby car seat.
+Rear-facing
+Children up to age 2 must ride in a 
+rear-facing car seat.
+Age: Birth - 2 years
+
+Illustration of a car seat with a properly secured harness.
+Forward-facing
+Ages 2 to 4 years must ride in a car 
+seat with a rear- or forward-facing 
+harness.
+Age: 2 to 4 yearsIllustration of a child booster seat.
+Booster
+Ages 4 and older must ride in a car 
+or booster seat until the vehicle lap 
+and shoulder seat belts fit properly— 
+typically, between the ages of 8 and 
+12 years of age.
+Age and size: 4 years to 4’9”Illustration of a unbuckled se
+Seat belt
+All occupants old and tall enough to 
+wear a seat belt must have a properly 
+fitting belt.
+Size: Over 4’9”
+AIRBAGS
+Airbags and seat belts work together to keep you safe in the 
+event of a crash. If you are not wearing your seat belt when 
+an airbag deploys, you risk serious injury or death. Airbags are 
+also why children under the age of 13 should never ride in the 
+front seat. They could be seriously injured or killed if an airbag 
+deploys.
+
+2.7  |  STEERINGHands holding a steering wheel at the 9 and 3 o'clock positions, with clock numb
+Place your hands outside the wheel, on the top half of the 
+steering wheel. This will give you the best control.Round analog clock with green border. The small hand of the clock dial is pointing at the 9 and the large hand is pointing at the 3.
+Imagine that the steering wheel 
+is a clock. Each hour represents a 
+location for you to hold the wheel. In 
+the image above, the driver’s hands 
+are at 9:00 and 3:00. 
+There are three turning methods that can provide smooth, 
+continuous steering control.
+
+HAND-TO-HAND STEERING (PULL/PUSH)Step-by-step illustration of turning a steering wheel clockwise with green arrows indicat
+When using this method, your 
+hands should be at 9 and 3 or 
+10 and 2. 
+Keep your hands in this 
+position when you turn.
+In this image, the driver is 
+pulling with their left hand, and 
+pushing with their right.
+Since your hands never cross 
+over the steering wheel, there 
+is less chance of an injury to 
+the face, hands, or arms if the 
+air bag deploys.
+Your hands never leave the 
+wheel and each hand stays on 
+its own side. One hand grips 
+the wheel and steers. The 
+other hand slides and remains 
+opposite of the steering hand.
+Hand-to-hand technique 
+keeps both hands on the 
+wheel, allows you to instantly 
+make necessary changes, and 
+keeps your arms away from the 
+airbag area.
+
+HAND-OVER-HAND STEERING Step-by-step illustration of turning a steering wheel counter-clockwise, then clockwise with green arrows indicating the motion and the hands crossing over each other.
+Use this method of steering 
+when turning at low speeds, 
+with limited visibility, at an 
+intersection, when parking 
+the vehicle, or when 
+recovering from a skid.
+When using this method, 
+your hands should start at 
+9 and 3 or 10 and 2.
+When turning, reach one arm 
+across the other to grasp the 
+wheel, and pull the wheel as 
+appropriate. 
+Release the hand 
+underneath so that you can 
+reposition it on the wheel.
+Straighten the steering 
+wheel as you smoothly 
+complete the turn.
+
+Illustration of one hand turning a steering wheel.
+ONE-HAND STEERING 
+Use one-hand steering when 
+backing or operating vehicle 
+controls (wipers, flashers, 
+lights, etc.) that require you 
+to reach from the steering 
+wheel. 
+The placement of one hand 
+on the steering wheel is 
+critical to vehicle balance 
+and controlled steering 
+when in reverse.
+The 12 position is recommended only when backing a vehicle. 
+In this situation, turn your body to see the path of travel 
+behind you.
+2.8  |  BRAKING
+Good vehicle handling depends on your ability to accurately 
+and smoothly manage speed and space at all times.
+BRAKING PRESSURE
+Determining the amount of braking pressure you need is an 
+important skill. It will develop as you practice and get more 
+familiar with the vehicle you drive. There are four levels of 
+braking:
+1.	 Light
+2.	 Medium
+3.	 Firm
+4.	 Emergency
+
+Ideally, you’ll only need to use light and medium braking, but 
+you can always use firm or emergency braking if you need to. As 
+a braking technique, imagine having a cup of water in your lap 
+that you don’t want to spill.
+Keep the people behind you in mind, also. Unnecessary firm or 
+emergency braking could surprise the people behind you who 
+were anticipating a smooth stop.
+ANTILOCK BRAKING SYSTEMS
+A vehicle’s Antilock Brake System (ABS) offers an important 
+safety advantage by allowing drivers to steer during an 
+emergency braking situation. An ABS does not shorten your 
+stopping distance, but it will allow you to keep better steering 
+control. When engaged, you can feel your vehicle shake a bit.
+Practice firm or emergency braking in a large, open, and paved 
+space. Hit the brakes hard, and feel the ABS keep the wheels 
+from locking up.
+2.9  |  ACCELERATING 
+To drive smoothly, you’ll want to be familiar and comfortable 
+with different levels of acceleration. There could be times 
+you’re in stop-and-go traffic where the only acceleration you 
+need is to release the brake pedal. There could be times you’ll 
+need to accelerate quickly to avoid a hazard. Your accelerating 
+technique should be like braking — imagine there’s a cup of 
+water in your lap, and accelerate without spilling the water.
+
+2.10  |  BALANCED WEIGHT Car with surrounding red, green, and yellow arrows a
+It’s natural for your vehicle’s balance to shift a bit when it starts 
+to move. To maintain stability of your vehicle, keep the weight 
+evenly balanced across the tires. Regular maintenance, correct 
+tire pressure, and alignment checks will help you do this.Car with curved red arrows forming
+PITCH
+Lay your hand flat on a table. Lift your fingers and feel the 
+increased pressure on your wrist. Now put your fingers on the 
+table and lift your wrist. This forward and backward motion is 
+called pitch (shown here with arrows).
+When you accelerate, the weight of the vehicle shifts to the 
+back and increases pressure on the rear of the vehicle. If you 
+stop abruptly, the weight shifts forward, increasing pressure on 
+the front of the vehicle.
+
+Car with curved green arrows forming a circular shape around it on the Z-axis.
+ROLL
+Lay your hand flat on a table. Rotate your hand so your little 
+finger is stuck to the table, but your thumbnail is pointed toward 
+the sky. Now reverse so your thumb is on the table. This side-to-
+side motion of a vehicle is called roll (shown above with arrows).
+When you make a left turn, centrifugal force transfers the weight 
+down on the outside or right side of your vehicle. The body of 
+the vehicle rolls to one side.Car with curved yellow arrows forming a circular shape around it on the Y-axis.
+YAW
+Keep your hand flat on a table. Move your fingers to the left and 
+let your wrist move to the right. Now wiggle it back and forth like 
+you’re waving at the table. This is called yaw (shown above with 
+arrows).
+
+When you turn the steering wheel sharply from side to side, 
+the front and back of your car don’t stay perfectly lined up. The 
+front wheels turn in the direction you’re steering, while the back 
+might slide a bit, creating a zig-zag motion.
+2.11  |  VEHICLE REFERENCE POINTS
+Reference points depend on the vehicle you’re driving and 
+the road you’re traveling. Familiarity with your vehicle reference 
+points will help you judge distance when you park, turn, back, 
+and stop.
+Examples of vehicle reference points:
+•	
+Left headlight
+•	
+Center of hood
+•	
+Side view mirrors
+•	
+Rear bumperCar with a yellow "LINE OF SIGHT" arrow pointing from the car's front left to a "R
+ 
+At an intersection, stopping when the stop line is under your 
+side mirror means you are about 3 to 6 inches from the line. This 
+reference point will help you determine the position of the front 
+end of your vehicle. 
+
+Overhead diagram of a car on a road with the reference point and line of sight indicated.
+To determine your lane position, check that the center of 
+your hood is in line with lane markings. If they're in line, you're 
+approximately 3 to 6 inches from the edge of the lane.
+2.12  |  YOUR BLIND ZONES
+Blind zones are the areas around a vehicle you can’t see from 
+the driver’s seat. These areas are dangerous because they can 
+hide another vehicle, motorcyclist, or bicyclist completely. It's 
+your responsibility to be aware of everything in your blind zones.
+One way you can reduce your blind zone is by adjusting your mirrors. 
+1.	 Adjust your rearview mirror so you can see out the back 
+window without having to stretch.
+2.	 There are a couple methods to adjust your side mirrors 
+to minimize your blind zones: traditional or enhanced. 
+Either way, you need to do a full visual search of the space 
+around your vehicle. Move your head, neck, and body so 
+that both eyes can see if your blind zones are clear. Note: 
+When turning your head to look, keep the steering wheel 
+straight.
+3.	 Some vehicle safety technology systems have features 
+that alert you if there is someone in your blind zone. This 
+assistance is helpful, but make a habit of using your eyes 
+to check for yourself.
+
+2.13  |  OTHER VEHICLES' BLIND ZONES 
+To stay aware of 
+your surroundings, 
+regularly check:
+1. The area in front of 
+you
+2. Your rearview mirror
+3+4. Your side mirrors
+5+6. Over your 
+shoulderTop-down view of a car within a circle divided into six numbered sections with additional blue-ray beams labeled 2, 3, and 4 at its front, showing blind zone detection areas and areas to scan.
+OBSERVATIONAL SCANS
+You also need to be aware of other vehicles’ blind zones. Do 
+your best to stay out of them. You can speed up or slow down 
+so the driver can clearly see you. 
+Pay special attention to large vehicles like buses, motor homes, 
+and commercial motor vehicles. They have bigger blind zones, 
+sometimes called “no zones.” This is because there should be 
+no vehicles traveling in that zone. 
+Be thoughtful and alert traveling around large vehicles. 
+Remember: if you can’t see their mirrors, the driver can’t 
+see you.
+
+Instructional graphic showing how to adjust car mirrors and monitor blind spots with labeled figures and text advisories.
+
+Text in graphic reads: 
+
+Adjust your mirrors to eliminate as much of your blind zones as possible. Recheck them every time you get behind the wheel.
+
+At all times, you need to be aware of everything going on around you. Constantly check your mirrors for any changes to your driving situation.
+Optimize
+Adjust your mirrors 
+to eliminate as 
+much of your blind 
+zones as possible. 
+Recheck your 
+mirrors every time 
+you get behind the 
+wheel.
+Stay Alert
+You need to be 
+aware of everything 
+going on around 
+you. Constantly 
+check your mirrors 
+for any changes 
+to your driving 
+situation.
+
+2.14  |  BEFORE YOU GO 
+When you're getting ready to drive, a good routine is to:
+1.	 Check outside your vehicle. Are there foreign objects in 
+the tires, broken glass in the area, or fluid leaks under the 
+vehicle? Are there other obstructions, children, pets, or 
+weather-related obstacles?
+2.	 Check inside your vehicle. Are there any warnings on the 
+instrument panel? Are all windows clear of obstructions? 
+Are loose items safely secured?
+3.	 Check all internal adjustments. Are your mirrors set? Are 
+the seat and steering wheel in the right place? Is your seat 
+belt buckled? Is your phone silenced and put away?
+4.	 Check in with yourself. Do you feel healthy and 
+clearheaded? Are you ready to focus your attention on 
+driving? Are your emotions under control so that you can 
+make wise choices behind the wheel?
+
+Chapter 3 
+Driver im
+age of 
+a green car with Washington license plate "WADRIVER," cityscape background
+
+3.0  |  YOU BEHIND THE WHEEL
+As a driver, you are part of a community that includes a variety 
+of vehicles, roads, and people. The harmony of this community 
+relies on drivers interacting with their environment and each 
+other safely and responsibly. There are a lot of personal factors 
+that influence your driving, but most people have the same 
+goal: to get where they are going safely.
+To be a good driver, you need to be:
+1.	 Mindful of yourself, others, and your impact on the 
+community.
+2.	 Responsible for the rules of the road.
+3.	 Familiar with how your vehicle works and takes up space.
+4.	 Patient and levelheaded.
+Your long-term success as a driver will depend on the habits 
+you create as you learn. Be intentional when you practice. 
+Develop smart and safe habits, like always looking over your 
+shoulder to check your blind zones, that will become automatic. 
+This will allow you to focus more on the ever-changing driving 
+environment. It can feel overwhelming at first, but the more 
+experience you have behind the wheel, the better driver 
+you’ll be.
+HEALTH
+Driving requires you to be physically and mentally fit.  
+Daily stressors can easily impact your health. A bad cold can 
+slow your mental processes and cause body soreness. A 
+headache or tension in your shoulders could reduce your ability 
+to handle the vehicle. Stress can impact your ability to make 
+wise decisions behind the wheel. Many health conditions can 
+impact your driving. Talk to your doctor if you’re concerned 
+about conditions that might affect your driving ability. 
+
+Before starting the engine, take a moment to check in 
+with yourself. Are you healthy in a way that supports wise 
+decision‑making, self-control, and situational awareness? Take 
+a few deep breaths and concentrate on driving. If you’re not 
+feeling well but need to go somewhere, please let someone 
+else drive.
+PHYSICAL HEALTH
+Your physical health is a priority. It directly impacts your ability to 
+be a safe and effective driver. Before getting behind the wheel, 
+ensure you’re in good health and not impaired by alcohol or 
+other drugs.
+VISION
+Good vision is so important for safe driving that the law requires 
+you to pass a vision test before you get your driver license. If 
+you can’t see clearly, you will have trouble identifying traffic 
+hazards and responding to problems. Seeing well is important 
+to safe driving.
+If you are required to wear corrective lenses:
+•	
+Always wear them when driving.
+•	
+Avoid using dark or tinted corrective lenses at night.
+Important aspects of vision are:
+•	
+Peripheral vision. You can spot vehicles and other 
+potential trouble out of the corner of your eye while you’re 
+still looking ahead.
+•	
+Judging distance and speed. Being able to see well helps 
+you determine how far away you are from other vehicles, 
+pedestrians, and other hazards.   
+
+SEEING AT NIGHT
+While driving in the dark, some drivers are bothered by the 
+glare from oncoming headlights. If you have problems seeing 
+at night, don’t drive more than is necessary, and be very careful 
+when you do.
+•	
+Make sure your headlights are on.
+•	
+Avoid the glare of oncoming lights by watching the right 
+edge of the road and using it as a steering guide.
+•	
+Ensure headlights are properly aimed. Misaimed headlights 
+could make it difficult for other drivers to see and will reduce 
+your ability to see the road.
+•	
+Reduce your speed and increase your following distances. 
+You should be able to stop inside the lit area created by 
+your headlights. 
+HEARING
+The sound of horns, sirens, or screeching tires can provide 
+direction or warn you of danger. Like eyesight, hearing problems 
+can progress slowly, so they’re often difficult to detect. Drivers 
+who are deaf or hard of hearing can often adjust by learning to 
+rely more on vision and staying more alert. 
+It is against the law to drive a vehicle while wearing earbuds, 
+earphones, headphones, or headsets that broadcast sound or 
+cancel noise.
+You can use a hands-free device in one ear if it complies with 
+Washington Administrative Code statute 204-10-045.
+Remember: If you have an instruction permit or intermediate 
+license, you cannot use a cell phone or any mobile electronic 
+device while driving, even if it is hands-free.
+
+Public service announcement with text message conversation. “Get home safe. Plan a sober ride before you go out.” Followed by a QR code and "TOGETHER WE GET THERE" logo.
+
+3.1  |  IMPAIRED DRIVING
+Impaired driving happens when anything makes it hard for 
+you to think straight, respond quickly, or control your car. This 
+includes things like alcohol, drugs, or being tired. All of these 
+can put you, your passengers, and others on the road at risk.
+ 
+The penalties for impaired driving under the influence of 
+alcohol or drugs are very tough: expensive fines, higher 
+insurance rates, license suspension or withdrawal, and even jail 
+sentences.
+Even an experienced driver cannot drive safely after drinking 
+alcohol or using drugs. Making the choice to never drive under 
+the influence will save lives: yours and others’. 
+ALCOHOL AND DRIVING 
+Alcohol is the most common impairing substance involved in 
+impaired driving crashes. Be alert for impaired driving behavior 
+of others and give them lots of room.
+Alcohol can affect drivers by causing:
+•	
+Feelings of relaxation and drowsiness.
+•	
+Blurry vision or limited eyesight.
+•	
+Reduced reaction times, concentration, and ability to scan 
+the environment.
+•	
+Difficulty in understanding what’s happening.
+•	
+Difficulty doing multiple tasks at once, like staying in a lane 
+and avoiding other traffic.
+•	
+Inability to obey the rules of the road.
+•	
+Overconfidence, which can lead to risky driving behavior.
+
+Please:
+•	
+Do not drive any vehicle if you have consumed impairing 
+substances.
+•	
+Do not ride with a driver who has had any kind or amount of 
+impairing substances.
+•	
+Do not let friends or family drive if they have been drinking 
+alcohol or using drugs.
+•	
+Plan for a sober driver.
+CANNABIS AND DRIVING
+Recreational use of marijuana, THC, and other cannabis 
+products (edibles, patches, vapes, tinctures, and topicals) is 
+legal for those 21 years or over, but driving after consuming any 
 cannabis is illegal for all ages. 
 There is no safe amount of cannabis for driving. 
-Research shows that cannabis can impair drivers in a variety of ways: 
+Research shows that cannabis can impair drivers in a variety of 
+ways: 
+•	
 Reduced attention, reaction time, and coordination 
-Decreased car handling 
-Slower reaction times 
-Inability to judge distances 
+•	
+Decreased car handling
+•	
+Slower reaction times
+•	
+Inability to judge distances
+•	
 Increased drowsiness 
-Loss of motor coordination 
-Impaired mental and physical functions 
-Medications and driving 
+•	
+Loss of motor coordination
+•	
+Impaired mental and physical functions
+
+MEDICATIONS AND DRIVING
 There’s more than one way to be under the influence. 
-Impaired driving is generally associated with alcohol, cannabis, or illegal drug use. However, 
-many legally obtained and commonly used over-the-counter and prescription drugs can impact 
-a user’s ability to drive safely. 
-Just because a drug is legal does not mean it is safe to use while driving. 
-Impaired driving is a criminal behavior. It doesn’t matter if the drug is prescribed, obtained over-
-the-counter, bought in a retail setting, or considered an illicit substance. 
-Over-the-counter drugs taken for headaches, colds, or allergies can make a person drowsy, 
-which could affect your driving. Like alcohol, prescription drugs can affect your reflexes, 
-judgment, vision, and alertness. 
-Do not drive if you just started taking prescription drugs for the first time, started taking a new 
-prescription medicine, or started taking a higher dose of a current drug. Wait until you know 
-what effect it has on your judgment, coordination, and reaction time. Talk to your doctor or 
-pharmacist. Read all warning labels before driving. Warnings against “operating heavy 
-machinery” include driving a vehicle. 
+Impaired driving is generally associated with alcohol, cannabis, 
+or illegal drug use. However, many legally obtained and 
+commonly used over-the-counter and prescription drugs can 
+impact a user’s ability to drive safely. 
+•	
+Just because a drug is legal does not mean it is safe to use 
+while driving. 
+•	
+Impaired driving is a criminal behavior. It doesn’t matter if 
+the drug is prescribed, obtained over-the-counter, bought 
+in a retail setting, or considered an illicit substance.
+Over-the-counter drugs taken for headaches, colds, or allergies 
+can make a person drowsy, which could affect your driving. Like 
+alcohol, prescription drugs can affect your reflexes, judgment, 
+vision, and alertness.
+Do not drive if you just started taking prescription drugs for the 
+first time, started taking a new prescription medicine, or started 
+taking a higher dose of a current drug. Wait until you know what 
+effect it has on your judgment, coordination, and reaction time. 
+Talk to your doctor or pharmacist. Read all warning labels before 
+driving. Warnings against “operating heavy machinery” include 
+driving a vehicle.
+Some medications might not impact you on their own, but if 
+taken with a second medication or alcohol, they could cause 
+severe impairment. Many drugs multiply the effects of alcohol 
+or have other side effects. Read the warnings on your medicine 
+or talk to your pharmacist before you drink and use medicine at 
+the same time.
 
-Some medications might not impact you on their own, but if taken with a second medication or 
-alcohol, they could cause severe impairment. Many drugs multiply the effects of alcohol or have 
-other side effects. Read the warnings on your medicine or talk to your pharmacist before you 
-drink and use medicine at the same time. 
-Polydrug use and driving 
-Polydrug use is the mixing or taking of more than one type of drug. Mixing alcohol, cannabis, or 
-other drugs can produce effects greater than any drug on its own. It can include alcohol, 
-cannabis, illegal drugs, prescription drugs, over-the-counter medicines, and other substances 
-such as non-regulated drugs and inhalants. Polydrug use is the most common impairment 
-involved in fatal crashes. 
-Effects of polydrug use vary from person to person and depend on the drug’s purity, quantity, 
-frequency of use, and how they’re taken. Polydrug use can lead to increased probability of 
-overdose, mental health troubles, risky behavior, serious injuries, and crashes. 
-Fatigue and drowsy driving 
-Fatigue is caused by physical or mental strain, repetitive tasks, illness, or lack of sleep. Like 
-alcohol and drugs, fatigue impairs your vision and judgment.  
-Drowsy driving affects your alertness, attention, reaction time, judgment, and decision-making 
-capabilities. When you drive fatigued, you risk falling asleep behind the wheel and causing a 
-crash involving injuries or fatalities.  
-Here are some signs of fatigue. Pull over and rest if you are: 
-Having difficulty focusing, or you can’t remember driving the last few miles. 
-Blinking frequently or have heavy eyelids. 
-Drifting from your lane, swerving, tailgating, and/or hitting rumble strips. 
-Having trouble keeping your head up. 
-Missing exits or traffic signs. 
-Feeling restless, irritable, or aggressive. 
-If you’re traveling with another driver, take turns driving. If you’re traveling alone and start to feel 
-tired, pull off the road and take a 20-minute nap. It’s better to stop and sleep than to risk causing 
-an accident. 
-Before a trip: 
-Get adequate sleep—most people need 7 to 9 hours to stay alert. 
-Plan to stop about every 100 miles or 2 hours during long trips. 
-Walk around, get some fresh air, and drink some water. Plan your trip with plenty of time for 
-breaks. 
-Arrange for a travel companion to help you stay alert, watch for trouble, and share the driving. 
+POLYDRUG USE AND DRIVING
+Polydrug use is the mixing or taking of more than one type of 
+drug. Mixing alcohol, cannabis, or other drugs can produce 
+effects greater than any drug on its own. It can include alcohol, 
+cannabis, illegal drugs, prescription drugs, over-the-counter 
+medicines, and other substances such as nonregulated drugs 
+and inhalants. Polydrug use is the most common impairment 
+involved in fatal crashes.
+Effects of polydrug use vary from person to person and depend 
+on the drug’s quantity, frequency of use, and how they’re taken. 
+Polydrug use can lead to increased probability of overdose, 
+mental health troubles, risky behavior, serious injuries, and 
+crashes.
+FATIGUE AND DROWSY DRIVING
+Fatigue is caused by physical or mental strain, repetitive tasks, 
+illness, or lack of sleep. Like alcohol and drugs, fatigue impairs 
+your vision and judgment. 
+Drowsy driving affects your alertness, attention, reaction time, 
+judgment, and decision-making capabilities. When you drive 
+fatigued, you risk falling asleep behind the wheel and causing a 
+crash involving injuries or fatalities. 
+Here are some signs of fatigue. Pull over and rest if you are:
+•	
+Having difficulty focusing, or you can’t remember driving the 
+last few miles. 
+•	
+Blinking frequently or have heavy eyelids.
+•	
+Having trouble keeping your head up.
+•	
+Missing exits or traffic signs.
+•	
+Feeling restless, irritable, or aggressive.
+•	
+Drifting from your lane, swerving, tailgating, and/or hitting 
+rumble strips.
 
-Mental health 
-Emotions can affect your driving. You make better decisions when you understand how your 
-feelings affect your behavior. 
-For example, if you’re feeling anxious when you’re driving, you might be preoccupied and allow 
-your foot to be too heavy on the accelerator. How you’re feeling (anxious) is changing your 
-behavior (driving faster). 
-Below are a few techniques to calm down and relieve stress before getting on the road. You can 
-do them while sitting in a parked car. 
-Breathe in through your nose, and exhale like you’re trying to cool hot soup. 
-Count slowly from 1 to 20, or backwards from 100 by three (100, 97, 94, 91, 88…). Concentrate 
-only on the numbers to quiet everything else in your head. 
-Allow plenty of time for your trip. Choose to be patient with yourself and others. 
-Emotional awareness encourages patience and respect for others on the road and cultivates 
-safer driving behavior.  
-Aggressive driving 
+ Large blue container truck labeled "DEPARMENT OF LICENSING" involved in a rear-end collision with a red car.
+ 
+If you’re traveling with another driver, take turns driving. If you’re 
+traveling alone and start to feel tired, pull off the road and take a 
+20-minute nap. It’s better to stop and sleep than to risk causing 
+an accident.
+Before a trip:
+•	
+Get adequate sleep — most people need 7 to 9 hours to 
+stay alert.
+•	
+Plan to stop about every 100 miles or 2 hours during 
+long trips.
+•	
+Walk around, get some fresh air, and drink some water. Plan 
+your trip with plenty of time for breaks.
+•	
+Arrange for a travel companion to help you stay alert, watch 
+for trouble, and share the driving.
+MENTAL HEALTH
+Emotions can affect your driving. You make better decisions 
+when you understand how your feelings affect your behavior.
+For example, if you’re feeling anxious when you’re driving, you 
+might be preoccupied and allow your foot to be too heavy on 
+the accelerator. How you’re feeling (anxious) is changing your 
+behavior (driving faster).
+
+Below are a few techniques to calm down and relieve stress 
+before getting on the road. You can do them while sitting in a 
+parked car.
+1.	 Breathe in through your nose, and exhale like you’re 
+trying to cool hot soup.
+2.	 Count slowly from 1 to 20, or backward from 100 by three 
+(100, 97, 94, 91, 88…). Concentrate only on the numbers to 
+quiet everything else in your head.
+3.	 Allow plenty of time for your trip. Choose to be patient 
+with yourself and others.
+Emotional awareness encourages patience and respect for 
+others on the road and cultivates safer driving behavior. 
+AGGRESSIVE DRIVING
 Aggressive driving is a traffic offense. 
-Aggressive driving is when a driver purposely does something that endangers people or 
-property. 
-The following behaviors are considered aggressive driving: 
-Actions taken while driving that risk harming other people or property. 
-Intentional actions that require another person to protect themselves. 
+Aggressive driving is when a driver purposely does something 
+that endangers people or property.
+The following behaviors are considered aggressive driving:
+•	
+Actions taken while driving that risk harming other people or 
+property.
+•	
+Intentional actions that require another person to protect 
+themselves.
 Behaviors associated with aggressive driving include: 
-Speeding. 
-Following too close. 
-Making unsafe lane changes. 
-Using improper signaling. 
-Failing to obey traffic control devices. 
-Driving too close to someone walking or cycling along the road. 
-Concentrate on what you’re doing. Try not to take aggressive driving personally. Be patient and 
-forgiving of other road users.  
-Racing and street demonstrations 
-Because street racing and unauthorized street demonstrations are so dangerous, penalties are 
-severe. They can apply to drivers and anyone else who instigates or assists with street racing 
-activities. Guilty participants can face fines, jail time, and risk having their vehicle impounded.  
+•	
+Speeding.
+•	
+Following too close.
+•	
+Making unsafe lane changes.
+•	
+Using improper signaling.
+•	
+Failing to obey traffic control devices.
+•	
+Driving too close to someone walking or cycling along 
+the road.
 
-Road rage 
-Road rage is a criminal offense. 
-Road rage is an angry response to something that happened on the road that leads to violent 
-behavior with a vehicle or other weapon. Road rage can happen between the driver or 
-passenger of one vehicle towards another driver, passenger, or person using the road. 
-Many things can contribute to road rage, including stress, tight schedules, traffic, or non-driving 
-frustrations. Give yourself plenty of time to travel, create safe space margins around your 
-vehicle, and try to show grace to other people. 
-If you are experiencing road rage 
-You might be having feelings of road rage if you are: 
-Having thoughts of strong disapproval or violence toward other people on the road. 
-Verbally disapproving of other people on the road to passengers in your vehicle. 
-Not obeying traffic safety laws because you don’t agree with them. 
-Following too close. 
-Speeding. 
-Weaving in and out of traffic. 
-Speeding up to beat a traffic light. 
-Cutting between vehicles to change lanes. 
-Using your vehicle horn excessively. 
-Flashing headlights excessively at oncoming traffic. 
-Braking to stop the driver behind you from following too closely. 
-Passing traffic and then slowing down to teach the other driver a lesson. 
-If you are the victim of road rage  
-When you see other drivers around you acting or reacting in anger, distance yourself from the 
-situation physically and mentally. 
-Take a deep breath and move out of the way. 
-Avoid aggressive speeding, honking, or hand gestures 
-Keep your eyes on the road. 
-Drive to an area where there are other people and open businesses if you feel you’re being 
-followed or harassed by another driver. 
-Call the police if necessary. 
-Reporting road rage 
+Concentrate on what you’re doing. Try not to take aggressive 
+driving personally. Be patient and forgiving of other road users. 
+  
+RACING AND STREET DEMONSTRATIONS
+Because street racing and unauthorized street demonstrations 
+are so dangerous, penalties are severe. They can apply to 
+drivers and anyone else who instigates or assists with street 
+racing activities. Guilty participants can face fines, jail time, and 
+risk having their vehicle impounded. 
+ROAD RAGE
+Road rage is a criminal offense.
+Road rage is an angry response to something that happened 
+on the road that leads to violent behavior with a vehicle or 
+other weapon. Road rage can happen between the driver or 
+passenger of one vehicle toward another driver, passenger, or 
+person using the road.
+Many things can contribute to road rage, including stress, tight 
+schedules, traffic, or non-driving frustrations. Give yourself 
+plenty of time to travel, create safe space margins around your 
+vehicle, and try to show grace to other people. Cartoon of an angry emoji character 
 
-Report in-progress road rage incidents immediately by calling 911. 
-Reducing incidents of road rage and aggressive driving is critical to the mission of the 
-Washington State Patrol. While troopers and other law enforcement agencies are always on the 
-lookout for aggressive driving, steps to improve traffic safety in Washington are made when 
-residents act. 
-If you have witnessed or been a victim of an aggressive driving act, please call 911 and provide 
-the following information: 
-Location vehicles were last seen 
-Plate number (if known) 
-Direction of travel (toward where) 
-Road or highway 
-Colors of the vehicles 
-Weapons involved (if applicable) 
-Summary of what happened 
-Role in incident (victim or witness) 
-3.2: Informed decisions on the road 
-Being a safe and responsible driver requires more than knowing the rules of the road. It involves 
-making informed decisions in every situation you encounter while driving. Whether you realize it 
-or not, you make thousands of decisions every day. Some of the most important ones you make 
-will be when you’re behind the wheel. 
-Why informed decisions matter 
-Every action you take behind the wheel is a decision, from changing lanes to merging onto a 
-highway. Making informed decisions means considering all the factors involved before acting. 
-This leads to smoother, safer driving for yourself and others. 
-Informed decisions can: 
-Increase awareness. Making informed decisions requires constant analysis of your 
-surroundings. This improves your overall situational awareness. 
-Promote responsible driving. Understanding the consequences of your choices encourages 
-responsible behavior. It also shows respect for other road users. 
-Reduce crashes. Anticipating potential problems will help you reduce the risk of collisions. 
-Informed decisions are impacted by your: 
-Knowledge of traffic laws. 
-Experience with safe driving practices. 
-Capabilities based on age and brain development. 
+IF YOU ARE EXPERIENCING ROAD RAGE
+You might be having feelings of road rage if you are:
+•	
+Having thoughts of strong disapproval or violence toward 
+other people on the road.
+•	
+Verbally disapproving of other people on the road to 
+passengers in your vehicle.
+•	
+Not obeying traffic safety laws because you don’t agree with 
+them.
+•	
+Following too close.
+•	
+Speeding.
+•	
+Weaving in and out of traffic.
+•	
+Speeding up to beat a traffic light.
+•	
+Cutting between vehicles to change lanes.
+•	
+Using your vehicle horn excessively.
+•	
+Flashing headlights excessively at oncoming traffic.
+•	
+Braking to stop the driver behind you from following 
+too closely.
+•	
+Passing traffic and then slowing down to teach the other 
+driver a lesson.
+IF YOU ARE THE VICTIM OF ROAD RAGE 
+When you see other drivers around you acting or reacting 
+in anger, distance yourself from the situation physically and 
+mentally. 
+•	
+Take a deep breath and move out of the way.
+•	
+Avoid aggressive speeding, honking, or hand gestures. 
+•	
+Keep your eyes on the road.
+•	
+Drive to an area where there are other people and open 
+businesses if you feel you’re being followed or harassed by 
+another driver. Call the police if necessary. 
 
-Teen drivers need to remember the part of their brain responsible for judgment and decision 
-making is still developing. This means teens can be more prone to taking risks or miscalculating 
-situations. All drivers need to prioritize safety-focused decisions over speed and social 
-pressures. This is especially true for teens. 
-Older drivers want to be aware that physical and mental capabilities change with age. Older 
-drivers can be more susceptible to serious injuries in vehicle crashes, however many remain 
-safe and competent drivers well into their later years. Regardless of age or experience, all 
-drivers must commit to staying focused and engaged every time they are behind the wheel. 
-Make good decisions 
-Good decisions are informed decisions. To make good decisions, you must be aware of what’s 
-going on around you. 
-Inform yourself with mirror checks. Be aware of the whole situation, including people around you 
-who might be affected by your decisions. Inform others of what you intend to do so they become 
-aware of your intentions and can prepare for them. 
-Prepare the vehicle so you arrive at the hazard in the right road position and at the right speed. 
-Do a final check before maneuvering. 
-This approach can be applied to any situation that requires you to make a change. You should 
-always aim to be aware, predictable, and smooth. 
-3.3: Problem solving on the road 
-Unexpected situations are inevitable and responding to these situations requires problem 
-solving. It’s likely that solving problems on the road will require you to make thoughtful changes 
-like: 
-Modifying your speed. 
-Adjusting your lane position to reduce risk and avoid hazards. 
-Changing your direction or path-of-travel to get to a safe place to reassess the situation. 
-Try not to surprise other people on the road. Communicate your intentions to other drivers to 
-avoid creating any problems. 
-You can use a variety of tools to make proactive decisions while reacting to your environment. 
-One tool is the OODA Loop. It’s a loop because every situation leads to another. 
-Observe. Observe the situation. What changed? Is there a car swerving, a sudden obstacle, or 
-a change in traffic flow? 
-Orient. Use your knowledge and experience to understand what that change means. How does 
-it affect your safety and the safety of others? What are the potential risks if you don’t change? 
-What opportunities present themselves if you do? 
-Decide. Based on your observations and understanding, choose the safest course of action. 
-Should you slow down, change lanes, or signal your intentions? 
+REPORTING ROAD RAGE
+Report in-progress road rage incidents immediately by 
+calling 911.
+Reducing incidents of road rage and aggressive driving is 
+critical to the mission of the Washington State Patrol. While 
+troopers and other law enforcement agencies are always on the 
+lookout for aggressive driving, steps to improve traffic safety in 
+Washington are made when residents act.
+If you have witnessed or been a victim of an aggressive driving 
+act, please call 911 and provide the following information:
+•	
+Location vehicles were last seen
+•	
+Plate number (if known)
+•	
+Direction of travel (toward where)
+•	
+Road or highway
+•	
+Colors of the vehicles
+•	
+Weapons involved (if applicable)
+•	
+Summary of what happened
+•	
+Role in incident (victim or witness)
+3.2  |  INFORMED DECISIONS ON THE ROAD
+Being a safe and responsible driver requires more than knowing 
+the rules of the road. It involves making informed decisions in 
+every situation you encounter while driving. Whether you realize 
+it or not, you make thousands of decisions every day. Some of 
+the most important ones you make will be when you’re behind 
+the wheel.
+ 
 
-Act. Smoothly and decisively execute your chosen action. Remember, clear communication is 
-crucial for others to understand your intentions. 
-As you build experience, you will be able to navigate the OODA loop with ease. However, there 
-are many variables when you’re driving. You will always need to stay alert and ready. 
-3.4: Avoiding distracted driving 
-Distracted driving is a serious concern posing risks for everyone on or near the road. It disrupts 
-the awareness, judgment, and skill needed to drive safely. Distractions inside and outside the 
-vehicle can affect your ability to react and navigate appropriately. 
-Distractions come in all shapes and sizes: 
-Inside the vehicle. Cell phones, eating, adjusting the radio, and interacting with passengers. 
-Outside the vehicle. Billboards, crashes, and other people’s behaviors. 
-Physical distractions. Fatigue, discomfort, and physical impairments. 
-Mental distractions. Daydreaming, worrying, and strong emotions. 
-Distracted drivers are more prone to: 
-Swerving out of their lane. 
-Speeding or driving too slowly. 
-Failing to see traffic signals, stop signs, motorcyclists, bicyclists, or pedestrians. 
-Following too closely to other vehicles or cyclists in the lane. 
-Strategies to avoid distractions: 
-Plan ahead. 
-Put your phone away. 
-Be observant. 
-By keeping your full attention on the road, you can: 
-React faster. 
-Make better decisions. 
-Improve situational awareness. 
-Reduce stress and fatigue. 
-Washington's distracted driving laws 
-Distracted driving is any activity that takes a person’s attention away from the primary task of 
-driving. All distractions endanger the driver, passengers, and others who share the road, 
-including pedestrians.  
+WHY INFORMED DECISIONS MATTER
+Every action you take behind the wheel is a decision, from 
+changing lanes to merging onto a highway. Making informed 
+decisions means considering all the factors involved before 
+acting. This leads to smoother, safer driving for yourself and 
+others. Informed decisions can:
+1.	 Increase awareness. Making informed decisions 
+requires constant analysis of your surroundings. This 
+improves your overall situational awareness.
+2.	 Promote responsible driving. Understanding the 
+consequences of your choices encourages responsible 
+behavior. It also shows respect for other road users. 
+3.	 Reduce crashes. Anticipating potential problems will 
+help you reduce the risk of collisions. 
+Informed decisions are impacted by your:
+•	
+Knowledge of traffic laws.
+•	
+Experience with safe driving practices.
+•	
+Capabilities based on age and brain development.
+Teen drivers need to remember the part of their brain 
+responsible for judgment and decision making is still 
+developing. This means teens can be more prone to taking risks 
+or miscalculating situations. All drivers need to prioritize safety-
+focused decisions over speed and social pressures. This is 
+especially true for teens.
+Older drivers want to be aware that physical and mental 
+capabilities change with age. Older drivers can be more 
+susceptible to serious injuries in vehicle crashes, but many 
+remain safe and competent drivers well into their later years. 
+Regardless of age or experience, all drivers must commit to 
+staying focused and engaged every time they are behind 
+the wheel.
 
-Washington State has strict laws against distracted driving. You cannot hold any electronic 
-device while driving (like cell phones, tablets, or gaming devices). This applies to all drivers, 
-regardless of age or experience. Using hands-free devices is permitted, but anything that takes 
-your eyes and mind off the road can still be dangerous. The notifications, bright lights, and 
-visual cues of your phone are all significant distractions. Take a moment to recognize how 
-distractions impact your driving. 
-A law enforcement officer can issue you a ticket for violating the distracted driving law. This 
-might result in heavy fines. Fines after your first violation can be doubled.  
-Driving is a huge responsibility. Please choose to focus on the road and become part of the 
-solution to end distracted driving. It might seem like “everybody does it” but studies show that’s 
-not true. Your decision will keep you and others safe. 
-3.5: Smart drivers 
-Smart drivers are: 
-Aware of what’s happening inside and outside the vehicle. 
-Able to control their vehicle gas, brake, steering, and position. 
-Predictable to others with signaling and smooth movements. 
-Thoughtful with their decision making. 
-Intentional when learning and using driving skills. 
-Pay Attention 
-When you’re a new driver, the number of things you must pay attention to feels overwhelming: 
-your vehicle, rules of the road, hazards, other vehicles, signs, road markings, pedestrians, 
+MAKE GOOD DECISIONS
+Good decisions are informed decisions. To make good 
+decisions, you must be aware of what’s going on around you. 
+1.	 Inform yourself with mirror checks. Be aware of the whole 
+situation, including people around you who might be 
+affected by your decisions. Inform others of what you 
+intend to do so they become aware of your intentions and 
+can prepare for them. 
+2.	 Prepare the vehicle so you arrive at the hazard in the right 
+road position and at the right speed. 
+3.	 Do a final check before maneuvering. 
+This approach can be applied to any situation that requires 
+you to make a change. You should always aim to be aware, 
+predictable, and smooth.
+3.3  |  PROBLEM SOLVING ON THE ROAD
+Unexpected situations are inevitable and responding to these 
+situations requires problem solving. It’s likely that solving 
+problems on the road will require you to make thoughtful 
+changes like:
+•	
+Modifying your speed.
+•	
+Adjusting your lane position to reduce risk and 
+avoid hazards.
+•	
+Changing your direction or path-of-travel to get to a safe 
+place to reassess the situation.
+Try not to surprise other people on the road. Communicate your 
+intentions to other drivers to avoid creating any problems. 
+
+You can use a variety of tools to make proactive decisions while 
+reacting to your environment. One tool is the OODA Loop. It’s a 
+loop because every situation leads to another. Diagram of the OODA Loop divi
+1.	 Observe. Observe the situation. What changed? Is there 
+a car swerving, a sudden obstacle, or a change in traffic 
+flow?
+2.	 Orient. Use your knowledge and experience to 
+understand what that change means. How does it 
+affect your safety and the safety of others? What are the 
+potential risks if you don’t change? What opportunities 
+present themselves if you do?
+3.	 Decide. Based on your observations and understanding, 
+choose the safest course of action. Should you slow 
+down, change lanes, or signal your intentions?
+4.	 Act. Smoothly and decisively execute your chosen 
+action. Remember, clear communication is crucial for 
+others to understand your intentions.
+As you build experience, you will be able to navigate the OODA 
+loop with ease. However, there are many variables when you’re 
+driving. You will always need to stay alert and ready.
+
+3.4  |  AVOIDING DISTRACTED DRIVINGCar dashboard with prohibition si
+Distracted driving is a serious concern posing risks for everyone 
+on or near the road. It disrupts the awareness, judgment, and 
+skill needed to drive safely. Distractions inside and outside 
+the vehicle can affect your ability to react and navigate 
+appropriately.
+ 
+Distractions come in all shapes and sizes:
+•	
+Inside the vehicle. Cell phones, eating, adjusting the radio, 
+and interacting with passengers.
+•	
+Outside the vehicle. Billboards, crashes, and other 
+people’s behaviors.
+•	
+Physical distractions. Fatigue, discomfort, and physical 
+impairments.
+•	
+Mental distractions. Daydreaming, worrying, and strong 
+emotions.
+
+Distracted drivers are more prone to:
+•	
+Swerving out of their lane.
+•	
+Speeding or driving too slowly.
+•	
+Failing to see traffic signals, stop signs, motorcyclists, 
+bicyclists, or pedestrians.
+•	
+Following too closely to other vehicles or cyclists in the lane.
+Strategies to avoid distractions:
+•	
+Plan ahead.
+•	
+Put your phone away.
+•	
+Be observant.
+By keeping your full attention on the road, you can:
+•	
+React faster.
+•	
+Make better decisions.
+•	
+Improve situational awareness.
+•	
+Reduce stress and fatigue.
+WASHINGTON’S DISTRACTED DRIVING LAWS
+Distracted driving is any activity that takes a person’s attention 
+away from the primary task of driving. All distractions endanger 
+the driver, passengers, and others who share the road, 
+including pedestrians. 
+Washington State has strict laws against distracted driving. 
+You cannot hold any electronic device while driving (like cell 
+phones, tablets, or gaming devices). This applies to all drivers, 
+regardless of age or experience. Using hands-free devices is 
+permitted, but anything that takes your eyes and mind off the 
+road can still be dangerous. The notifications, bright lights, and 
+visual cues of your phone are all significant distractions. Take a 
+moment to recognize how distractions impact your driving. 
+
+A law enforcement officer can issue you a ticket for violating 
+the distracted driving law. This might result in heavy fines. Fines 
+after your first violation can be doubled. 
+Driving is a huge responsibility. Please choose to focus on 
+the road and become part of the solution to end distracted 
+driving. It might seem like “everybody does it” but studies show 
+that’s not true. Your decision will keep you and others safe. 
+3.5  |  SMART DRIVERS
+Smart drivers are:
+•	
+Aware of what’s happening inside and outside the vehicle.
+•	
+Able to control their vehicle gas, brake, steering, and 
+position.
+•	
+Predictable to others with signaling and smooth 
+movements.
+•	
+Thoughtful with their decision making.
+•	
+Intentional when learning and using driving skills.
+PAY ATTENTION
+When you’re a new driver, the number of things you must pay 
+attention to feels overwhelming: your vehicle, rules of the road, 
+hazards, other vehicles, signs, road markings, pedestrians, 
 bicyclists… Smart drivers find a way to balance their attention. 
-Switching attention. When you quickly switch your focus from one thing to another. 
-Divided attention. When you’re performing several things at the same time. 
-Focused attention. When your whole brain concentrates on one task. 
-Sustained attention. When you need to pay attention for a long time. 
-Things you can do to help you pay attention: 
-Eliminate distractions inside your vehicle. 
-Be well-rested. 
-Put away and silence your electronics. 
-Limit the number of passengers and pets in your vehicle. 
-Resist multitasking behind the wheel. 
-Visually search and scan 
+•	
+Switching attention. When you quickly switch your focus 
+from one thing to another. 
+•	
+Divided attention. When you’re performing several things 
+at the same time.
+•	
+Focused attention. When your whole brain concentrates 
+on one task.
+•	
+Sustained attention. When you need to pay attention for a 
+long time.
 
-Visual searching means using your eyes to actively check your surroundings. Scanning involves 
-also moving your head, neck, and body so that you can see as much as possible around your 
-vehicle. Searching and scanning help your attention skills be aware of the always-changing 
-environment around you: in and outside your vehicle. It’s how you gather information so you can 
-make wise decisions. 
-Constant visual searching supports your ability to drive safely. Make sure you are traveling at a 
-speed that supports your ability to search and scan effectively. 
-Scan to the front 
-To avoid last-minute braking or the need to turn or swerve suddenly, look ahead for: 
-Traffic situations you’ll need to steer around and blockages that might hide a pedestrian, 
-bicyclist, or another vehicle. 
-Feet, wheels, shadows, and movement in, under, and around parked vehicles. 
-What’s happening beyond the vehicle in front of you. 
-Looking ahead allows you to anticipate potential situations and prepares you to stop or change 
-directions if needed.  
-Scan to the side 
-When approaching intersections, pay close attention to vehicles, pedestrians, and cyclists 
-approaching from the left and right. 
-Watch for pedestrians and cyclists who might be crossing the road. 
-When foliage or other objects obscure your view to the sides, watch for movement to identify 
-potential hazards and people who could be planning to cross the road. 
-Before turning, check your side mirrors and do an over-shoulder check for bicyclists or 
-pedestrians who might be alongside you or about to cross the street. 
-Scan behind 
-Besides watching traffic in front of and beside you, check traffic behind you. It is essential to 
-look for vehicles and cyclists behind you when you change lanes, turn across a bicycle lane, 
+Things you can do to help you pay attention:
+•	
+Eliminate distractions inside your vehicle.
+•	
+Be well-rested.
+•	
+Put away and silence your electronics.
+•	
+Limit the number of passengers and pets in your vehicle.
+•	
+Resist multitasking behind the wheel.
+Driver's view of pedestrians at a cros
+VISUALLY SEARCH AND SCAN
+Visual searching means using your eyes to actively check your 
+surroundings. Scanning involves also moving your head, neck, 
+and body so that you can see as much as possible around your 
+vehicle. Searching and scanning help your attention skills be 
+aware of the always-changing environment around you: in and 
+outside your vehicle. It’s how you gather information so you can 
+make wise decisions.
+
+Constant visual searching supports your ability to drive safely. 
+Make sure you are traveling at a speed that supports your ability 
+to search and scan effectively.
+ 
+Scan to the front
+To avoid last-minute braking or the need to turn or swerve 
+suddenly, look ahead for:
+•	
+Traffic situations you’ll need to steer around and blockages 
+that might hide a pedestrian, bicyclist, or another vehicle.
+•	
+Feet, wheels, shadows, and movement in, under, and around 
+parked vehicles.
+•	
+What’s happening beyond the vehicle in front of you.
+ 
+Looking ahead allows you to anticipate potential situations and 
+prepares you to stop or change directions if needed. 
+ 
+Scan to the side
+•	
+When approaching intersections, pay close attention to 
+vehicles, pedestrians, and cyclists approaching from the left 
+and right. 
+•	
+Watch for pedestrians and cyclists who might be crossing 
+the road.
+•	
+When foliage or other objects obscure your view to the 
+sides, watch for movement to identify potential hazards and 
+people who could be planning to cross the road.
+•	
+Before turning, check your side mirrors and do an over-
+shoulder check for bicyclists or pedestrians who might be 
+alongside you or about to cross the street.
+Scan behind
+Besides watching traffic in front of and beside you, check 
+traffic behind you. It is essential to look for vehicles and cyclists 
+behind you when you change lanes, turn across a bicycle lane, 
 slow down, back up, or are driving down a long or steep hill. 
-Check more often when traffic is heavy. If you know someone is following too closely or coming 
-up too fast, you will have time to do something about it (change lanes, tap on the brakes, speed 
-up, or slow down). 
-3.6: Respect and Responsibility 
-Identify and commit yourself to safe, respectful, and responsible driver behavior. 
-Ensure all people in the vehicle use safety restraints. 
-Be fit to drive. 
-Show empathy toward others. 
 
-Respect other road users’ space. 
-Avoid conflict regardless of fault. 
-Take care of the road environment. 
-Traffic advisories 
-Traffic advisories are notifications or alerts given to drivers about current or upcoming traffic 
-conditions, incidents, or road closures. These advisories come from transportation officials, 
-traffic management centers, or navigation apps. 
-Find traffic advisories that will help you make informed decisions about your travel routes. This 
-can help you avoid potential delays or hazards. Traffic advisories are provided in many ways, 
-including electronic road signs, social media, radio broadcasts, traffic websites, and mobile 
-apps. 
-Litter 
-Litter isn’t just ugly. It also creates safety hazards for people using the roads. Litter on roads can 
-cause accidents. Flammable or inflamed litter can spark wildfires, damaging the environment 
-and potentially causing fatalities. This is why fines for littering in Washington are so severe. You 
-and your passengers are responsible for securing items you’re transporting and properly 
-throwing away trash. 
-Washington State law sets minimum fines for littering and illegal dumping. Many cities and 
-counties have local ordinances that differ from state law. Contact your local police department, 
-sheriff’s office, city, or county clerk for information on local litter enforcement and to find out what 
-laws apply in your area. 
-The environment 
-How you drive impacts the environment 
-When you leave your car running while parked, especially in a garage, it can release harmful 
-gases like carbon monoxide, which can be lethal. Idling your engine also adds pollution to the 
-air. 
-By making these small changes, you can help lower vehicle emissions: 
-Turn off your engine if you’re parked for a while. 
-Drive smoothly instead of speeding or braking hard, which uses more fuel. 
-Keep your tires properly inflated for better gas mileage. 
-Carpool or use public transport when possible to reduce the number of cars on the road. 
-What you drive impacts the environment 
-Most vehicle manufacturers have made efforts to reduce carbon footprints through lower 
-emissions, fuel efficiency, and safety features designed to improve traffic flow. Opting to plan 
-efficient routes and carpool with other people supports these efforts (in addition to having 
+Check more often when traffic is heavy. If you know someone is 
+following too closely or coming up too fast, you will have time to 
+do something about it (change lanes, tap on the brakes, speed 
+up, or slow down).
+3.6 | RESPECT AND RESPONSIBILITY
+Identify and commit yourself to safe, respectful, and responsible 
+driver behavior.
+•	
+Ensure all people in the vehicle use safety restraints.
+•	
+Be fit to drive.
+•	
+Show empathy toward others.
+•	
+Respect other road users’ space.
+•	
+Avoid conflict regardless of fault.
+•	
+Take care of the road environment.
+TRAFFIC ADVISORIES
+Traffic advisories are notifications or alerts given to drivers 
+about current or upcoming traffic conditions, incidents, or road 
+closures. These advisories come from transportation officials, 
+traffic management centers, or navigation apps.
+Find traffic advisories that will help you make informed 
+decisions about your travel routes. This can help you avoid 
+potential delays or hazards. Traffic advisories are provided in 
+many ways, including electronic road signs, social media, radio 
+broadcasts, traffic websites, and mobile apps.
+ 
 
-economic benefits). Washington’s Clean Car Law requires vehicles made in 2009 and later to 
-meet strict clean air standards before they can be registered, licensed, or sold.  
-If you need to dispose of a vehicle or vehicle parts, contact a vehicle disposal recycling center to 
-help you do this in an environmentally conscious way. 
-Self-evaluation 
-Self-evaluation is a quick, easy, and important part of being a responsible driver. It can be done 
-during or after the drive. Ask yourself the following questions: 
+LITTER
+Litter isn’t just ugly. It also creates safety hazards for people 
+using the roads. Litter on roads can cause accidents. 
+Flammable or inflamed litter can spark wildfires, damaging 
+the environment and potentially causing fatalities. This is 
+why fines for littering in Washington are so severe. You and 
+your passengers are responsible for securing items you’re 
+transporting and properly throwing away trash.
+Washington State law sets minimum fines for littering and illegal 
+dumping. Many cities and counties have local ordinances that 
+differ from state law. Contact your local police department, 
+sheriff’s office, city, or county clerk for information on local litter 
+enforcement and to find out what laws apply in your area.
+THE ENVIRONMENT
+How you drive impacts the environment
+When you leave your car running while parked, especially in 
+a garage, it can release harmful gases like carbon monoxide, 
+which can be lethal. Idling your engine also adds pollution to 
+the air.
+By making these small changes, you can help lower vehicle 
+emissions:
+•	
+Turn off your engine if you’re parked for a while.
+•	
+Drive smoothly instead of speeding or braking hard, which 
+uses more fuel.
+•	
+Keep your tires properly inflated for better gas mileage.
+•	
+Carpool or use public transport when possible to reduce the 
+number of cars on the road.
+What you drive impacts the environment
+Most vehicle manufacturers have made efforts to reduce  
+carbon footprints through lower emissions, fuel efficiency, and 
+
+safety features designed to improve traffic flow. Opting to plan 
+efficient routes and carpool with other people supports these 
+efforts (in addition to having economic benefits). Washington’s 
+Clean Car Law requires vehicles made in 2009 and later to 
+meet strict clean air standards before they can be registered, 
+licensed, or sold. 
+If you need to dispose of a vehicle or vehicle parts, contact 
+a vehicle disposal recycling center to help you do this in an 
+environmentally conscious way.
+SELF-EVALUATION 
+Self-evaluation is a quick, easy, and important part of being a 
+responsible driver. It can be done during or after the drive. Ask 
+yourself the following questions:
+•	
 Did anything surprise me? 
+•	
 Did I surprise anyone? 
-Was my driving legal, proficient, and smooth? 
-What changes do I need to make for next time? 
-Regularly reviewing your driving skills at the end of each drive not only helps you improve your 
-abilities but also helps you maintain your skills once they are developed. Skills deteriorate over 
-time, so regularly evaluating keeps you driving at your best. 
-To keep your skills fresh, identify: 
-Factors that contribute to changes in your driving skills. 
-Changes in driving practices. 
-Changes in traffic laws. 
-Changes and advancements in vehicle technology. 
-Opportunities for lifelong learning related to driving. 
- 
-Chapter 4: Roads 
-4.0: Awareness and cooperation 
-Think of all the reasons people use Washington roadways: to visit family, to take sick kids to the 
-doctor, or to get home after a difficult day at work. Washington roads are used by people just 
-like you, and the road system relies on the cooperation and shared understanding of the people 
-who use it. You expect others to know and follow the rules of the road. They expect the same of 
-you. 
-Sometimes roads can be confusing. For example, they could be under construction or crowded 
-with vehicles, trucks, motorcycles, bicyclists, and pedestrians. There are moments that might 
-require you to be more patient and thoughtful. You might find it easier to navigate the road if you 
-remember life can be hard and most people are doing their best. 
-The key is courtesy, respect, and awareness of others. Your care and consideration could save 
-someone or yourself from serious injury or death. 
-4.1: Sharing with people 
+•	
+Was my driving legal, proficient, and smooth?
+•	
+What changes do I need to make for next time?
+Regularly reviewing your driving skills at the end of each drive 
+not only helps you improve your abilities but also helps you 
+maintain your skills once they are developed. Skills deteriorate 
+over time, so regularly evaluating keeps you driving at your best.
+To keep your skills fresh, identify:
+•	
+Factors that contribute to changes in your driving skills.
+•	
+Changes in driving practices.
+•	
+Changes in traffic laws.
+•	
+Changes and advancements in vehicle technology.
+•	
+Opportunities for lifelong learning related to driving.
 
-Always yield to pedestrians.    
-Pedestrians and bicyclists have the right-of-way at crosswalks and intersections whether the 
-road is marked or not. 
-Wait until a pedestrian has cleared your lane and one additional lane before proceeding. If the 
-pedestrian is using a wheelchair, cane, guide dog, or other service animal, wait until they have 
-completely crossed the street before continuing. 
-Don’t drive into oncoming traffic to pass a pedestrian or bicyclist. 
-Look for people who:  
-Can’t see you, such as people behind buildings or cars, pedestrians with their back to you, and 
-people wearing hats or using umbrellas. 
-Are distracted, such as children, delivery persons, road workers, and pedestrians on their phone 
-or wearing headphones. 
-Might be confused, such as tourists and people following a map or looking for a new location. 
-Are using a wheelchair, cane, or service animal. It’s unlawful to interfere with a service animal. 
-Don’t honk. It could confuse or frighten the animal or pedestrian. 
-4.2: Sharing with school buses 
-The loading and unloading of a school bus is a potentially dangerous situation. 
-School-aged children are not always predictable or aware of danger. Make sure you’re 
-thoughtful and cautious of children as they get on and off the school bus. Be patient and follow 
-the speed limit and the school bus signals. 
-School bus lights are like traffic signals: Red means stop, and yellow means caution or slow 
-down. 
-Fines are doubled for anyone who passes a stopped school bus. 
+Chapter 4
+ Road
+s image o
+f a h
+ighway with a school bus and a truck, road signs, and power lines.
+
+4.0  |  AWARENESS AND COOPERATION
+Think of all the reasons people use Washington roadways: to 
+visit family, to take sick kids to the doctor, or to get home after 
+a difficult day at work. Washington roads are used by people 
+just like you, and the road system relies on the cooperation and 
+shared understanding of the people who use it. You expect 
+others to know and follow the rules of the road. They expect the 
+same of you.
+Sometimes roads can be confusing. For example, they could 
+be under construction or crowded with vehicles, trucks, 
+motorcycles, bicyclists, and pedestrians. There are moments 
+that might require you to be more patient and thoughtful. You 
+might find it easier to navigate the road if you remember life can 
+be hard and most people are doing their best.
+The key is courtesy, respect, and awareness of others. Your care 
+and consideration could save someone or yourself from serious 
+injury or death.
+4.1  |  SHARING WITH PEOPLE
+Always yield to pedestrians.
+Pedestrians and bicyclists have the right-of-way at crosswalks 
+and intersections whether the road is marked or not. 
+•	
+Wait until a pedestrian has cleared your lane and one 
+additional lane before proceeding. If the pedestrian is using 
+a wheelchair, cane, guide dog, or other service animal, 
+wait until they have completely crossed the street before 
+continuing.
+•	
+Don’t drive into oncoming traffic to pass a pedestrian or 
+bicyclist. 
+
+Look for people who: 
+•	
+Can’t see you, such as people behind buildings or cars, 
+pedestrians with their back to you, and people wearing hats 
+or using umbrellas.
+•	
+Are distracted, such as children, delivery persons, road 
+workers, and pedestrians on their phone or wearing 
+headphones.
+•	
+Might be confused, such as tourists and people following 
+a map or looking for a new location.
+•	
+Are using a wheelchair, cane, or service animal. It’s 
+unlawful to interfere with a service animal. Don’t honk. It 
+could confuse or frighten the animal or pedestrian.
+4.2  |  SHARING WITH SCHOOL BUSESSide view of a yellow s
+The loading and unloading of a school bus is a 
+potentially dangerous situation.
+School-aged children are not always predictable or aware of 
+danger. Make sure you’re thoughtful and cautious of children 
+as they get on and off the school bus. Be patient and follow the 
+speed limit and the school bus signals. 
+School bus lights are like traffic signals: Red means stop, and 
+yellow means caution or slow down.
+
+Yellow school bus with lights flashing and a stop sign extended. A red barn and a green landscape in the background. A notice reads, "Fines are doubled for anyone that passes a stopped school bus."
+DID 
+YOU 
+KNOW?
+Fines are doubled 
+for anyone who 
+passes a stopped 
+school bus. 
+WHEN YOU ARE BEHIND THE BUS
 It’s unlawful to pass when red lights flash. 
-Never pass a school bus with flashing lights. The lights and sign tell you that children are near 
-and getting on/off the bus. 
-All drivers traveling in the same direction as the bus must stop when the red lights flash, and the 
-stop sign is extended. 
-Don’t use a center turn lane to pass a school bus. Drivers in all turn lanes must stop. 
-You may go after the lights stop flashing, the sign is retracted, and the metal arm returns to the 
-front bumper of the bus. 
-Continue to watch for children even after the red lights have stopped flashing. 
-When you are in front of the bus 
-On a 2-lane road 
+Never pass a school bus with flashing lights. The lights and sign 
+tell you that children are near and getting on/off the bus. 
+•	
+All drivers traveling in the same direction as the bus must 
+stop when the red lights flash, and the stop sign is extended. 
+•	
+Don’t use a center turn lane to pass a school bus. Drivers in 
+all turn lanes must stop.
+•	
+You may go after the lights stop flashing, the sign is 
+retracted, and the metal arm returns to the front bumper of 
+the bus.
+•	
+Continue to watch for children even after the red lights have 
+stopped flashing. 
 
-All vehicles must stop when the red lights flash and the stop sign extends. You can resume 
-traveling in the opposite direction when the lights stop flashing, the sign is retracted, and the 
-metal arm returns to the front bumper of the bus.  
-On a multilane road 
-Drivers traveling behind the bus must stop when the red lights flash and the stop sign extends. 
-Drivers traveling in the opposite direction as the bus don’t need to stop when the red lights flash 
-or the stop sign extends IF: 
-There are three or more lanes. 
-Lanes are separated by a median or barrier. 
-4.3: Sharing with transit buses 
-Yield to any transit vehicle traveling in the same direction as you that has signaled and is pulling 
-back onto the roadway. 
-4.4: Sharing with large vehicles 
-Safely sharing the road with large trucks and buses requires knowledge of their special 
-limitations. You need more time and space when driving around large vehicles. When you are 
-near large vehicles on the road, pay special attention to the following: 
-Visibility. When following large vehicles, adjust your following distance so you have a wide view 
-of the roadway ahead.  
-Blind zones. If you are near a large vehicle and can’t see the driver’s mirrors, the driver can’t 
-see you. There are blind zones on each side of large vehicles where the driver cannot see you. 
-Avoid driving alongside large vehicles for too long.   
-Stopping. Large vehicles can’t stop as quickly as smaller vehicles. It takes a loaded truck with 
-properly adjusted brakes, traveling at 55 mph, 450 feet to come to a complete stop. Cutting in 
-front of them without enough space is dangerous for everyone. 
-Merging. When entering traffic ahead of a large vehicle, wait until you can clearly see both of 
-their headlights in your rearview mirror before merging in front of them. After merging, maintain 
-the flow of traffic to reduce impacts on other drivers.  
-Turning space. To avoid hitting something, large vehicles might require more than one lane to 
-complete a turn. They also need 2 lanes of space in a roundabout. Don’t pass a large vehicle 
-when the driver is turning. This is a frequent cause of collisions involving large vehicles. Be 
-patient and wait until their turn is complete before moving ahead.  
-Hazardous materials. As you’re driving, be aware of vehicles with signs indicating they’re 
-carrying hazardous materials. Avoid driving near them when possible. 
-Long, steep grades. When traveling up or down steep roads, large vehicles travel slowly. Be 
-prepared to encounter slow vehicles in the right lane. 
-Snowplows 
+School bus stopped on a multi-lane road with stop signs and cars halted in adjacent lanes.
+ 
+WHEN YOU ARE IN FRONT OF THE BUS 
+On a 2-lane road
+All vehicles must stop when the red lights flash and the 
+stop sign extends. You can resume traveling in the opposite 
+direction when the lights stop flashing, the sign is retracted, and 
+the metal arm returns to the front bumper of the bus. A stopped school bus with flashing lights and stop sign extended in front and rear views, with surrounding vehicles halted and prominent stop signs displayed.The top segment shows a yellow s
 
-Use caution when driving near snow removal equipment. Snowplows can force snow up and off 
-the road, causing blizzard-like conditions. This can reduce visibility for drivers following too 
-closely. 
-4.5: Sharing with motorcycles 
-Motorcyclists have the same rights and responsibilities as other road users. They obey the 
-same traffic laws. However, because motorcycles are small vehicles, they’re more vulnerable 
-and harder to see. Make it a habit to scan for motorcycles and be cautious around them.    
-Following 
-Leave a lot of room to stop in front of you when you’re following a motorcycle. You want to have 
-enough time to safely stop in an emergency. Weather conditions and slippery surfaces can be 
-serious problems for motorcyclists. Allow even more following room when it’s raining or the road 
-surface is slick. 
-Lanes 
-Motorcyclists are constantly changing positions within their lane, so they can see and be seen, 
-and to avoid objects in the road. They’re entitled to the same lane width as all other vehicles. 
-Never move into the same lane alongside a motorcyclist, even if the lane is wide and the 
-motorcyclist is riding far to one side. 
-Turning 
-Motorcyclists are often hidden or missed in blind zones. Do an over-the-shoulder check to make 
-sure your blind zone is clear. For example, if you are turning right, look left, look right, then look 
-left again. Looking twice can save a life. Drivers pulling into a lane in front of a motorcycle or 
-turning in front of an oncoming motorcycle might not see the motorcycle. They could also 
-misjudge the speed of the oncoming motorcycle. 
-Road surface 
-Bumpy road surfaces and irregularities that don’t affect other drivers, such as gravel, debris, 
-pavement seams, small animals, potholes, and even manhole covers, can force a motorcyclist 
-to change speed or lane position. Anticipate changes a motorcyclist might need to make. 
-Lights 
-Your lights 
-Give motorcyclists plenty of time to notice your turn signals and brake lights.  
-Motorcyclists’ lights 
-When slowing down, motorcyclists might use the throttle and not their brakes, so brake lights 
-wouldn’t be visible. Additionally, some motorcycles don’t have turn signals that turn off 
-automatically. Make sure you’re alert and paying careful attention when driving alongside a 
-motorcycle.   
-For more information about riding motorcycles, search for motorcycle operator manual on this 
-website. 
+On a multilane road
+•	
+Drivers traveling behind the bus must stop when the red 
+lights flash and the stop sign extends.
+•	
+Drivers traveling in the opposite direction as the bus don’t 
+need to stop when the red lights flash or the stop sign 
+extends IF:
+	
+○
+There are three or more lanes.
+	
+○
+Lanes are separated by a median or barrier.A top-down illustration showing a multi-lane road with various vehicles, traffic signs, and road markings. The road is divided into three lanes, separated by solid yellow lines and dashed white lines.In the top lane, there is a yell
 
-4.6: Sharing with bicyclists 
-Bicyclists have the same rights, duties, and responsibilities as a vehicle driver. Like motorcycles, 
-bicycles are small and less visible, which increases riders’ risk of being struck by a driver and 
-seriously injured or killed. 
-General guidance 
-When turning a corner or pulling into a driveway, watch for bicyclists who are in the crosswalk or 
-on the sidewalk. 
+ Side view of a blue and yellow city transit bus with mountains in the background.
+4.3  |  SHARING WITH TRANSIT BUSES
+Yield to any transit vehicle traveling in the same direction as you 
+that has signaled and is pulling back onto the roadway.
+4.4  |  SHARING WITH LARGE VEHICLES
+Safely sharing the road with large trucks and buses requires 
+knowledge of their special limitations. You need more time 
+and space when driving around large vehicles. When you are 
+near large vehicles on the road, pay special attention to the 
+following: 
+Visibility. When following large vehicles, adjust your following 
+distance so you have a wide view of the roadway ahead. 
+Blind zones. If you are near a large vehicle and can’t see the 
+driver’s mirrors, the driver can’t see you. There are blind zones 
+on each side of large vehicles where the driver cannot see you. 
+Avoid driving alongside large vehicles for too long.
+Stopping. Large vehicles can’t stop as quickly as smaller 
+vehicles. It takes a loaded truck with properly adjusted brakes, 
+traveling at 55 mph, 450 feet to come to a complete stop. 
+Cutting in front of them without enough space is dangerous 
+for everyone.
+
+Merging. When entering traffic ahead of a large vehicle, 
+wait until you can clearly see both of their headlights in your 
+rearview mirror before merging in front of them. After merging, 
+maintain the flow of traffic to reduce impacts on other drivers. 
+Turning space. To avoid hitting something, large vehicles 
+might require more than one lane to complete a turn. They 
+also need 2 lanes of space in a roundabout. Don’t pass a large 
+vehicle when the driver is turning. This is a frequent cause of 
+collisions involving large vehicles. Be patient and wait until their 
+turn is complete before moving ahead. 
+Hazardous materials. As you’re driving, be aware of vehicles 
+with signs indicating they’re carrying hazardous materials. Avoid 
+driving near them when possible.
+Long, steep grades. When traveling up or down steep roads, 
+large vehicles travel slowly. Be prepared to encounter slow 
+vehicles in the right lane.
+ A multi-lane road depicting a large truck in the center lane with surrounding blind spots and colored cars in adjacent lanes. To the immediate right of the truck, in an adjacent lane, there is a white car with a marked distance of 20 feet. To the left of the truck, also in an adjacent lane, there is a blue car with a marked distance of 30 feet. A red car is positioned behind the truck in the same lane, and a green car is shown to the left in a different lane. The dark triangular shadow areas surrounding the truck indicate the blind spots where the truck driver has limited visibility. Yellow dashed and solid lines mark the lanes and text is conveyed with various warnings regarding blind spots and lanes.
+
+SNOWPLOWS
+Use caution when driving near snow removal equipment. 
+Snowplows can force snow up and off the road, causing 
+blizzard-like conditions. This can reduce visibility for drivers 
+following too closely.
+4.5  |  SHARING WITH MOTORCYCLES 
+Motorcyclists have the same rights and responsibilities as other 
+road users. They obey the same traffic laws. However, because 
+motorcycles are small vehicles, they’re more vulnerable and 
+harder to see. Make it a habit to scan for motorcycles and be 
+cautious around them.
+ Road with a motorcycle and a green car following it by "3-4 Seconds."
+FOLLOWING
+Leave a lot of room to stop in front of you when you’re following 
+a motorcycle. You want to have enough time to safely stop in an 
+emergency. Weather conditions and slippery surfaces can be 
+serious problems for motorcyclists. Allow even more following 
+room when it’s raining or the road surface is slick.
+ Four-lane road, divided by dashed white lines. There are two motorcycles in the second lane from the left, traveling in the same direction. One of the motorcycles is slightly ahead of the other. Image shows that motorcycles may travel side-by-side but it's important for other vehicles to give them plenty of space.
+
+LANES
+Motorcyclists are constantly changing positions within their 
+lane, so they can see and be seen, and to avoid objects 
+in the road. They’re entitled to the same lane width as all 
+other vehicles. Never move into the same lane alongside a 
+motorcyclist, even if the lane is wide and the motorcyclist is 
+riding far to one side.
+ Motorcycle approaching as seen in a car's side mirror.
+ 
+TURNING
+Motorcyclists are often hidden or missed in blind zones. Do an 
+over-the-shoulder check to make sure your blind zone is clear. 
+For example, if you are turning right, look left, look right, then 
+look left again. Looking twice can save a life. Drivers pulling into 
+a lane in front of a motorcycle or turning in front of an oncoming 
+motorcycle might not see the motorcycle. They could also 
+misjudge the speed of the oncoming motorcycle.
+ROAD SURFACE
+Bumpy road surfaces and irregularities that don’t affect other 
+drivers, such as gravel, debris, pavement seams, small animals, 
+potholes, and even manhole covers, can force a motorcyclist 
+to change speed or lane position. Anticipate changes a 
+motorcyclist might need to make.
+
+LIGHTS
+Your lights. Give motorcyclists plenty of time to notice your 
+turn signals and brake lights. 
+ 
+Motorcyclists’ lights. When slowing down, motorcyclists might 
+use the throttle and not their brakes, so brake lights wouldn’t be 
+visible. Additionally, some motorcycles don’t have turn signals 
+that turn off automatically. Make sure you’re alert and paying 
+careful attention when driving alongside a motorcycle.
+For more information about riding motorcycles, visit dol.wa.gov 
+and search for motorcycle operator manual. 
+4.6  |  SHARING WITH BICYCLISTS
+Bicyclists have the same rights, duties, and responsibilities as 
+a vehicle driver. Like motorcycles, bicycles are small and less 
+visible, which increases riders’ risk of being struck by a driver 
+and seriously injured or killed.Cyclist and red car on a city street with 
+
+GENERAL GUIDANCE
+•	
+When turning a corner or pulling into a driveway, watch for 
+bicyclists who are in the crosswalk or on the sidewalk.
+•	
 At intersections, yield to bicyclists as you would to a vehicle. 
-You cannot share a lane with a bicyclist. Legally, bicyclists may use the full lane and ride where 
-they’re most visible to you and other drivers. When you’re driving behind a bicyclist, leave at 
-least 3 feet of space. 
-Bicyclists in crosswalks are considered pedestrians. You must yield to them in both marked and 
-unmarked crosswalks and intersections. 
-Passing a bicyclist 
+•	
+You cannot share a lane with a bicyclist. Legally, bicyclists 
+may use the full lane and ride where they’re most visible 
+to you and other drivers. When you’re driving behind a 
+bicyclist, leave at least 3 feet of space..
+•	
+Bicyclists in crosswalks are considered pedestrians. You 
+must yield to them in both marked and unmarked crosswalks 
+and intersections.
+PASSING A BICYCLIST 
+•	
 Don’t pass until it’s safe for you and the bicyclist. 
-Move over one full lane if there are two lanes in the same direction. If there’s only 1 lane in each 
-direction, move into the other lane when there isn’t any oncoming traffic. Leave at least 3 feet 
-between the bicyclist and the widest part of your vehicle. (Remember the bicyclist might need to 
-change their position to avoid a hazard you can’t see.) 
+•	
+Move over one full lane if there are two lanes in the same 
+direction. If there’s only 1 lane in each direction, move into 
+the other lane when there isn’t any oncoming traffic. Leave 
+at least 3 feet between the bicyclist and the widest part of 
+your vehicle. (Remember the bicyclist might need to change 
+their position to avoid a hazard you can’t see.) 
+•	
 Never cross into oncoming traffic to pass a bicyclist. 
-Pass slowly on the bicyclist’s left side and never into oncoming traffic. 
-Make sure you’re clear of the bicyclist before returning to the lane. Moving over too soon could 
-put the bicyclist in danger. 
-Let the bicyclist clear the intersection before making a turn. If you’re going to turn right, don’t 
-pass a bicyclist just before the turn. 
-Bike lanes 
-Watch for bicycle lanes, which are typically painted green, use solid white lines, and are marked 
-with a bicycle symbol. Although bike lane markings vary in length, you should drive as though 
-the markings continue. 
-Drive in bicycle lanes only when turning or crossing the lane to park near the curb. 
-Look carefully in all directions for a bicyclist after you park and before opening your door. 
-For more information about riding bicycles, visit wsdot.wa.gov and search for bicycling and 
-walking. 
-4.7: Sharing the road with trains 
-Railroad tracks deserve careful attention. 
+•	
+Pass slowly on the bicyclist’s left side and never into 
+oncoming traffic. 
+•	
+Make sure you’re clear of the bicyclist before returning to 
+the lane. Moving over too soon could put the bicyclist in 
+danger.
+•	
+Let the bicyclist clear the intersection before making a turn. 
+If you’re going to turn right, don’t pass a bicyclist just before 
+the turn.
 
-Only drive across railroad tracks at designated crossings. Look for safety signage, flashing 
-lights, and crossing gates. Flashing red lights at a railroad crossing means a train is 
-approaching and you need to stay outside of the gates.  
-Trains ALWAYS have the right-of-way. They are heavy and cannot stop quickly even if they are 
-traveling at low speeds. It can take up to a mile for a train to come to a full stop. 
-When lights are flashing and bells are ringing at a train crossing, you must stop — whether the 
-gate is down or not. Never drive around the gate. 
-Stop between 15 and 50 feet away from the nearest rail of a crossing when: 
+BIKE LANES
+•	
+Watch for bicycle lanes, which are typically painted green, 
+use solid white lines, and are marked with a bicycle symbol. 
+Although bike lane markings vary in length, you should drive 
+as though the markings continue.
+•	
+Drive in bicycle lanes only when turning or crossing the lane 
+to park near the curb.
+•	
+Look carefully in all directions for a bicyclist after you park 
+and before opening your door.
+For more information about riding bicycles, visit wsdot.wa.gov 
+and search for bicycling and walking.
+4.7  |  SHARING THE ROAD WITH TRAINS
+Railroad tracks deserve careful attention.
+ Red car stopped at a railroad crossing with a train passing and crossing signals active.
+Only drive across railroad tracks at designated crossings. Look 
+for safety signage, flashing lights, and crossing gates. Flashing 
+red lights at a railroad crossing means a train is approaching 
+and you need to stay outside of the gates. 
+
+Trains ALWAYS have the right-of-way. They are heavy and 
+cannot stop quickly even if they are traveling at low speeds. It 
+can take up to a mile for a train to come to a full stop.
+When lights are flashing and bells are ringing at a 
+train crossing, you must stop — whether the gate is 
+down or not. Never drive around the gate. 
+Stop between 15 and 50 feet away from the nearest rail of a 
+crossing when:
+•	
 The signal is flashing. 
+•	
 The crossing gate is lowering or already down. 
-A flagger is giving a signal to stop. 
-A train is approaching so closely as to create an immediate hazard. 
-You hear a train’s warning horn. 
-A stop sign is posted. 
-You can go when the red lights stop flashing and all other warning signs deactivate. 
-Important safety reminders 
-Do not try to beat a train across the tracks. As soon as the warnings have been activated: stop. 
-Do not stop on the tracks. If your vehicle gets stuck at a crossing, get everyone out immediately. 
-Do not disregard warning signals. Even if you don’t see a train, trust the signals. Trains might be 
-closer, quieter, and moving faster than they appear. Trains can come from either direction and 
-run on any track. 
-When to call for help 
-If there is anything on or close to the railroad tracks, call the number on the blue and white 
-Emergency Notification System sign. Give the crossing ID number to the dispatcher. Let them 
-know your location and the details of the situation. No sign? Dial 911. 
-Light rail 
-Sound Transit’s Link light rail line is a critical element of Washington’s long-term transportation 
-network. Here are some guidelines for driving near rail stations and lines:   
-Pay attention to all signs and road markings. 
-Be alert and watch for approaching light rail trains. 
-Leave at least one car length (or more) between your vehicle and light rail trains. 
-Do not stop, park, or leave your car on the tracks! Park with plenty of room for rail trains to get 
-around you. 
-4.8: Sharing with agricultural vehicles 
+•	
+A flagger is giving a signal to stop.
+•	
+A train is approaching so closely as to create an immediate 
+hazard. 
+•	
+You hear a train’s warning horn.
+•	
+A stop sign is posted.
+You can go when the red lights stop flashing and all other 
+warning signs deactivate.
+IMPORTANT SAFETY REMINDERS
+Do not try to beat a train across the tracks. 
+As soon as the warnings have been activated: stop.
+Do not stop on the tracks. 
+If your vehicle gets stuck at a crossing, get everyone out 
+immediately.
+Do not disregard warning signals. 
+Even if you don’t see a train, trust the signals. Trains might 
+be closer, quieter, and moving faster than they appear. 
+Trains can come from either direction and run on any track.
 
-Agricultural and farm vehicles designed to go 25 mph or less will have a triangle sign or emblem 
-on the back. When you see a slow moving vehicle, remember to: 
-Be patient and slow down. 
-Give plenty of space and use caution when passing. 
-If you need to pass an agricultural vehicle and there are two lanes in the same direction, move 
-over one full lane. If there is only one lane in each direction, look for oncoming traffic and 
-proceed carefully. As you pass, there should be at least 3 feet between the widest part of your 
-vehicle and the agricultural vehicle. 
-4.9: Sharing with emergency vehicles 
-Fire trucks, ambulances, and police cars using lights and/or sirens always have the right-of-
-way.  
-As soon as you see or hear the signals, immediately pull your vehicle to the right side of the 
-road and stop. Wait until the emergency vehicle has passed before signaling and reentering 
-traffic. You should reenter traffic in the order you were traveling before. Wait until the emergency 
-vehicle has passed before signaling and reentering traffic. You should reenter traffic in the order 
-you were traveling before. By moving to the right, you help emergency vehicle drivers do their 
-job and could help save a life!  
-4.10: Traffic laws 
-The rules of the road are designed to keep people safe. They prevent traffic incidents by 
-establishing the rules everyone agrees to follow when they use the road. The laws exist to keep 
-road systems moving smoothly.   
-For the most part, the fundamental rules of the road stay the same. However, traffic laws can 
-change. You can find the most current rules of the road by searching RCW 46.61 online. For as 
-long as you drive, it is your responsibility to stay informed about the most current rules of the 
-road.  
-General driving guidance 
-As a driver in Washington state, it’s a good idea to keep this general driving guidance in mind: 
-Drive on the right side of the road. The only time you might temporarily travel on the left is if you 
-are safely and legally passing another vehicle on a two-lane road. 
-Keep right except to pass. When there are multiple lanes traveling in the same direction, drive in 
-the right lane. Use the left lane to pass slower traffic. 
+WHEN TO CALL FOR HELPBlue emergency sign found at railroad crossing. It reads "REPORT PROBLEM OR EMERGENCY"
+If there is anything on or close to the 
+railroad tracks, call the number on the 
+blue and white Emergency Notification 
+System sign. Give the crossing ID 
+number to the dispatcher. Let them 
+know your location and the details of the 
+situation. No sign? Dial 911.
+LIGHT RAIL
+Sound Transit’s Link light rail line is a critical element of 
+Washington’s long-term transportation network. Here are some 
+guidelines for driving near rail stations and lines:
+•	
+Pay attention to all signs and road markings.
+•	
+Be alert and watch for approaching light rail trains.
+•	
+Leave at least one car length (or more) between your 
+vehicle and light rail trains.
+•	
+Do not stop, park, or leave your car on the tracks! Park with 
+plenty of room for rail trains to get around you.
+4.8  |  SHARING WITH AGRICULTURAL VEHICLES
+Agricultural and farm vehicles designed to go 25 mph or less 
+will have a triangle sign or emblem on the back. When you see a 
+slow moving vehicle, remember to:
+•	
+Be patient and slow down.
+•	
+Give plenty of space and use caution when passing.
+If you need to pass an agricultural vehicle and there are two 
+lanes in the same direction, move over one full lane. If there is 
+only one lane in each direction, look for oncoming traffic and 
+proceed carefully. As you pass, there should be at least 3 feet 
+between the widest part of your vehicle and the agricultural 
+vehicle.
+
+4.9  |  SHARING WITH EMERGENCY VEHICLES 
+Fire trucks, ambulances, and police cars using lights and/or 
+sirens always have the right-of-way. 
+As soon as you see or hear the signals, immediately pull your 
+vehicle to the right side of the road and stop. Wait until the 
+emergency vehicle has passed before signaling and reentering 
+traffic. You should reenter traffic in the order you were traveling 
+before. Wait until the emergency vehicle has passed before 
+signaling and reentering traffic. You should reenter traffic in the 
+order you were traveling before. By moving to the right, you help 
+emergency vehicle drivers do their job and could help save 
+a life!
+
+RULES OF THE ROAD
+4.10  |  TRAFFIC LAWS
+The rules of the road are designed to keep people safe. They 
+prevent traffic incidents by establishing the rules everyone 
+agrees to follow when they use the road. The laws exist to keep 
+road systems moving smoothly.
+For the most part, the fundamental rules of the road stay the 
+same. However, traffic laws can change. You can find the most 
+current rules of the road by searching RCW 46.61 online. For as 
+long as you drive, it is your responsibility to stay informed about 
+the most current rules of the road. 
+GENERAL DRIVING GUIDANCE 
+As a driver in Washington state, it’s a good idea to keep this 
+general driving guidance in mind:
+•	
+Drive on the right side of the road. The only time you might 
+temporarily travel on the left is if you are safely and legally 
+passing another vehicle on a two-lane road. 
+•	
+Keep right except to pass. When there are multiple lanes 
+traveling in the same direction, drive in the right lane. Use 
+the left lane to pass slower traffic.
+•	
 Follow speed limit laws, even when using the left lane to pass. 
-Remember, carpool lanes are not passing lanes. 
-Don’t use the shoulders of the road to pass. Unless directed by officials or signs, you shouldn’t 
-drive on the shoulder. 
-Avoid blocking travel lanes. If you need to stop, keep moving until you can safely pull over. 
+•	
+Remember, carpool lanes are not passing lanes.
+•	
+Don’t use the shoulders of the road to pass. Unless directed 
+by officials or signs, you shouldn’t drive on the shoulder.
+•	
+Avoid blocking travel lanes. If you need to stop, keep moving 
+until you can safely pull over.
+•	
+Keep moving forward. Don’t drive in reverse on the road, 
+even if you miss your turn or exit. It’s illegal to back up on a 
+shoulder or freeway.
 
-Keep moving forward. Don’t drive in reverse on the road, even if you miss your turn or exit. It’s 
-illegal to back up on a shoulder or freeway. 
-Do not hitchhike or pick up hitchhikers on Washington freeways. It’s illegal and dangerous. 
-Traffic control devices 
-Traffic control devices are signals, signs, and road markings that control the flow of traffic, 
-making streets and highways safer for motorists, bicyclists, and pedestrians. It is your 
-responsibility to look for and comply with all signals, signs, and road markings.   
-In special circumstances, law enforcement, construction workers, maintenance personnel, and 
-school crossing guards can direct traffic. These people can overrule traffic signals, and their 
-orders or directions must be followed. 
-Broken lights or signals 
-If a traffic signal isn’t working, treat the intersection like a four-way stop. Come to a complete 
-stop. Yield to traffic on your right. Proceed cautiously when it’s safe. 
-4.11: Traffic light signals 
+•	
+Do not hitchhike or pick up hitchhikers on Washington 
+freeways. It’s illegal and dangerous.
+TRAFFIC CONTROL DEVICES
+Traffic control devices are signals, signs, and road markings that 
+control the flow of traffic, making streets and highways safer for 
+motorists, bicyclists, and pedestrians. It is your responsibility to 
+look for and comply with all signals, signs, and road markings.
+In special circumstances, law enforcement, construction 
+workers, maintenance personnel, and school crossing guards 
+can direct traffic. These people can overrule traffic signals, and 
+their orders or directions must be followed.
+BROKEN LIGHTS OR SIGNALS
+If a traffic signal isn’t working, treat the intersection like a four-
+way stop. Come to a complete stop. Yield to traffic on your right. 
+Proceed cautiously when it’s safe.
+
+4.11  |  TRAFFIC LIGHT SIGNALSTraffic signal with the top light illuminated in red.
 Solid Red 
-Stop. Wait until the traffic light turns green and there are no vehicles or pedestrians in the 
-intersection before you move ahead.  
-After coming to a complete stop at a red light, you can turn right if you don’t see a “no turn on 
-red” sign and you have plenty of room to enter traffic. 
-After coming to a complete stop at a red light, you can turn left onto a one-way street if you don’t 
-see a “no turn on red” sign and you have plenty of room to enter traffic. 
-Flashing Red 
-Stop. A flashing red traffic light functions as a stop sign. 
-Come to a full stop and then go when it’s your turn. 
-Red Arrow 
-Stop. A red arrow means you can’t go in the direction of the arrow. 
-Solid Yellow 
-Slow down. 
-This means the light is changing to red. 
-When you see a yellow light, slow down and prepare to stop. 
-If you’re in the intersection when the yellow light comes on, continue through the intersection at 
-the posted speed.  
-You are not allowed to accelerate beyond the posted speed limit to enter or clear an intersection 
-when the light is yellow. 
+Stop. Wait until the traffic light turns 
+green and there are no vehicles or 
+pedestrians in the intersection before 
+you move ahead.
+After coming to a complete stop at a 
+red light, you can turn right if you don’t 
+see a “no turn on red” sign and you 
+have plenty of room to enter traffic.
+After coming to a complete stop at a red light, you can turn 
+left onto a one-way street if you don’t see a “no turn on red” 
+sign and you have plenty of room to enter traffic.Traffic signal with the top light illuminated and flashing
+Flashing Red
+Stop. A flashing red traffic light 
+functions as a stop sign. Come to a full 
+stop, and then go when it’s your turn.Four black circles, each with a red arrow pointing in a d
+Red Arrow
+Stop. A red arrow means you can’t go in 
+the direction of the arrow. 
 
-Flashing Yellow 
-Slow down. 
-A flashing yellow light has the same meaning as a yield sign. 
-Treat the intersection as an uncontrolled intersection. 
-Proceed when you have the right-of-way. 
-Yellow Arrow 
-Slow down. 
-A yellow arrow means the light is going to turn red soon. 
-Prepare to stop and give the right-of-way to oncoming traffic. 
-Solid Green 
-Go ahead, but make sure to: 
-Wait for the intersection to clear. 
-Yield to emergency vehicles as required by law. 
+Traffic signal with the middle light illuminated in yellow.
+Solid Yellow
+Slow down. This means the light is 
+changing to red. When you see a yellow 
+light, slow down and prepare to stop. 
+If you’re in the intersection when the 
+yellow light comes on, continue through 
+the intersection at the posted speed. 
+You are not allowed to accelerate 
+beyond the posted speed limit to enter 
+or clear an intersection when the light is 
+yellow.Traffic signal with the middle light illuminated and flashing yellow.
+Flashing Yellow
+Slow down. A flashing yellow light has 
+the same meaning as a yield sign. Treat 
+the intersection as an uncontrolled 
+intersection. Proceed when you have 
+the right-of-way.Four black circles, each with a yellow arrow pointing in a different direction: up, down, right, and left.
+Yellow Arrow
+Slow down. A yellow arrow means the 
+light is going to turn red soon. Prepare 
+to stop and give the right-of-way to 
+oncoming traffic. 
+
+Traffic signal with the bottom light illuminated in green.
+Solid Green
+Go ahead, but make sure to:
+•	
+Wait for the intersection to clear.
+•	
+Yield to emergency vehicles as 
+required by law.
+•	
 Yield to pedestrians. 
-Flashing Green 
-You won’t see a flashing green light in Washington state. However, you might see them in 
-British Columbia, Canada, as warning that pedestrians are waiting to cross. 
-Green Arrow 
-Go in the direction of the arrow. 
-A green arrow gives you the right-of-way to travel in that direction. 
-There should be no oncoming vehicles, crossing traffic, or pedestrians while the arrow is green. 
-Freeway ramp meters 
-Ramp meters work like regular traffic signals. 
-When the light is red, stop at the white stop line. 
-When the signal turns green, you can continue along the on-ramp. 
-4.12: Signs 
-Traffic signs tell you about traffic rules, hazards, roadway directions, and the location of roadway 
-services. The shape and color of these signs, and their symbols and words, give clues to the 
-type of information they provide. 
-Red = Prohibitive or restricted action 
-Orange = Construction and maintenance warning 
+When you’re turning left at a green light, yield to approaching 
+vehicles. Oncoming traffic has the right-of-way. Pause in a 
+place that gives you a clear view of approaching traffic, and 
+then safely complete the turn when there is a break in traffic.Traffic signal with the bo
+Flashing Green
+You won’t see a flashing green light in 
+Washington state. However, you might 
+see them in British Columbia, Canada, 
+as warning that pedestrians are waiting 
+to cross.Four black circles, each with a green arrow pointing in a different direction: up, down, right, and left.
+Green Arrow
+Go in the direction of the arrow. A green 
+arrow gives you the right-of-way to 
+travel in that direction. There should be 
+no oncoming vehicles, crossing traffic, 
+or pedestrians while the arrow is green. 
 
-Yellow = General and unexpected road conditions warning 
-Fluorescent Yellow Green = Warning of school, pedestrian, and bicycling activity 
-White = Regulatory 
-Green = Guide or directional information 
-Blue = Motorist services guidance 
-Brown = Public recreation, cultural and historical area identification 
-Common signs 
-Stop  
-A stop sign means you must stop at the line, crosswalk, or corner. Look for crossing vehicles 
-and pedestrians in all directions and yield the right-of-way. 
-Yield  
-A yield sign means you must slow down and allow traffic that has the right-of-way to cross first. 
+FREEWAY RAMP METERS
+Ramp meters work like regular traffic signals. When the light is 
+red, stop at the white stop line. When the signal turns green, you 
+can continue along the on-ramp.
+4.12  |  SIGNS
+Traffic signs tell you about traffic rules, hazards, roadway 
+directions, and the location of roadway services. The shape and 
+color of these signs, and their symbols and words, give clues to 
+the type of information they provide.
+Red
+Prohibitive or restricted 
+actionIcon of a red octagon stop sign with the word "STOP" written in white letters.
+Orange
+Construction and 
+maintenance warningIcon of an orange diamond sign with a flagger.
+Yellow
+General and unexpected 
+road conditions warningIcon of a yellow diamond sign with black arrows representing a Circular Intersection or Roundabout Traffic.
+Fluorescent 
+Yellow Green
+Warning of school, 
+pedestrian, and bicycling 
+activityIcon of a fluorescent yellow green sign with the “School Zone” pictograms.
+White
+RegulatoryIcon of a white rectangle sign with the words SPEED LIMIT 55 written in black letters.
+Green
+Guide or directional 
+informationIcon of a green directional information road sign.
+Blue
+Motorist services guidanceThree blue road signs indicating a hospital, EV charging station, and rest area.
+Brown
+Public recreation, cultural 
+and historical area 
+identificationThree brown recreational signs with white pictograms for hiking, picnicking, and skiing.
+
+COMMON SIGNSRed octagon stop sign with the word "STOP" in white letters.
+Stop 
+A stop sign means you must stop at the 
+line, crosswalk, or corner. Look for crossing 
+vehicles and pedestrians in all directions 
+and yield the right-of-way.Triangle yield road sign with red border.
+Yield 
+A yield sign means you must slow down 
+and allow traffic that has the right-of-way to 
+cross first.Speed limit sign showing 55.
 Speed Limit 
-These signs tell you the maximum safe speed allowed or the minimum safe speed required. 
-The maximum speed limit is for ideal conditions. Reduce your speed when road conditions 
-require it — like the roadway is slippery or it’s foggy and difficult to see. Even if you’re driving 
-under the posted speed limit, you can get a ticket for traveling too fast for road conditions. 
-Some roads have minimum speed limits. You’re required to travel at least this fast so you are 
-not a hazard to other drivers. 
-Keep Right 
-This sign reminds you to stay in the right lane unless you’re passing another vehicle. 
-Automated traffic safety cameras 
-These cameras automatically record images if you:  
-Fail to stop at a steady red light. 
-Fail to stop at a railroad crossing signal. 
-Exceed the speed limit in a school zone. 
-All locations with traffic cameras are clearly marked. Speeding tickets from these locations are 
-mailed to the vehicle owner. 
+These signs tell you the maximum safe 
+speed allowed or the minimum safe speed 
+required.
+•	
+The maximum speed limit is for ideal 
+conditions. Reduce your speed when 
+road conditions require it — like the 
+roadway is slippery or it’s foggy and 
+difficult to see. Even if you’re driving 
+under the posted speed limit, you can 
+get a ticket for traveling too fast for road 
+conditions.
+•	
+Some roads have minimum speed 
+limits. You’re required to travel at least 
+this fast so you are not a hazard to 
+other drivers.White traffic sign with black symbols indicating to keep right
+Keep Right
+This sign reminds you to stay in the right 
+lane unless you’re passing another vehicle.
+
+School speed zone photo enforced ahead sign.
+Automated traffic safety cameras
+These cameras automatically record 
+images if you: 
+•	
+Fail to stop at a steady red light.
+•	
+Fail to stop at a railroad crossing signal.
+•	
+Exceed the speed limit in a school 
+zone.
+All locations with traffic cameras are clearly 
+marked. Speeding tickets from these 
+locations are mailed to the vehicle owner.A yellow speed warning sign sugg
 Speed warning 
-These signs indicate that a speed change is recommended for a potential hazard or road 
-condition (often a curve or turn). Adjust your speed appropriately given all factors (road, 
-weather, traffic, etc.) and follow the speed warning limit. 
-
-Variable speed limit and advanced notification 
-These digital signs attempt to distribute the flow of traffic by posting changing speed limits. 
-Digital advanced notification signs can also quickly close entire lanes and provide warning 
-information to drivers before they reach slower traffic. 
+These signs indicate that a speed change 
+is recommended for a potential hazard 
+or road condition (often a curve or turn). 
+Adjust your speed appropriately given all 
+factors (road, weather, traffic, etc.) and 
+follow the speed warning limit.Digital speed limit sign showing 40.
+Variable speed limit and 
+advanced notification
+These digital signs attempt to distribute 
+the flow of traffic by posting changing 
+speed limits. Digital advanced notification 
+signs can also quickly close entire lanes 
+and provide warning information to drivers 
+before they reach slower traffic.Two "One-way" road signs, one with with a left-pointing arrow and one with a right-pointing arrow.
 One Way 
-These signs identify where traffic flows only in the direction of the arrow. Never drive the wrong 
-way on a one-way street. 
+These signs identify where traffic flows only 
+in the direction of the arrow. Never drive 
+the wrong way on a one-way street.
+
+Six prohibitory traffic signs indicating no pedestrians, no U-turns, no right turns, no left turns, no trucks, and no parking.
 Not allowed 
-Some regulatory signs have a red circle with a red slash over a symbol. These signs indicate 
-certain actions, such as left turns, right turns, or U-turns, are not allowed. 
-Do Not Enter 
-A square sign with a white horizontal line inside a circle means you can’t enter the street from 
-that direction.  
+Some regulatory signs have a red circle 
+with a red slash over a symbol. These signs 
+indicate certain actions, such as left turns, 
+right turns, or U-turns, are not allowed.Red circle with white text reading "Do N
+Do Not Enter
+A square sign with a white horizontal line 
+inside a circle means you can’t enter the 
+street from that direction.Red rectangular sign with white letters that read "WRONG WAY"
 Wrong Way 
-This alerts you that you’re driving in the wrong direction and is meant to prevent head-on 
-collisions. Stop and turn around immediately.   
-No passing and passing safely 
-These signs tell you where passing isn’t allowed. You might see these signs where there are 
-potential hazards, such as hills, curves, and intersections, and other places a vehicle could 
-enter the roadway. There are also signs and lane markings that tell you when it is safe to pass. 
-Shared center lane left turn only 
-This sign indicates where a lane is reserved for left-turning vehicles from either direction and 
-isn’t to be used for through traffic or passing other vehicles. Arrows are often painted on the 
-road. 
-Roundabout 
-These signs mark the entrance to a roundabout. Roundabouts can also have yield, pedestrian 
-warning, and directional arrow signs.  
-Work zone signs 
-These construction, maintenance, or emergency operations signs warn you people are working 
-near the roadway. Motorists, pedestrians, and bicyclists must yield to any highway construction 
-personnel, vehicles with flashing yellow lights, or equipment inside a highway construction or 
-maintenance work zone. Fines double for offenses committed while driving in construction areas 
-when workers are present.   
-Service signs 
-Service signs show the location of various services, such as hospitals, electric vehicle charging 
-stations, and rest areas. 
+This alerts you that you’re driving in the 
+wrong direction and is meant to prevent 
+head-on collisions. Stop and turn around 
+immediately.Yellow triangular road sign with text "NO PASSING ZONE".
+No passing and passing safely
+These signs tell you where passing isn’t 
+allowed. You might see these signs where 
+there are potential hazards, such as hills, 
+curves, and intersections, and other places 
+a vehicle could enter the roadway. There 
+are also signs and lane markings that tell 
+you when it is safe to pass."CENTER LANE ONLY” sign with two curved arrows pointing left and right.
+Shared center lane left turn only
+This sign indicates where a lane is reserved 
+for left-turning vehicles from either 
+direction and isn’t to be used for through 
+traffic or passing other vehicles. Arrows are 
+often painted on the road.
 
-Recreation signs 
-Recreation signs show local attractions, such as hiking trails, picnic spaces, and skiing areas. 
-Destination signs 
-Destination signs show directions and distances to various locations, such as cities, airports, or 
-state lines or special areas such as national parks, historical areas, or museums. 
-The shape and color of route number signs indicate the type of roadway — interstate, U.S., 
-state, city, or county road. For example: city mileage, optional exit and exit only, and highway 
-signs. 
-Other traffic signs 
-Some, but not all, Washington State signs are listed below. You are responsible for knowing all 
-signs, including city and county signs. 
-No turn on red 
-Lane use control 
-Mile marker 
-School zone speed limit 
-Reduced speed limit ahead 
-Railroad intersection 
-Cross road 
-Curve 
-Deer crossing 
-Hill 
-Low clearance 
-Merge 
-Merging traffic 
-No passing zone 
-Pedestrian crossing 
-Reversing curves 
-School crossing 
-Side road 
-Signal ahead 
-Slippery when wet 
+Yellow diamond traffic sign with circular arrows indicating a roundabout and a white traffic sign indicating left lane can go straight or turn left, and right lane can turn right.
+Roundabout
+These signs mark the entrance to a 
+roundabout. Roundabouts can also have 
+yield, pedestrian warning, and directional 
+arrow signs. 
+WORK ZONE SIGNSSix orange road construction signs, including messages like "ROAD CONSTRUCTION AHEAD," "CONSTRUCTION," "DETOUR," and symbols of a person digging and a flagger.
+These construction, 
+maintenance, or emergency 
+operations signs warn you 
+people are working near 
+the roadway. Motorists, 
+pedestrians, and bicyclists 
+must yield to any highway 
+construction personnel, 
+vehicles with flashing yellow 
+lights, or equipment inside 
+a highway construction or 
+maintenance work zone. 
+Fines double for offenses 
+committed while driving in 
+construction areas when 
+workers are present.
+SERVICE SIGNSThree blue road signs indicating a hospital, EV charging station, and rest area.
+Service signs show the 
+location of various services, 
+such as hospitals, electric 
+vehicle charging stations, 
+and rest areas.
 
-Soft shoulder 
-Stop ahead 
-Sharp turn 
-Two-way traffic 
-Added lane (from right, no merging required) 
-Advance warning bicyclist 
-Narrow road or bridge ahead 
-Circular intersection 
-Curve left 35 mph recommended 
-Divided highway (road) begins 
-Divided highway (road) ends 
-Slow moving vehicle 
-Winding road 
-Advisory speed 
-Chain advisory 
-Light rail 
-Sharp curve ahead  
-Railroad crossing 
-Traffic direction 
-Tsunami hazard zone 
-National forest 
-Volcano evacuation route 
-4.13: Common intersections 
-An intersection is any place where two or more roads come together. There are many types of 
-intersections: cross streets, roundabouts, calming circles, side streets, driveways, shopping 
-centers, and parking lot entrances. Every intersection is legally a crosswalk, whether it’s marked 
-or unmarked. Each intersection type requires wise decision making, cautious behavior, and 
-awareness of yourself and others.   
+RECREATION SIGNSThree brown recreational signs with white pictograms for hiking, picnicking, and skiing.
+Recreation signs show local 
+attractions, such as hiking 
+trails, picnic spaces, and 
+skiing areas.
+DESTINATION SIGNS
+Destination signs show directions and distances to various 
+locations, such as cities, airports, or state lines or special areas 
+such as national parks, historical areas, or museums. 
+The shape and color of route number signs indicate the type 
+of roadway — interstate, U.S., state, city, or county road.Green road sign showing dista
+City mileageHighway exit sign for “
+Optional exit and 
+exit onlyFour different road signs: Interstate 5, U.S.
+Highway signs
+
+OTHER TRAFFIC SIGNS 
+Some, but not all, Washington State signs are shown below. 
+You are responsible for knowing all signs, including city and 
+county signs.White rectangle sign with black letters that read "NO TURN ON READ" above a red circle.
+No turn on redTraffic sign showing lane usage rules with time intervals
+Lane use controlGreen rectangle sign with white letters indicating the numeric mile marker. Mile markerWhite rectangle sign with black letters that read "SCHOOL SPEED LIMIT 15 WHEN FLASHING".
+School zone speed 
+limitWhite rectangle sign with black letters that read "REDUCED SPEED AHEAD."
+Reduced speed 
+limit aheadRailroad crossing sign in an "X" shape.
+Railroad 
+intersectionYellow diamond traffic sign with a black cross symbol.
+Cross roadYellow diamond road sign with a black arrow curving left.
+CurveYellow diamond road sign with a black silhouette of a leaping deer. Deer crossingYellow diamond road sign with a truck descending a steep gr
+HillYellow diamond road sign with black numbers indicating low clearance height
+Low clearanceYellow diamond-shaped road sign with black merge or lane reduction symbol. MergeDiamond-shaped yellow traffic sign with a black merging arrow symbol.
+Merging trafficYellow triangular traffic sign with "NO PASSING ZONE" in black letters.
+No passing zoneYellow diamond road sign with a black silhouette of a person walking.
+Pedestrian crossingYellow diamond road sign with a black curving arrow 
+Reversing curvesYellow diamond road sign with a black silhouette of and adult and child walking.
+School crossingYellow diamond-shaped traffic sign with a black "T" symbol.Side road
+
+Yellow diamond traffic sign with a red, yellow, and green traffic light graphic.
+Signal aheadYellow diamond-shaped traffic sign with a black car and curving skid marks.
+Slippery when wetYellow diamond traffic sign with black text that reads "SOFT SHOULDER."
+Soft shoulderYellow diamond traffic sign with a red octagon shape under a black arrow pointing up
+Stop aheadDiamond-shaped road sign with a yellow background and a black left turn arrow. Sharp turnYellow diamond traffic sign with one arrow pointing up and one arrow pointing down.Two-way trafficRoad sign indicating lane reduction and mer
+Added lane (from 
+right, no merging 
+required)Yellow diamond-shaped sign with black bicycle symbol in the center.
+Advance warning 
+bicyclistDiamond-shaped traffic sign indicating road narrowing.
+Narrow road 
+or bridge 
+aheadYellow diamond traffic sign with three black arrows in a circle.
+Circular 
+intersectionRoad sign indicating recommended speed for turn or curve
+Curve left 35 mph 
+recommendedRoad sign with yellow background and black symbols of two arrows pointing in opposite directions around an object to show divided highway begins.
+Divided highway 
+(road) beginsRoad sign with yellow background and black symbols of two arrows pointing around an object in opposite directions to show divided highwa
+Divided highway 
+(road) endsYellow diamond traffic sign with the text “SLOW MOVING VEHICLES.”
+Slow moving 
+vehicleDiamond-shaped traffic sign with a wavy black arrow pointing upwards on a yellow background.
+Winding 
+roadYellow rectangular traffic sign displaying "EXIT 25 MPH."
+Advisory speedElectronic road sign displaying "TIRE CHAINS REQUIRED."
+Chain advisorySquare traffic sign with a yellow train on a black background.Light rail
+
+Yellow road sign with a thick black left-pointing chevron arrow.
+Sharp curve aheadRailroad crossing sign with a yellow background, black "X," and "R" on either side.
+Railroad crossingRectangular yellow road sign with a black leftward-pointing arrow.
+Traffic directionTsunami hazard zone sign with a wave and a running figure that reads "IN CASE OF EARTHQUAKE,
+Tsunami hazard 
+zoneBrown road sign with white letters that read “NATIONAL FOREST”
+National 
+forestBlue circular sign with white volcano and text “VOLCANO EVACUATION ROUTE.”
+Volcano 
+evacuation route
+4.13  |  COMMON INTERSECTIONS
+An intersection is any place where two or more roads come 
+together. There are many types of intersections: cross streets, 
+roundabouts, calming circles, side streets, driveways, shopping 
+centers, and parking lot entrances. Every intersection is legally 
+a crosswalk, whether it’s marked or unmarked. Each intersection 
+type requires wise decision making, cautious behavior, and 
+awareness of yourself and others.
 Before you enter an intersection: 
+•	
 Stop and yield to pedestrians and traffic in the intersection. 
-Look in each direction multiple times. 
+•	
+Look in each direction multiple times.
+•	
+Check your side mirrors and over your shoulder to be sure 
+there isn’t a cyclist, motorcyclist, or pedestrian coming into 
+your path.
+•	
+Look for road markings to follow as you proceed to a new 
+lane or road.
+•	
+Make sure you can clearly see crossing traffic before 
+entering an intersection. If you stop on the stop line, but 
+your view of a cross street is blocked, edge forward slowly 
+until you can see. This allows crossing drivers to see the 
+front of your vehicle before you can see them. This gives 
+them a chance to slow down and warn you if needed. 
 
-Check your side mirrors and over your shoulder to be sure there isn’t a cyclist, motorcyclist, or 
-pedestrian coming into your path. 
-Look for road markings to follow as you proceed to a new lane or road. 
-Make sure you can clearly see crossing traffic before entering an intersection. If you stop on the 
-stop line, but your view of a cross street is blocked, edge forward slowly until you can see. This 
-allows crossing drivers to see the front of your vehicle before you can see them. This gives 
-them a chance to slow down and warn you if needed.  
-Make sure there is enough space for you to cross or turn without blocking the intersection. 
-It’s very important to scan the entire area around an intersection, especially when you are near 
-shopping centers, parking lots, construction areas, busy sidewalks, playgrounds, parks, and 
-schoolyards. 
-Right-of-way 
-Right-of-way rules determine the order vehicles move through an intersection. The law 
-determines who must yield (give up) the right-of-way.  
+•	
+Make sure there is enough space for you to cross or turn 
+without blocking the intersection.
+It’s very important to scan the entire area around an 
+intersection, especially when you are near shopping centers, 
+parking lots, construction areas, busy sidewalks, playgrounds, 
+parks, and schoolyards.
+Right-of-way
+Right-of-way rules determine the order vehicles move through 
+an intersection. The law determines who must yield (give up) 
+the right-of-way. 
+ 
 Four-way stop 
-When you approach an intersection controlled by stop signs, the following rules apply: 
+When you approach an intersection controlled by stop signs, 
+the following rules apply: 
+•	
 The first vehicle to arrive is the first to go. 
-The second vehicle to arrive is the second to go, etc. 
-If two vehicles arrive at approximately the same time, yield to the one on the right. 
-Any vehicle turning left must yield the right-of-way to vehicles going straight or turning right. 
+•	
+The second vehicle to arrive is the second to go, etc.
+•	
+If two vehicles arrive at approximately the same time, yield to 
+the one on the right. 
+•	
+Any vehicle turning left must yield the right-of-way to 
+vehicles going straight or turning right. 
 Two-way stop 
-Turning vehicles must yield to the vehicle going straight. The vehicle going straight has the right-
-of-way. 
-4.14 Turning 
-Whether turning left or right at an intersection, state law requires you to turn into the lane closest 
-to the direction you are coming from. 
-If there is more than one turn lane, stay in your original lane as you turn. Make sure you plan 
-your turns carefully so you don’t veer into another lane while turning. Once you complete your 
-turn, you can change to another lane if you need to. 
-Put on your turn signal at least 100 feet before you turn left or right across oncoming traffic. 
-Then, look for a safe gap in the traffic. Check the street you’re turning onto to make sure no 
-vehicles, pedestrians, or bicyclists are in or approaching your path.   
-Check behind you for bicyclists and yield to them before making your turn. Bicyclists might be 
-moving toward you faster than you realize. Be sure you have time to execute the turn safely. 
-U-turns 
+Turning vehicles must yield to the vehicle going straight. 
+The vehicle going straight has the right-of-way.
 
-If you need to turn around, look for signs showing whether  
-or not a U-turn is allowed. You must have clear visibility in all directions before making a U-turn. 
-For that reason, do not make a U-turn on a curve or when approaching the crest of a hill.  In 
-Washington, U-turns are generally allowed unless a sign is posted telling you a U-turn is not 
-allowed. 
-Cross intersection 
-A cross-intersection is a four-way junction with one or more lanes traveling in each direction. It 
-can be marked with traffic lights, street signs, and/or road markings. Know and apply the right-
-of-way laws at cross intersections. 
-T-intersection 
-A T-intersection is a three-way junction where a road ends and intersects with a through road. 
-Some T-intersections will have a yield or stop sign to let you know that passing traffic has the 
-right-of-way. 
-Y-intersection 
-A Y-intersection is when a minor road connects with more major routes. There might be a stop 
-sign where the minor road connects with the major road. The cars on major roads have the 
-right-of-way. 
-Mid-block crossing 
-These are crosswalks in the middle of the roadway. Pedestrians always have the right-of-way in 
-a marked crosswalk.   
-Drivers should stop to allow pedestrians and bicyclists to cross, regardless of whether the 
-crosswalk has a stop sign or not. 
-4.15: Other intersections 
-Traffic calming circles 
-A traffic calming circle is an intersection with a painted or raised center island that traffic flows 
-counterclockwise around. This type of intersection can have stop or yield signs on all, some, or 
-none of its approaches. They can be found at 4-way, 3-way, or 2-way intersections. Apply the 
-same right-of-way rules as you would at any other intersection. 
-Traffic calming circles are intended for passenger vehicles and may not easily accommodate 
-large vehicles like fire trucks, buses, or delivery trucks. Give larger vehicles plenty of space and 
-be aware that they might have to go clockwise to get through the circle. 
-Roundabout 
-A roundabout is a circular intersection where all approaching vehicles yield on entry and travel 
-counterclockwise around a raised center island. 
-Roundabouts are designed for a wide variety of users, including cars, fire trucks, buses, delivery 
-vehicles, freight trucks, bicyclists, and pedestrians. 
+4.14  |  TURNING
+Whether turning left or right at an intersection, state law 
+requires you to turn into the lane closest to the direction you 
+are coming from.
+If there is more than one turn lane, stay in your original lane as 
+you turn. Make sure you plan your turns carefully so you don’t 
+veer into another lane while turning.
+Once you complete your turn, you can change to another lane 
+if you need to.The image shows a diagram of an intersection, illustrating correct and incorrect ways for cars making left and right turns. It depicts a four-way intersection framed by crosswalks and bike lanes. The roads have two lanes in each direction with central dividing lines. Two cars, one black and one red, are shown in the center of the intersection. Green and red arrows indicate the correct (green) and incorrect (red) turning paths for each car from a front and rear perspective.
+ Traffic intersection with four cars making left turns as shown by green arrows.
+Put on your turn signal at least 100 feet before you turn left or 
+right across oncoming traffic. Then, look for a safe gap in the 
+traffic. Check the street you’re turning onto to make sure no 
+vehicles, pedestrians, or bicyclists are in or approaching your 
+path.
+Check behind you for bicyclists and 
+yield to them before making your turn. 
+Bicyclists might be moving toward you faster than you realize. 
+Be sure you have time to execute the turn safely.
 
-Roundabouts can have a truck apron around the central island. Truck aprons are designed for 
-large vehicles. Give large vehicles plenty of space as they are allowed to cross truck aprons and 
-both lanes as they approach and drive through the intersection. 
-Bicycles can choose to navigate the roundabout as a pedestrian or as a vehicle. When traveling 
-as a vehicle, bicyclists should ride in the middle of the lane to increase their visibility to drivers.  
-How to drive a roundabout 
-Slow down when approaching the roundabout. Roundabouts are designed for speeds between 
-15 and 25 mph. 
-Pick a lane as you approach the roundabout. The lane choice sign shows you which lanes are 
-used for right turns, straight through travel, and left turns. Once you pick a lane, stay in that lane 
-until you exit the roundabout. 
-Stop for pedestrians and bicyclists in crosswalks when you enter and exit the roundabout. 
-Yield to all traffic in the roundabout. Look left and yield to all traffic already in the roundabout 
-since they have the right-of-way. Once you see a gap in traffic, enter the circle and proceed to 
-your exit. Remember to keep a safe distance behind trucks because they need a lot of space 
-and are allowed to use both lanes. 
-Enter the roundabout to the right, traveling counterclockwise and staying in your lane. 
-Exit at the street you want. 
-Drive through the roundabout and pull over if an emergency vehicle approaches, just like you 
-would at any other intersection. 
-Diverging diamonds 
-A diverging diamond is a new type of intersection in Washington. It’s designed so traffic can 
-cross to the other side of the roadway. This might not seem logical because you cross lanes 
-with traffic going in the opposite direction. The intersection allows for vehicles to turn left (on and 
-off freeway ramps) more efficiently. These intersections reduce the number of points where 
-vehicles cross paths, which in turn decreases the risk of collisions. By eliminating left turns 
-against oncoming traffic, diverging diamond intersections improve traffic flow and reduce 
-congestion. 
-What to expect 
-Lane shift. As you approach the interchange, you’ll be guided to cross over to the left side of the 
-roadway. This might feel strange initially, as you’ll be driving on the opposite side of the road, 
-but clear markings and signals will guide you. 
-Free-flow left turns. The main advantage is that it allows you to make left turns onto the freeway 
-without stopping or yielding to oncoming traffic. 
-Return to normal. After crossing the overpass or underpass, you’ll be directed to cross back 
-over to the right side of the road. 
-What to do 
+U-turns
+If you need to turn around, look for signs showing whether 
+or not a U-turn is allowed. You must have clear visibility in all 
+directions before making a U-turn. For that reason, do not make 
+a U-turn on a curve or when approaching the crest of a hill. 
+In Washington, U-turns are generally allowed unless a sign is 
+posted telling you a U-turn is not allowed.Four-way intersection with a stop sign in the bottom right corner.
+Cross Intersection
+A cross-intersection is a four-way 
+junction with one or more lanes traveling 
+in each direction. It can be marked with 
+traffic lights, street signs, and/or road 
+markings. Know and apply the right-of-
+way laws at cross intersections. T-intersection with yellow and silver cars on the main road and a red car on the side road near a 
+T-Intersection
+A T-intersection is a three-way junction 
+where a road ends and intersects with a 
+through road. Some T-intersections will 
+have a yield or stop sign to let you know 
+that passing traffic has the right-of-way. Y-shaped intersection 
+Y-Intersection
+A Y-intersection is when a minor road 
+connects with more major routes. There 
+might be a stop sign where the minor 
+road connects with the major road. The 
+cars on major roads have the right-of-
+way. 
 
-Pay close attention to signs and pavement markings. They will guide you through the lane shift 
-and turns. 
-Don’t worry about oncoming traffic when turning left onto the freeway. The design eliminates 
-conflicts with oncoming vehicles. 
-Stay alert and drive at a safe speed. Even though traffic flow is improved, it’s important to 
-remain aware of your surroundings. 
-Uncontrolled intersections 
-Uncontrolled intersections don’t have signs, but the normal right-of-way rules apply. These 
-intersections are typically found on local roads and streets. When you enter an uncontrolled 
-intersection, you must yield the right-of-way if any of these apply:   
+Road with a yellow and white pedestrian crossing, flanked by sidewalks.
+Mid-block crossing
+These are crosswalks in the middle of 
+the roadway. Pedestrians always have 
+the right-of-way in a marked crosswalk.
+Drivers should stop to allow pedestrians 
+and bicyclists to cross, regardless of 
+whether the crosswalk has a stop sign 
+or not.
+4.15  |  OTHER INTERSECTIONSCircular intersection with a yellow car and a red car moving counter-clockwise.
+Traffic calming circles
+A traffic calming circle is an intersection 
+with a painted or raised center island 
+that traffic flows counterclockwise 
+around. This type of intersection can 
+have stop or yield signs on all, some, 
+or none of its approaches. They can 
+be found at 4-way, 3-way, or 2-way 
+intersections. Apply the same right-
+of-way rules as you would at any other 
+intersection. 
+Traffic calming circles are intended for passenger vehicles and 
+may not easily accommodate large vehicles like fire trucks, 
+buses, or delivery trucks. Give larger vehicles plenty of space 
+and be aware that they might have to go clockwise to get 
+through the circle.
+
+ROUNDABOUTS
+A roundabout is a circular intersection where all approaching 
+vehicles yield on entry and travel counterclockwise around a 
+raised center island.
+Roundabouts are designed for a wide variety of users, including 
+cars, fire trucks, buses, delivery vehicles, freight trucks, 
+bicyclists, and pedestrians.An overhead view of a roundabout with four incoming roads. The roundabout is situated in a green area with trees at the center. Multiple vehicles, including cars and a truck, are navigating the intersection. Yield signs are prominently displayed at each entry point to the roundabout. Crosswalks are marked at each intersection, and directional arrows are painted on the roads. In the lower left corner, there is a yellow diamond-shaped road sign with a circular arrow symbol indica
+
+Roundabouts can have a truck apron around the central 
+island. Truck aprons are designed for large vehicles. Give large 
+vehicles plenty of space as they are allowed to cross truck 
+aprons and both lanes as they approach and drive through the 
+intersection.
+Bicycles can choose to navigate the roundabout as a 
+pedestrian or as a vehicle. When traveling as a vehicle, 
+bicyclists should ride in the middle of the lane to increase their 
+visibility to drivers.
+How to drive a roundabout
+1.	 Slow down when approaching the roundabout. 
+Roundabouts are designed for speeds between 15 and 
+25 mph.
+2.	 Pick a lane as you approach the roundabout. The lane 
+choice sign shows you which lanes are used for right 
+turns, straight through travel, and left turns. Once you 
+pick a lane, stay in that lane until you exit the roundabout. 
+3.	 Stop for pedestrians and bicyclists in crosswalks when 
+you enter and exit the roundabout.
+4.	 Yield to all traffic in the roundabout. Look left and yield 
+to all traffic already in the roundabout since they have 
+the right-of-way. Once you see a gap in traffic, enter the 
+circle and proceed to your exit. Remember to keep a safe 
+distance behind trucks because they need a lot of space 
+and are allowed to use both lanes.
+5.	 Enter the roundabout to the right, traveling 
+counterclockwise and staying in your lane.
+6.	 Exit at the street you want. 
+7.	 Drive through the roundabout and pull over if an 
+emergency vehicle approaches, just like you would at any 
+other intersection.
+
+A top-dow
+n illus
+tration of 
+a diverging dia
+mond interchange. This
+ interchange sh
+owcases the arrangemen
+t of roads and 
+traffic flow patterns.
+ The main roads
+ intersect at the center, featuring large triangular areas with purple backgrounds. Vehicles are represented by simplistic car icons pointing in different directions, illustrating traffic flow. The roads are marked with dashed and solid lines, indicating lanes and traffic movement. Two yellow signs labeled "Crossover point" are placed on either side of the intersection. An interstate shield marked "I-5" is located near the bottom left. A blue rectangular sign in the center reads "Diverging Diamond Interchange." Green landscape elements with tree illustrations are visible around the interchange.
+DIVERGING DIAMONDS
+A diverging diamond is a new type of intersection in 
+Washington. It’s designed so traffic can cross to the other 
+side of the roadway. This might not seem logical because you 
+cross lanes with traffic going in the opposite direction. The 
+intersection allows for vehicles to turn left (on and off freeway 
+ramps) more efficiently. These intersections reduce the number 
+of points where vehicles cross paths, which in turn decreases 
+the risk of collisions. By eliminating left turns against oncoming 
+traffic, diverging diamond intersections improve traffic flow and 
+reduce congestion.
+
+What to expect
+•	
+Lane Shift. As you approach the interchange, you’ll be 
+guided to cross over to the left side of the roadway. This 
+might feel strange initially, as you’ll be driving on the 
+opposite side of the road, but clear markings and signals will 
+guide you.
+•	
+Free-Flow Left Turns. The main advantage is that it allows 
+you to make left turns onto the freeway without stopping or 
+yielding to oncoming traffic.
+•	
+Return to Normal. After crossing the overpass or underpass, 
+you’ll be directed to cross back over to the right side of the 
+road.
+What to do
+•	
+Pay close attention to signs and pavement markings. They 
+will guide you through the lane shift and turns.
+•	
+Don’t worry about oncoming traffic when turning left onto 
+the freeway. The design eliminates conflicts with oncoming 
+vehicles.
+•	
+Stay alert and drive at a safe speed. Even though traffic 
+flow is improved, it’s important to remain aware of your 
+surroundings.
+UNCONTROLLED INTERSECTION 
+Uncontrolled intersections don’t have signs, but the normal 
+right-of-way rules apply. These intersections are typically found 
+on local roads and streets. When you enter an uncontrolled 
+intersection, you must yield the right-of-way if any of these 
+apply:
+•	
 A vehicle is already in the intersection. 
+•	
 You enter or cross a state highway from a secondary road. 
+•	
 You enter a paved road from an unpaved road. 
-You plan to make a left turn and a vehicle is approaching from the opposite direction. 
-4.16: Road markings 
-Road markings are lines, arrows, words, or symbols painted on the roadway to give you 
-directions or warnings. They’re used to divide lanes. Road markings show when you can pass 
-other vehicles or change lanes. They show which lanes to use for turns, define pedestrian 
-walkways, and show where you must stop for signs or traffic signals. 
-Lanes 
-Solid white line 
-Solid white lines mark the edge of the road and separate bicycle lanes from other traffic.  
-No marking 
-If there are no markings on the road, stay as close to the right side as safely possible. 
-White and yellow line 
-White and yellow lines separating travel lanes or marking the center of the road tell you if traffic 
-is traveling in one or two directions.  
-Yellow lines separate traffic in opposite directions. 
-White lines separate traffic lanes moving in the same direction. 
-Dashed white line 
-Shorter dashed white lines mean the lane is ending. You will either need to merge or exit. You 
-can cross dashed lines if it is safe. 
-Median 
+•	
+You plan to make a left turn and a vehicle is approaching 
+from the opposite direction.
 
-Medians divide two or more roadways. They can be open spaces, cement dividers, or 18-inch 
-solid yellow pavement markings with stripes. It’s illegal to drive within, over, or across medians. 
-Dashed white line between lanes of traffic 
-A dashed white line between lanes of traffic means you can cross it to change lanes if it is safe. 
-Solid white line 
-A solid white line means you should stay in your lane unless a special situation requires you to 
-change lanes. 
-Double solid white line 
-Double solid white lines are a barrier between lanes. It’s illegal to cross double white lines. 
-Dashed yellow line 
-A dashed yellow line shows the center of a two-way, two-lane road. If it’s safe, you may use the 
-oncoming lane to pass another vehicle.  
-Solid yellow line 
-A solid yellow line can indicate the edge of the road or a no-passing zone. Do not cross a solid 
-yellow line to pass another vehicle. 
-Double solid yellow centerline 
-Double solid yellow centerlines show the middle of a two-way road. You are not allowed to pass, 
-in either direction, on roads with double yellow lines. 
-Solid yellow line with a dashed yellow line 
-A solid yellow and a dashed yellow line also show the center of a two-way roadway. You’re not 
-allowed to pass when the solid yellow line is on your side of the road. If the dashed line is on 
-your side of the road, you may pass if it’s safe to do so. 
-Turn lane 
-Turn lanes are usually at major intersections. There are signs and road markings indicating 
-these lanes. Sometimes an arrow signal helps control these lanes. Once you’re in a turn lane, 
-you must follow through with the turn. 
-Solid yellow line on your side 
-You can cross a solid yellow line on your side of the road to get into a center lane. This lane is 
-marked with left turn arrows. 
-These shared center lanes are reserved for vehicles making left turns in either direction from or 
-into the roadway (or U-turns when they are permitted). 
-Keep your eyes on traffic coming the other direction because those cars also have the right to 
-use the same turn lane. 
-These lanes must not be used for passing. You shouldn’t travel farther than 300 feet in a center 
-lane.   
+4.16  |  ROAD MARKINGS
+Road markings are lines, arrows, words, or symbols painted on 
+the roadway to give you directions or warnings. They’re used 
+to divide lanes. Road markings show when you can pass other 
+vehicles or change lanes. They show which lanes to use for 
+turns, define pedestrian walkways, and show where you must 
+stop for signs or traffic signals.
+LANESTop-down view of a red car turning left at a road intersection with marked bicycle lanes.
+Solid white lines mark the 
+edge of the road and separate 
+bicycle lanes from other 
+traffic. Car on a road with no lane markings.
+If there are no markings on 
+the road, stay as close to the 
+right side as safely possible.
 
-HOV / Carpool lane 
-HOV lanes are reserved for carpools, vanpools, and buses. HOV lanes are identified by the 
-diamond symbol on signs and on the pavement. These lanes are separated from the other 
-lanes on the highway by a solid white line. To travel in an HOV lane, a vehicle must meet the 
-occupancy requirements posted on the signs. Motorcycles are also allowed to use HOV lanes. 
-Reversible lane 
-Reversible lanes, like express lanes, help address traffic congestion by switching the travel 
-direction of one or more lanes when additional capacity is needed. Reversible lanes are typically 
-operated on regular, fixed schedules that reflect daily commuting patterns. They can also be 
-activated for major events or incidents. 
-These lanes are usually marked by double-dashed white lines. Check with the overhead signs 
-before you start driving in a reversible lane. A green arrow means you can use the lane, and, a 
-red X means you can’t. A steady yellow X means the lane is changing direction, and you should 
-move out of the lane as soon as it’s safe. 
-Reserved lane 
-Reserved lanes are identified by signs and/or pavement markings indicating the lane is reserved 
-for special uses. For example, transit lanes are for bus use only. 
-Toll lane 
-Express toll lanes and high occupancy toll lanes provide toll-free express trips for buses, 
-vanpools, carpools, and motorcycles, but they also give individual drivers the option to pay the 
-toll to use the lanes for a faster trip.   
-For more information, search toll roads on wsdot.wa.gov. 
-Using a Good To Go! account is the best way to pay tolls in Washington. Good To Go! accounts 
-save you money on every toll road in the state and give you the convenience of automatic 
-payments. For more information regarding Good To Go! accounts, visit mygoodtogo.com. 
-Other road markings 
-Crosswalks 
-Crosswalks provide a safe way for pedestrians and bicyclists to cross the road. You must yield 
-to people in or about to enter a crosswalk. 
-Get in the habit of being alert for pedestrians and bicyclists when you’re crossing an intersection 
-or turning.  
-Some crosswalks might also have in-pavement lights that are activated by crossing pedestrians. 
-You must yield when these lights are flashing.   
-Not all crosswalks are marked! Every intersection is legally defined as a crosswalk regardless of 
-whether a crosswalk marking is present. 
-Bike lane 
+A top-down view of two sections of a road, one with vehicles traveling in opposite directions and one with vehicles traveling the same direction. 
+White and yellow lines 
+separating travel lanes or 
+marking the center of the road 
+tell you if traffic is traveling in 
+one or two directions. 
+Yellow lines separate traffic 
+in opposite directions. White 
+lines separate traffic lanes 
+moving in the same direction.Highway with an exit ramp, showi
+Shorter dashed white lines 
+mean the lane is ending.
+You will either need to merge 
+or exit. You can cross dashed 
+lines if it is safe.Four-lane highway with vehicles traveling in both directions, separated by a grassy
+Medians divide two or more 
+roadways. They can be open 
+spaces, cement dividers, or 
+18-inch solid yellow pavement 
+markings with stripes. It’s 
+illegal to drive within, over, or 
+across medians.
 
-Bike lanes are marked with solid white lines and bike symbols.  
-Some bike lanes are separated from the adjacent travel lane with a buffer consisting of two solid 
-white lines with diagonal crosshatching in between. This buffer is considered part of the bike 
-lane and should not be entered unless you’re making a legal turn after checking that it’s safe to 
-do so. Some bike lanes are physically separated from passing traffic by methods such as 
-bollards, posts, or planters. 
-Stop line 
-Stop lines appear at a stop sign or signal. You must stop before your vehicle reaches the stop 
-line or crosswalk (if there is one). 
-Fire lane 
-Fire lanes are usually marked with red stripes or a red curb. Don’t park or stop in fire lanes. In 
-some communities, the road in front of a fire station is marked as a fire lane to keep the path 
-clear for aid vehicles. 
-Yellow stripes 
-Yellow stripes show where you’re not allowed to drive. 
-Sharrows 
-Sharrows are road markings used to indicate a vehicle lane is shared with bicycle traffic. 
-If you see sharrow markings, watch for people riding bikes. 
-Drive slowly and provide at least 3 feet of space when passing. 
-Bicycles should position themselves in line with the sharrow markings and ride in the direction 
-the arrow is pointing. 
+Three scenarios of green and white cars traveling on a multi-lane road with different lane markings.The first scenario shows the green and white cars both traveling in the same direction on a road with a dashed white line separating the lanes.The second scenario shows both cars on a road with a single, solid white line separating the lanes.The third scenario shows two, solid white lines separating the vehicles traveling in the same direction.
+A dashed white line between 
+lanes of traffic means you can 
+cross it to change lanes if it is 
+safe.
+A solid white line means 
+you should stay in your lane 
+unless a special situation 
+requires you to change lanes. 
+Double solid white lines are 
+a barrier between lanes. It’s 
+illegal to cross double white 
+lines.Three scenarios of green and white cars traveling on a multi-lane road with different lane markings.The first scenario shows the green and white cars both traveling in opposite directions on a road with a dashed yellow line separating the lanes. The second scenario shows both cars on a road with a single, solid yellow line separating the lanes. The third scenario shows two, solid yellow lines separating the vehicles traveling in opposite directions.
+A dashed yellow line shows 
+the center of a two-way, two-
+lane road. If it’s safe, you may 
+use the oncoming lane to 
+pass another vehicle. 
+A solid yellow line can 
+indicate the edge of the road 
+or a no‑passing zone. Do not 
+cross a solid yellow line to 
+pass another vehicle.
+Double solid yellow 
+centerlines show the middle 
+of a two-way road. You are 
+not allowed to pass, in either 
+direction, on roads with 
+double yellow lines.
+
+Two cars on a road with a red arrow and "X" showing an illegal lane change.
+A solid yellow and a dashed 
+yellow line also show the 
+center of a two-way roadway. 
+You’re not allowed to pass 
+when the solid yellow line is 
+on your side of the road. If the 
+dashed line is on your side of 
+the road, you may pass if it’s 
+safe to do so.A road with two lanes showing “LEFT” and “LEFT OR STRAIGHT” traffic arrow lane 
+Turn lanes are usually at major 
+intersections. There are signs 
+and road markings indicating 
+these lanes. Sometimes an 
+arrow signal helps control 
+these lanes. Once you’re in 
+a turn lane, you must follow 
+through with the turn.Three lanes depicted with dashed and solid yellow lines separating them. In the center lane, an arrow painted white indicates two direct
+You can cross a solid yellow 
+line on your side of the road 
+to get into a center lane. This 
+lane is marked with left turn 
+arrows. 
+These shared center lanes are 
+reserved for vehicles making 
+left turns in either direction 
+from or into the roadway 
+(or U-turns when they are 
+permitted).
+Keep your eyes on traffic coming the other direction because 
+those cars also have the right to use the same turn lane. 
+
+These lanes must not be used for passing. You shouldn’t travel 
+farther than 300 feet in a center lane.
+HOV / CARPOOLSix-lane road with cars in various lanes, divided by a solid yellow line. Diamond symbols in the leftmost lanes.
+ Traffic sign indicating the left lane is for buses, high-occupancy vehicles, and motorcycles only.
+HOV lanes are reserved for carpools, vanpools, and buses.
+HOV lanes are identified by the diamond symbol on signs and 
+on the pavement. These lanes are separated from the other 
+lanes on the highway by a solid white line. To travel in an HOV 
+lane, a vehicle must meet the occupancy requirements posted 
+on the signs. Motorcycles are also allowed to use HOV lanes.
+
+A three-lane road with three overhead lane usage signals and vehicles traveling in different lanes. From left to right, the first lane has a red signal with a red X indicating it is closed. The second lane has a green signal with a down arrow indicating it is open. The third lane also has a green signal with a down arrow indicating it is open. Vehicles are traveling in the directions of the arrow.
+REVERSIBLE LANES
+Reversible lanes, like express lanes, help address traffic 
+congestion by switching the travel direction of one or more 
+lanes when additional capacity is needed. Reversible lanes 
+are typically operated on regular, fixed schedules that reflect 
+daily commuting patterns. They can also be activated for major 
+events or incidents.
+These lanes are usually marked by double-dashed white lines. 
+Check with the overhead signs before you start driving in a 
+reversible lane. A green arrow means you can use the lane, and, 
+a red X means you can’t. A steady yellow X means the lane is 
+changing direction, and you should move out of the lane as 
+soon as it’s safe.
+
+RESERVED LANES
+Reserved lanes are identified by signs and/or pavement 
+markings indicating the lane is reserved for special uses. For 
+example, transit lanes are for bus use only.
+TOLL LANES
+Express toll lanes and high occupancy toll lanes provide 
+toll-free express trips for buses, vanpools, carpools, and 
+motorcycles, but they also give individual drivers the option to 
+pay the toll to use the lanes for a faster trip.
+For more information, search toll roads on wsdot.wa.gov.Green sign with a whit
+Using a Good To Go! account 
+is the best way to pay tolls in 
+Washington. Good To Go! 
+accounts save you money on 
+every toll road in the state and 
+give you the convenience of 
+automatic payments. 
+For more information regarding Good To Go! accounts, 
+visit mygoodtogo.com.
+
+OTHER ROAD MARKINGSPeople crossing a street at a crosswalk wit
+Crosswalks provide a safe way for pedestrians and bicyclists to 
+cross the road. You must yield to people in or about to enter a 
+crosswalk.
+Get in the habit of being alert for pedestrians and bicyclists 
+when you’re crossing an intersection or turning. 
+Some crosswalks might also have in-pavement lights that are 
+activated by crossing pedestrians. You must yield when these 
+lights are flashing.
+Not all crosswalks are marked! Every intersection is legally 
+defined as a crosswalk regardless of whether a crosswalk 
+marking is present.
+
+Overhead view of a car and cyclists in designated lanes
+Bike lanes are marked with 
+solid white lines and bike 
+symbols. 
+Some bike lanes are 
+separated from the adjacent 
+travel lane with a buffer 
+consisting of two solid 
+white lines with diagonal 
+crosshatching in between. 
+This buffer is considered part 
+of the bike lane and should 
+not be entered unless you’re 
+making a legal turn after 
+checking that it’s safe to 
+do so. 
+Some bike lanes are physically separated from passing traffic 
+by methods such as bollards, posts, or planters.Top-down view of a blue car turning left at an intersection with a bike la
+Stop lines appear at a stop 
+sign or signal. You must stop 
+before your vehicle reaches 
+the stop line or crosswalk 
+(if there is one).Rectangle with red boundary and diagonal lines, labeled
+Fire lanes are usually marked 
+with red stripes or a red curb. 
+Don’t park or stop in fire lanes. 
+In some communities, the 
+road in front of a fire station is 
+marked as a fire lane to keep 
+the path clear for aid vehicles.
+
+Three geometric shapes with yellow diagonal lines
+Yellow stripes show where 
+you’re not allowed to drive.Multi-lane road with cars an
+Sharrows are road markings 
+used to indicate a vehicle 
+lane is shared with bicycle 
+traffic.
+If you see sharrow markings, 
+watch for people riding bikes. 
+Drive slowly and provide at 
+least 3 feet of space when 
+passing.
+Bicycles should position 
+themselves in line with the 
+sharrow markings and ride 
+in the direction the arrow is 
+pointing.
+
+Car lane and a green bike box with cyclists. Text on ground reads "WAIT HERE".
 Bicycle boxes 
-When the light turns green, bicyclists cross the intersection first and enter the bike lane on the 
-other side of the intersection. You can’t turn right on red near a bicycle box. Stay behind the 
-white line until the bicycle box is clear. 
-Bicycles should position themselves in front of vehicles at the intersection. 
-4.17: Zones 
-School zone 
-A school zone refers to the roads around a school building or playground. These areas can be 
-marked with signs, pavement markings, and flashing lights.   
-The school zone speed limit is 20 mph because higher speeds increase the risk of fatal crashes. 
-You might see signs that clarify when the 20 mph speed limit applies. 
-Remember: Students might participate in after-school activities, sports teams, or access the 
-playground after hours. Slow down and watch out when you’re driving near a school. Any effort 
-to reduce the risk for children is worth your time and attention. 
-Work zone 
+When the light turns 
+green, bicyclists cross the 
+intersection first and enter 
+the bike lane on the other 
+side of the intersection. You 
+can’t turn right on red near a 
+bicycle box. Stay behind the 
+white line until the bicycle box 
+is clear.
+Bicycles should position 
+themselves in front of vehicles 
+at the intersection.
+4.17  |  ZONESThree school zone speed limit signs, all indicating a 20 mph limit with different conditions: "WHEN FLASHING," "WHEN CHILDREN ARE PRESENT," and "SCHOOL DAYS 7am-5pm".
+SCHOOL ZONE
+A school zone refers to the roads around a school building or 
+playground. These areas can be marked with signs, pavement 
+markings, and flashing lights.
+The school zone speed limit is 20 mph because higher speeds 
+increase the risk of fatal crashes. You might see signs that clarify 
+when the 20 mph speed limit applies. 
 
-A work zone is an area where roadwork or construction takes place. It could involve lane 
-closures, detours, and moving equipment. 
-Be aware of crew members who work to keep travelers safe while vehicles speed past. 
-Employees in work zones are parents, partners, siblings, and friends who need a safe work 
-environment. 
-Please do your part to keep these workers safe. For example: 
-Watch for signs, cones, barrels, large vehicles, and workers when approaching a work zone. 
-Eliminate distractions to enhance focus. Turn down music and pause conversations. 
-Always reduce your speed in a work zone, even if there are no workers. The narrower lanes and 
-rough pavement can create a hazardous condition. 
-Increase your following distance, watch the traffic around you, and be prepared to stop. 
-Use extreme caution when driving through a work zone at night, whether you see workers or 
-not. 
-Move over when possible to allow space for workers and construction vehicles. 
-Observe the posted work zone signs until you see the End Road Work sign. 
-Expect delays, plan for them, and leave early to reach your destination on time. 
-Use a different route to avoid work zones when possible. 
-Emergency zone 
-An emergency zone is created in response to a roadside situation that requires immediate 
-attention. It could be a crash, broken vehicle, or individual in distress. These are situations 
-nobody plans for, and they require care and patience from all road users. 
-Emergency zones might involve road flares or signs, but roadside response vehicles will use 
-flashing lights. As soon as you see a roadside response vehicle with flashing lights, you must 
-either: 
-Move over into a farther lane. 
-Slow down to at least 10 mph below the posted speed limit. Never drive faster than 50 mph in 
-an emergency zone. 
-Roadside response vehicles could include tow trucks, solid waste trucks, incident response, 
-highway maintenance, utility vehicles, law enforcement, fire trucks, and ambulances. 
-Create a safe space for roadside workers as soon as possible. You can help them while they 
-are there helping others. 
-4.18: Parking 
-General parking rules 
-You’re responsible for making sure your parked vehicle isn’t a hazard to others.  
+Remember: Students might participate in after-school activities, 
+sports teams, or access the playground after hours. Slow down 
+and watch out when you’re driving near a school. Any effort to 
+reduce the risk for children is worth your time and attention.
+WORK ZONEOrange diamond-shaped sign with the text WASHINGTON Give 'em a BRAKE Transportation and Utili
+A work zone is an area where 
+roadwork or construction 
+takes place. It could involve 
+lane closures, detours, and 
+moving equipment.Two construction workers, one holding a "SLOW" sign and the oth
+Be aware of crew members 
+who work to keep travelers 
+safe while vehicles speed 
+past. Employees in work zones 
+are parents, partners, siblings, 
+and friends who need a safe 
+work environment. 
+Please do your part to keep these workers safe.
+•	
+Watch for signs, cones, barrels, large vehicles, and workers 
+when approaching a work zone. 
+•	
+Eliminate distractions to enhance focus. Turn down music 
+and pause conversations. 
+•	
+Always reduce your speed in a work zone, even if there are 
+no workers. The narrower lanes and rough pavement can 
+create a hazardous condition.
+•	
+Increase your following distance, watch the traffic around 
+you, and be prepared to stop.
 
-Make sure to park in designated areas only. Check for signs prohibiting or limiting parking. 
-Colored curb markings can indicate parking restrictions. You’re responsible for making sure your 
-parked vehicle isn’t a hazard to others. 
+•	
+Use extreme caution when driving through a work zone at 
+night, whether you see workers or not.
+•	
+Move over when possible to allow space for workers and 
+construction vehicles.
+•	
+Observe the posted work zone signs until you see the End 
+Road Work sign.
+•	
+Expect delays, plan for them, and leave early to reach your 
+destination on time.
+•	
+Use a different route to avoid work zones when possible.
+ Highway scene with emergency vehicles and cars reacting to a stopped car and a sign reading STATE LAW MOVE OVER SLOW DOWN.
+EMERGENCY ZONE
+An emergency zone is created in response to a roadside 
+situation that requires immediate attention. It could be a crash, 
+broken vehicle, or individual in distress. These are situations 
+nobody plans for, and they require care and patience from all 
+road users.
+
+Emergency zones might involve road flares or signs, but 
+roadside response vehicles will use flashing lights. As soon as 
+you see a roadside response vehicle with flashing lights, you 
+must either:
+1.	 Move over into a farther lane.
+2.	 Slow down to at least 10 mph below the posted 
+speed limit. Never drive faster than 50 mph in an 
+emergency zone. 
+Roadside response vehicles could include tow trucks, solid 
+waste trucks, incident response, highway maintenance, utility 
+vehicles, law enforcement, fire trucks, and ambulances.
+Create a safe space for roadside workers as soon as possible. 
+You can help them while they are there helping others. 
+4.18  |  PARKING
+GENERAL PARKING RULES
+You’re responsible for making sure your parked vehicle isn’t a 
+hazard to others. 
+Make sure to park in designated areas only. Check for signs 
+prohibiting or limiting parking. Colored curb markings can 
+indicate parking restrictions. You’re responsible for making sure 
+your parked vehicle isn’t a hazard to others.
 Do not park: 
-In an intersection. 
+•	
+In an intersection.
+•	
 On a crosswalk, sidewalk, or bicycle lane. 
-Within 30 feet of a traffic signal, stop sign, or yield sign. 
-Within 5 feet of a driveway, alley, or private road. 
-Within 75 feet of a fire station driveway on the opposite side of the street. 
-Within 20 feet of pedestrian safety zones. 
-On railroad tracks. 
+•	
+Within 30 feet of a traffic signal, stop sign, or yield sign.
+•	
+Within 5 feet of a driveway, alley, or private road.
+•	
+Within 75 feet of a fire station driveway on the opposite side 
+of the street.
+
+•	
+Within 20 feet of pedestrian safety zones.
+•	
+On railroad tracks.
+•	
 Within 50 feet of a railroad crossing. 
-In a construction zone. 
-Next to an already parked vehicle (double parking). 
-On the shoulder of the freeway (unless you have an emergency). 
-On a bridge, overpass, or in a tunnel or an underpass. 
-Facing oncoming traffic. 
-More than 12 inches from the curb. 
-Wherever there is a sign that says you cannot park. 
-Within 15 feet of a fire hydrant. 
-Signs or painted curbs 
-Signs or painted curbs might indicate other parking restrictions. This includes: 
-White means that only short stops are permitted. 
-Yellow or red indicates a loading zone or some other restriction. 
-Set your parking brake 
-Always set your parking brake, especially on a hill.  
-Check traffic before you open your door 
-Check your rear and side-view mirror. 
-Open the door with your hand that’s farthest from the door. This is called the “Dutch Reach” 
-method. It forces your body to turn, which allows you to see approaching bicyclists. It also 
-prevents the vehicle door from being opened too quickly. This can protect bicyclists and prevent 
-your door from being damaged by an approaching vehicle. 
+•	
+In a construction zone.
+•	
+Next to an already parked vehicle (double parking).
+•	
+On the shoulder of the freeway (unless you have an 
+emergency). 
+•	
+On a bridge, overpass, or in a tunnel or an underpass.
+•	
+Facing oncoming traffic.
+•	
+More than 12 inches from the curb.
+•	
+Wherever there is a sign that says you cannot park.
+•	
+Within 15 feet of a fire hydrant.
+Signs or painted curbs might indicate other parking restrictions:
+•	
+White means that only short stops are permitted.
+•	
+Yellow or red indicates a loading zone or some other 
+restriction.
+Set your parking brake
+Always set your parking brake, especially on a hill. 
+Check traffic before you open your door
+•	
+Check your rear and side-view mirror.
+•	
+Open the door with your hand that’s farthest from the door. 
+This is called the “Dutch Reach” method. It forces your body 
+to turn, which allows you to see approaching bicyclists. 
+It also prevents the vehicle door from being opened too 
+quickly. This can protect bicyclists and prevent your door 
+from being damaged by an approaching vehicle. 
+Never leave children or animals 
+unattended in a parked vehicle.
 
-Ensure adults, children, and animals properly exit the vehicle 
-It’s a crime to leave a child under the age of 16 unattended in a parked vehicle while the motor 
-is running. 
-It’s a crime to leave a child under the age of 12 unattended in a parked vehicle. 
-It’s a crime to leave an animal unattended in a vehicle if the animal could be harmed or killed by 
-exposure to excessive heat, cold, lack of ventilation, or lack of necessary water. 
-If no one in the immediate area has access to the vehicle, law enforcement is authorized to 
-immediately remove children or animals by any means reasonable to protect their health and 
-safety. The officer, or the agency employing an officer, isn’t responsible for damage to the 
-vehicle if they need to remove children or animals for legal or safety reasons. 
-Take your keys and lock your door 
-Locking your door prevents theft and protects your vehicle against unwanted intruders. 
-Perpendicular and angled parking 
-Entering a perpendicular or angled parking space 
-Identify the space you want to park in, and check traffic. 
-Signal your intention to turn. 
-Move forward slowly, turning the steering wheel left or right as appropriate, until the vehicle 
-reaches the middle of the space. 
-Center the vehicle between the painted lines. 
-Move to the front of the parking space, stop, and secure the vehicle. 
-Exiting a perpendicular or angled parking space 
-Check for traffic in all directions. 
-Continue to check traffic and move straight back until your bumper clears the vehicle parked 
-beside you. 
-Turn the steering wheel sharply in the direction you want your vehicle to move. 
-Clear the parking space and stop. Move forward, accelerating smoothly and steering as needed 
-to straighten the wheels. 
-Parallel parking 
-Entering a parallel parking space 
-Identify the space where you’ll park, check traffic, and signal. 
-Reverse and look in the direction the vehicle will be moving. 
-Back slowly until your front bumper is in line with the rear bumper of the vehicle you’re parking 
-behind. 
+Ensure adults, children, and animals properly exit the 
+vehicle
+•	
+It’s a crime to leave a child under the age of 16 unattended 
+in a parked vehicle while the motor is running.
+•	
+It’s a crime to leave a child under the age of 12 unattended 
+in a parked vehicle.
+•	
+It’s a crime to leave an animal unattended in a vehicle if the 
+animal could be harmed or killed by exposure to excessive 
+heat, cold, lack of ventilation, or lack of necessary water. 
+•	
+If no one in the immediate area has access to the vehicle, 
+law enforcement is authorized to immediately remove 
+children or animals by any means reasonable to protect 
+their health and safety. The officer, or the agency employing 
+an officer, isn’t responsible for damage to the vehicle if 
+they need to remove children or animals for legal or safety 
+reasons.
+Take your keys and lock your door
+Locking your door prevents theft and protects your vehicle 
+against unwanted intruders.
 
-Turn your steering wheel sharply and back slowly into the space. 
-Turn the steering wheel rapidly to center the vehicle into the space. 
-Stop before touching the bumper of the vehicle behind you. 
-Move forward to adjust your vehicle in the parking space. Make sure your vehicle is no more 
-than 12 inches from the curb. 
-Exiting a parallel parking space 
-Check traffic in all directions, place your foot on the brake, shift to reverse, and move backward 
-as much as possible toward the vehicle behind you. 
-Check for traffic and signal. 
-Move forward slowly, steering into the lane. 
-Make sure the front bumper of your vehicle will clear the vehicle ahead; if not, reverse and 
-adjust the steering wheel. 
-Move forward into the closest lane of traffic when your front door clears the rear bumper of the 
-vehicle parked ahead of you. 
-Parking on a hill 
-Always set your parking brake when you park on a hill. You need to make sure your vehicle 
-doesn’t roll into the road. Turning your wheels toward the edge of the road provides additional 
-security in case your parking brake fails. 
-Facing up the hill 
-On hills with tall curbs, turn your steering wheel away from the curb until the back of your front 
-tire touches the curb. If your vehicle starts to roll, it will roll backwards into the curb. On hills with 
-lower or rounded curbs, turning your steering wheel toward the curb might be safer because 
-your vehicle would roll away from the road if your parking brake failed. 
-Facing down the hill 
-Turn your steering wheel toward the curb until the front of your front tire touches the curb. If your 
-vehicle starts to roll, it will roll forward into the curb.  
-If there is no curb 
-Turn your steering wheel and tires toward the edge of the road. This way, if your vehicle starts to 
-roll, it will roll away from traffic.   
-Reserved disabled parking 
-Some parking spots are reserved for vehicles with disabled parking plates or a disabled parking 
-placard. The white stripes next to a reserved space, called an access aisle, must be kept clear. 
-You can be fined for parking in stalls without displaying the required placard and/or for blocking 
-the access aisle. 
+ Diagram showing two red cars maneuvering into perpendicular and angled parking spaces with yellow arrows indicating their paths.
+PERPENDICULAR AND ANGLED PARKING
+Entering a perpendicular or angled parking space
+1.	 Identify the space you want to park in, and check traffic.
+2.	 Signal your intention to turn.
+3.	 Move forward slowly, turning the steering wheel left or 
+right as appropriate, until the vehicle reaches the middle 
+of the space.
+4.	 Center the vehicle between the painted lines.
+5.	 Move to the front of the parking space, stop, and secure 
+the vehicle.
+Exiting a perpendicular or angled parking space
+1.	 Check for traffic in all directions.
+2.	 Continue to check traffic and move straight back until 
+your bumper clears the vehicle parked beside you.
+3.	 Turn the steering wheel sharply in the direction you want 
+your vehicle to move.
+4.	 Clear the parking space and stop. Move forward, 
+accelerating smoothly and steering as needed to 
+straighten the wheels.
 
-If you have a disability that limits or impairs your ability to walk, you may apply for temporary or 
-permanent disabled parking privileges.  Do not hang the parking placard from your rearview 
-mirror while you’re driving because it will obstruct your view. 
-To apply, you and your physician must complete the Disabled Parking Application for Individuals 
-form. 
-Electric vehicle charging station parking 
-It’s illegal to park a vehicle in any electric vehicle charging station if the vehicle is not connected 
-to the charging equipment. 
-4.19: Transporting 
-Towing 
-If you’re towing anything, like a boat, trailer, or camper, you’re responsible for following all 
-manufacturers’ agreements, state laws, and federal standards. You need to know and follow all 
+Three-panel diagram showing a yellow car parallel parking.
+PARALLEL PARKING
+Entering a parallel parking space
+1.	 Identify the space where you’ll park, check traffic, and 
+signal.
+2.	 Reverse and look in the direction the vehicle will be 
+moving.
+3.	 Back slowly until your front bumper is in line with the rear 
+bumper of the vehicle you’re parking behind.
+4.	 Turn your steering wheel sharply and back slowly into the 
+space.
+5.	 Turn the steering wheel rapidly to center the vehicle into 
+the space.
+6.	 Stop before touching the bumper of the vehicle 
+behind you. 
+7.	 Move forward to adjust your vehicle in the parking space. 
+Make sure your vehicle is no more than 12 inches from 
+the curb.
+Exiting a parallel parking space
+1.	 Check traffic in all directions, place your foot on the 
+brake, shift to reverse, and move backward as much as 
+possible toward the vehicle behind you.
+
+2.	 Check for traffic and signal. 
+3.	 Move forward slowly, steering into the lane.
+4.	 Make sure the front bumper of your vehicle will clear the 
+vehicle ahead; if not, reverse and adjust the steering 
+wheel.
+5.	 Move forward into the closest lane of traffic when your 
+front door clears the rear bumper of the vehicle parked 
+ahead of you.Two yellow cars on uphill and downhill roads showing the directions of wheels turned away from the curb (uphill)
+PARKING ON A HILL
+Always set your parking brake when you park on a hill 
+You need to make sure your vehicle doesn’t roll into the road. 
+Turning your wheels toward the edge of the road provides 
+additional security in case your parking brake fails.
+Facing up the hill
+On hills with tall curbs, turn your steering wheel away from the 
+curb until the back of your front tire touches the curb. If your 
+vehicle starts to roll, it will roll backwards into the curb. On hills 
+with lower or rounded curbs, turning your steering wheel toward 
+the curb might be safer because your vehicle would roll away 
+from the road if your parking brake failed.
+
+Facing down the hill
+Turn your steering wheel toward the curb until the front of your 
+front tire touches the curb. If your vehicle starts to roll, it will roll 
+forward into the curb. 
+If there is no curb
+Turn your steering wheel and tires toward the edge of the road. 
+This way, if your vehicle starts to roll, it will roll away from traffic.
+RESERVED DISABLED PARKING
+Some parking spots are reserved for 
+vehicles with disabled parking plates or 
+a disabled parking placard. The white 
+stripes next to a reserved space, called 
+an access aisle, must be kept clear. You 
+can be fined for parking in stalls without 
+displaying the required placard and/or 
+for blocking the access aisle.
+If you have a disability that limits or 
+impairs your ability to walk, you may 
+apply for temporary or permanent 
+disabled parking privileges.Sign for reserved parking for individuals with disabilities, with text and a wheelchair i
+Do not hang the parking placard from your rearview mirror while 
+you’re driving because it will obstruct your view. 
+To apply, you and your physician must complete the Disabled 
+Parking Application for Individuals form, available at 
+dol.wa.gov.
+
+ELECTRIC VEHICLE CHARGING STATION PARKINGSign stating "Electric Vehicle Charging
+It’s illegal to park a vehicle in any 
+electric vehicle charging station if 
+the vehicle is not connected to the 
+charging equipment.
+4.19  |  TRANSPORTING
+TOWING
+If you’re towing anything, like a boat, trailer, or camper, you’re 
+responsible for following all manufacturers’ agreements, state 
+laws, and federal standards. You need to know and follow all 
 guidelines regarding: 
-Weight limits. 
-Vehicle restrictions. 
-Tow cables and taillight hookups. 
+•	
+Weight limits.
+•	
+Vehicle restrictions.
+•	
+Tow cables and taillight hookups.
+•	
 Service brakes. 
-Licensing and documentation. 
-Secure your load 
-Driving with an unsecured load is both against the law and extremely dangerous. Secure your 
-load so loose items don’t release into the air or slide, shift, or fall onto the road and cause a 
-crash. 
+•	
+Licensing and documentation.
+
+SECURE YOUR LOAD
+Driving with an unsecured load is both against the law and 
+extremely dangerous. Secure your load so loose items don’t 
+release into the air or slide, shift, or fall onto the road and cause 
+a crash.
 To secure the load in your vehicle or trailer: 
+•	
 Tie everything down with rope, netting, or straps. 
+•	
 Tie large objects directly to your vehicle or trailer. 
-Pack your vehicle or trailer only with items you can safely and securely carry. 
-Animals 
-It’s illegal for anyone to transport an animal outside a vehicle (such as the bed of a truck) 
-without a protective harness or enclosure, so the animal can’t jump or fall out. 
-It’s a misdemeanor to transport animals in a way that would pose a risk to the animal or public 
-safety, according to Washington’s Prevention of Cruelty to Animals laws. If you’re taken into 
-custody for any reason, an officer can take charge of any animal(s) in the vehicle. If your animal 
-is in police custody, you’ll need to pay a fee before you can collect the animal. 
-It’s illegal to engage in any activity that takes your focus off safely driving your vehicle. Animals 
-that are loose in a vehicle or riding on the driver’s lap are a potential distraction. 
+•	
+Pack your vehicle or trailer only with items you can safely 
+and securely carry.
+ANIMALS
+•	
+It’s illegal for anyone to transport an animal outside a vehicle 
+(such as the bed of a truck) without a protective harness or 
+enclosure, so the animal can’t jump or fall out.
+•	
+It’s a misdemeanor to transport animals in a way that would 
+pose a risk to the animal or public safety, according to 
+Washington’s Prevention of Cruelty to Animals laws. If you’re 
+taken into custody for any reason, an officer can take charge 
+of any animal(s) in the vehicle. If your animal is in police 
+custody, you’ll need to pay a fee before you can collect the 
+animal. 
+•	
+It’s illegal to engage in any activity that takes your focus off 
+safely driving your vehicle. Animals that are loose in a vehicle 
+or riding on the driver’s lap are a potential distraction.
 
-4.20: Maritime 
-Ferries 
-Washington State Ferries, sometimes referred to as the state’s marine highway system, are part 
-of Washington’s highway network. As part of that network, all rules of the road apply. 
-As you approach the ferry terminal, you might see signs directing you into a designated ferry 
-lane. Pull up behind other vehicles already in line. Ferry line-cutting is a traffic offense that can 
-lead to a fine. If you’re in a ferry holding lane in a residential area, please don’t block residential 
-driveways or intersections. 
-Bicyclists receive priority loading on most ferries and have a bicycle waiting area in front of 
-motor vehicles. Bicyclists can proceed past vehicles waiting in the ferry holding lane. For more 
-information about the Washington State Ferries system, or for fares and schedules, please visit 
-wsdot.wa.gov and search for ferries. 
-Beaches 
-Driving is allowed on ocean beaches only in Grays Harbor and Pacific Counties. The beach is 
-considered a state highway, so all driving laws apply. The speed limit is 25 mph, and 
-pedestrians and bicyclists have the right-of-way at all times. 
-You may enter the beach with your vehicle only through marked beach approaches and drive 
-only on hard-packed sand. Watch for signs prohibiting beach driving in some areas and 
-circumstances. 
- 
-Chapter 5: Hazards 
-5.0: Dangers of driving 
-You know there are serious risks and consequences to driving. You will make mistakes, and 
-those around you will make mistakes. Even though risk is always present, driving safely can 
-reduce crash potential. 
-Navigating risk involves being aware, predictable, smooth, and proficient behind the wheel. To 
-drive well and without incidents, you need to intentionally develop and use safe driving habits as 
-your default driving style. 
-Fatal crash common factors include: 
-Speed 
-Impairment 
-Distractions 
-Unrestrained occupants 
-Inexperience* 
-*In Washington, vehicle crashes are a leading causes of death for people ages 16 to 25. This 
-age group is more susceptible to fatal and serious injury crashes. 
+4.20  |  MARITIME
+FERRIES
+Washington State Ferries, sometimes referred to as the state’s 
+marine highway system, are part of Washington’s highway 
+network. As part of that network, all rules of the road apply.
+As you approach the ferry terminal, you might see signs 
+directing you into a designated ferry lane. Pull up behind other 
+vehicles already in line. Ferry line-cutting is a traffic offense that 
+can lead to a fine. If you’re in a ferry holding lane in a residential 
+area, please don’t block residential driveways or intersections.
+Bicyclists receive priority loading on most ferries and have a 
+bicycle waiting area in front of motor vehicles. Bicyclists can 
+proceed past vehicles waiting in the ferry holding lane. For 
+more information about the Washington State Ferries system, 
+or for fares and schedules, please visit wsdot.wa.gov and search 
+for ferries.
+BEACHES
+Driving is allowed on ocean beaches only in Grays Harbor and 
+Pacific counties. The beach is considered a state highway, so all 
+driving laws apply. The speed limit is 25 mph, and pedestrians 
+and bicyclists have the right-of-way at all times.
+You may enter the beach with your vehicle only through marked 
+beach approaches and drive only on hard-packed sand. 
+Watch for signs prohibiting beach driving in some areas and 
+circumstances.
 
-Risk awareness 
-Risk awareness is your ability to identify present and potential hazards on the road. It helps you 
-be aware of things that might require you to change your behavior to avoid a crash. Risk 
-awareness includes being mindful of other road users, weather conditions, and potential 
-distractions.  
-Risk awareness relies on understanding what is happening around you and what may happen 
-next. 
-Keep your head scanning continually. Stay aware of what’s happening in front of you, beside 
-you, and behind you. You can do this by using your peripheral vision and mirrors. 
-Leave enough space in front of your vehicle to see what’s happening on the road ahead. 
-Check behind you after spotting a hazard that requires you to make a change. What’s 
-happening behind you can affect your decision-making. 
-It’s impossible to remove risk completely. However, you can learn how to avoid or minimize risks 
-by identifying them and then adjusting your driving appropriately.  
-Hazard perception 
-Hazard perception is your ability to scan for potential risks on the road and to identify them 
-before they become a problem. This skill is important for safe driving and helps prevent crashes. 
-Hazard perception requires: 
-Attentiveness. 
-Quick decision-making. 
-Ability to react appropriately to changing situations. 
-A hazard is anything that requires you to make a change. When you’re behind the wheel, you 
-should always be looking for hazards or responding to them. 
+Chapter 5 Risk 
+imag
+e o
+f a
+ red 
+car on a h
+azardous r
+oad with 
+cauti
+o
+n cones, rock debris, and warning signs.
+
+5.0  |  DANGERS OF DRIVING
+You know there are serious risks and consequences to driving. 
+You will make mistakes, and those around you will make 
+mistakes. Even though risk is always present, driving safely can 
+reduce crash potential.
+Navigating risk involves being aware, predictable, smooth, and 
+proficient behind the wheel. To drive well and without incidents, 
+you need to intentionally develop and use safe driving habits as 
+your default driving style.
+Fatal crash common factors
+•	
+Speed
+•	
+Impairment
+•	
+Distractions
+•	
+Unrestrained occupants
+•	
+Inexperience*
+*In Washington, vehicle crashes are a leading causes of death
+for people ages 16 to 25. This age group is more susceptible to 
+fatal and serious injury crashes. 
+RISK AWARENESS
+Risk awareness is your ability to identify present and potential 
+hazards on the road. It helps you be aware of things that might 
+require you to change your behavior to avoid a crash. Risk 
+awareness includes being mindful of other road users, weather 
+conditions, and potential distractions. 
+Risk awareness relies on understanding what is happening 
+around you and what may happen next. 
+•	
+Keep your head scanning continually. Stay aware of what’s
+happening in front of you, beside you, and behind you. You 
+can do this by using your peripheral vision and mirrors. 
+
+•	
+Leave enough space in front of your vehicle to see what’s 
+happening on the road ahead. 
+•	
+Check behind you after spotting a hazard that requires you 
+to make a change. What’s happening behind you can affect 
+your decision-making
+It’s impossible to remove risk completely. However, you can 
+learn how to avoid or minimize risks by identifying them and 
+then adjusting your driving appropriately.
+HAZARD PERCEPTION
+Hazard perception is your ability to scan for potential risks on 
+the road and to identify them before they become a problem. 
+This skill is important for safe driving and helps prevent crashes. 
+Hazard perception requires:
+•	
+Attentiveness.
+•	
+Quick decision-making.
+•	
+Ability to react appropriately to changing situations.
+A hazard is anything that requires you to make a change. 
+When you’re behind the wheel, you should always 
+be looking for hazards or responding to them.
 A hazard might require you to change your speed or direction. 
-A hazard can be an immediate danger, such as a child running out onto the road, or something 
-less serious, such as a trash can in the road, coming up to a speed limit sign, or approaching 
-the turn to your driveway. 
+•	
+A hazard can be an immediate danger, such as a child 
+running out onto the road, or something less serious, such 
+as a trash can in the road, coming up to a speed limit sign, or 
+approaching the turn to your driveway. 
+•	
 A hazard can be stationary or moving. 
-There could be more than one hazard at the same time. It’s your responsibility as a driver to 
-determine which hazard requires the most urgent response. 
-Drive slower when approaching hazards to give yourself more space and time to make safe 
-decisions. 
-Situational awareness 
-Situational awareness is observing what is happening all around you and predicting what you 
-should prepare for next. You should do this constantly. 
+•	
+There could be more than one hazard at the same time. It’s 
+your responsibility as a driver to determine which hazard 
+requires the most urgent response.
+Drive slower when approaching hazards to give yourself more 
+space time to make safe decisions.
 
-You need to know who might be affected by your actions and who needs to know your 
-intentions. The drivers behind you could be the most affected by your decisions.  
-Hazard management 
-You will encounter an unlimited number of situations on the road. It would be difficult to predict 
-or have a plan for each one. Instead, you should develop a reliable routine for responding to 
-hazards that requires you to: 
-Plan. Scan your environment to know what’s happening around you. Be sure you also look in 
-your rearview mirror to see what’s happening behind you. Decide if the change you want to 
-make is safe. 
-Communicate. Let others know what you plan to do. Use your signals and make sure everyone 
-is well aware of your intentions. 
-Check. Prepare your vehicle position and speed so you have adequate space to make your 
-change with no more than medium braking. Recheck your mirrors and look over your shoulder 
-for pedestrians and bicyclists. Make sure no other drivers are trying to move into the same 
-space. 
-Execute. Make the change smoothly. Try not to surprise anyone. Be ready to change your plan 
-if needed. 
-Evaluate. Think about how it went. See if you need to adjust your routine for next time. 
-5.1: Speed 
-Even if you’re in a hurry, the risks of speeding are not worth it. Speeding puts everyone on the 
-road in danger. Follow the posted speed limit to protect yourself, the people who care about 
-you, and the other individuals and families sharing the road with you.  
-Following the posted speed limit is about more than following the law. Even if you’re in a hurry, 
-the risks of speeding are not worth it. Speeding puts everyone on the road in danger. Prioritize 
-safety and drive at a speed that allows you to maintain control and react to hazards. 
-Excessive speeds 
-Driving over the speed limit could harm your car, other people, and you. Excessive speeds can: 
-Reduce the effectiveness of seat belts. Seat belts are designed to protect you in a crash, but 
-their effectiveness decreases at higher speeds. 
-Limit your ability to visually scan for hazards. The faster you drive, the less time you have to 
-scan the road ahead for potential dangers, like pedestrians, cyclists, or other vehicles. 
-Reduce vehicle and traction control. High speeds can make it harder to control your vehicle, 
-especially in adverse conditions like rain or snow. This can lead to skidding or losing control 
-entirely. 
-Create longer stopping distances. It takes longer to stop a vehicle at higher speeds. This 
-increases the risk of a collision if you need to brake suddenly. 
+SITUATIONAL AWARENESS
+Situational awareness is observing what is happening all around 
+you and predicting what you should prepare for next. You 
+should do this constantly. 
+You need to know who might be affected by your actions and 
+who needs to know your intentions. The drivers behind you 
+could be the most affected by your decisions. 
+HAZARD MANAGEMENT 
+You will encounter an unlimited number of situations on the 
+road. It would be difficult to predict or have a plan for each one. 
+Instead, you should develop a reliable routine for responding to 
+hazards that requires you to:
+•	
+Plan. Scan your environment to know what’s happening 
+around you. Be sure you also look in your rearview mirror to 
+see what’s happening behind you. Decide if the change you 
+want to make is safe.
+•	
+Communicate. Let others know what you plan to do. Use 
+your signals and make sure everyone is well aware of your 
+intentions.
+•	
+Check. Prepare your vehicle position and speed so you 
+have adequate space to make your change with no more 
+than medium braking. Recheck your mirrors and look over 
+your shoulder for pedestrians and bicyclists. Make sure no 
+other drivers are trying to move into the same space.
+•	
+Execute. Make the change smoothly. Try not to surprise 
+anyone. Be ready to change your plan if needed.
+•	
+Evaluate. Think about how it went. See if you need to adjust 
+your routine for next time.
 
-Give you less time to assess your path of travel and make necessary changes. Speeding gives 
-you less time to react to changes in the road, such as curves, intersections, or obstacles. 
-Increase the severity of injuries in the event of a crash. The force of impact in a crash increases 
-with speed, leading to more severe injuries or fatalities. 
-Speed limits 
-Speed limits indicate the maximum speed legal under ideal conditions. Washington law also 
-requires you to drive at speeds that are safe for current road conditions. This means reducing 
-your speed when conditions are poor. You can drive below the speed limit, but exceeding it is 
-illegal. 
-You’re responsible for always driving at a safe speed, regardless of the posted limit. 
-Adjusting speed for conditions 
-Speeding is a dangerous and unnecessary risk. Arriving late is better than not arriving at all. 
-Reduce your speed in conditions like the following: 
-Sharp curves or hills where visibility is limited 
-Slippery roads due to rain, snow, or ice 
-Areas with pedestrians, children, cyclists, or animals 
-Shopping centers, parking lots, and areas with heavy foot traffic 
-Heavy traffic congestion 
-Narrow bridges and tunnels 
-Residential areas 
-5.2: Space 
-Judging space when you’re driving is a valuable skill. It can take time and practice before you’re 
-proficient, which is why novice drivers are at a greater risk. You can judge space by distance or 
-time, but you need to constantly evaluate your position on the road. Try to keep plenty of space 
-around you as you drive.  
-You can reduce your risk and give yourself time to determine an alternative path, if needed, by 
-leaving enough space around your vehicle. It will provide additional room to take action should 
-there be a problem in your path of travel. When you’re driving near other vehicles, it’s important 
-to leave a distance that’s at least twice the length of your vehicle between you and the vehicle 
-ahead. When merging, give yourself enough space so you safely apply your hazard 
-management routine to plan, communicate, check, execute, and evaluate. 
-5.3: Merging 
-When you’re merging, enter traffic with enough space so you don’t cause the people around you 
-to swerve, slow, or stop. Trying to merge into a space that is too small can be dangerous, 
-especially if the driver in front needs to stop or slow down. 
+5.1  |  SPEED
+Even if you’re in a hurry, the risks of speeding are not worth 
+it. Speeding puts everyone on the road in danger. Follow the 
+posted speed limit to protect yourself, the people who care 
+about you, and the other individuals and families sharing the 
+road with you. 
+Following the posted speed limit is about more than following 
+the law. Even if you’re in a hurry, the risks of speeding are 
+not worth it. Speeding puts everyone on the road in danger. 
+Prioritize safety and drive at a speed that allows you to maintain 
+control and react to hazards.
+EXCESSIVE SPEEDS
+Driving over the speed limit could harm your car, other people, 
+and you. Excessive speeds can:
+•	
+Reduce the effectiveness of seat belts. Seat belts are 
+designed to protect you in a crash, but their effectiveness 
+decreases at higher speeds.
+•	
+Limit your ability to visually scan for hazards. The faster 
+you drive, the less time you have to scan the road ahead 
+for potential dangers, like pedestrians, cyclists, or other 
+vehicles.
+•	
+Reduce vehicle and traction control. High speeds can 
+make it harder to control your vehicle, especially in adverse 
+conditions like rain or snow. This can lead to skidding or 
+losing control entirely.
+•	
+Create longer stopping distances. It takes longer to stop a 
+vehicle at higher speeds. This increases the risk of a collision 
+if you need to brake suddenly.
+•	
+Give you less time to assess your path of travel and 
+make necessary changes. Speeding gives you less time to 
+react to changes in the road, such as curves, intersections, 
+or obstacles.
 
-Drivers already on the interstate have the right-of-way, so creating space to merge might require 
-you to adjust your speed, faster or slower. Use the entire on-ramp, your turn signal, and your 
-mirrors to merge into a safe space on the interstate. 
-Zipper merging 
-When traffic is moving slowly or is stopped due to a lane closure, it’s important to merge 
-smoothly and efficiently. Zipper merging is a technique that: 
-Improves traffic flow by 60 percent. 
-Creates a predictable merging pattern, reducing the risk of collisions caused by sudden lane 
-changes. 
-Helps avoid the frustration of long lines and the temptation to cut in line. 
-How to zipper merge: 
-Stay in your lane. Continue using both lanes until you reach the designated merge area. 
-Take turns. Alternate merging with vehicles from the other lane, like the teeth of a zipper coming 
-together. 
-Be courteous. Allow one vehicle from the ending lane to merge in front of you, then merge into 
-the open lane. 
-Maintain speed. Continue merging at a steady pace, matching the speed of traffic in the open 
-lane. 
-5.4: Time 
-To reduce risk, give yourself plenty of time to evaluate and move through traffic. You can use a 
-technique, like eye-lead time, which allows you to scan the road ahead for potential hazards. 
-Eye-lead time is an important part of defensive driving. It gives you time to see, analyze, and 
-respond to hazards. Scan as far as you can see ahead and to the sides. Use your mirrors to 
-scan behind. The earlier you identify a hazard, the more time you have to prepare for it and the 
-more time those around you have to adjust to your changes. This is a proactive approach to 
-driving. It’s less risky than relying on your reactions to avoid danger. 
-Count seconds 
-Practice judging the space your vehicle will travel in a short amount of time using this simple 
-exercise: 
-Pick out a marker, such as a road sign or utility pole, that you think is 15 seconds ahead of your 
-vehicle. 
-Count until you reach the marker. 
-Guessing before you count helps you develop the ability to correctly estimate the distance your 
-vehicle will travel in seconds. Your accuracy will improve as you continue to practice this 
-method. 
+•	
+Increase the severity of injuries in the event of a crash. 
+The force of impact in a crash increases with speed, leading 
+to more severe injuries or fatalities.
+SPEED LIMITS
+Speed limits indicate the maximum speed legal under ideal 
+conditions. Washington law also requires you to drive at speeds 
+that are safe for current road conditions. This means reducing 
+your speed when conditions are poor. You can drive below the 
+speed limit, but exceeding it is illegal.
+You’re responsible for always driving at a safe 
+speed, regardless of the posted limit.
+ 
+ADJUSTING SPEED FOR CONDITIONS
+Speeding is a dangerous and unnecessary risk. Arriving late is 
+better than not arriving at all. Reduce your speed in conditions 
+like the following:
+•	
+Sharp curves or hills where visibility is limited
+•	
+Slippery roads due to rain, snow, or ice
+•	
+Areas with pedestrians, children, cyclists, or animals
+•	
+Shopping centers, parking lots, and areas with heavy foot 
+traffic
+•	
+Heavy traffic congestion
+•	
+Narrow bridges and tunnels
+•	
+Residential areas
 
-It is crucial to give yourself time to stop or maneuver around obstacles and in unpredictable 
-traffic situations. With enough time, you can evaluate and prioritize your decisions in traffic. This 
-can help reduce panic and impulsive reactions. 
-Turning in front of approaching vehicles 
-You’ll get better with experience, but it can be challenging to judge how much time you have to 
-turn when facing oncoming traffic. It’s better to give yourself too much time than not enough. 
-Remember approaching traffic has the right-of-way. You can watch oncoming vehicles pass a 
-marker on the side of the road, like a tree, and count how many seconds it takes until they clear 
-the road you want to turn onto. 
-You can use that time frame to estimate how long the next vehicle will take to travel the same 
-distance. Then you know when you have enough time to turn safely. 
-Turning into the flow of traffic requires something similar. You need time to complete your turn 
-without impacting the flow of traffic you’re entering. You need enough time to make the turn and 
-reach the speed of oncoming traffic. 
-5.5: Focus 
-Being mindful will help you prioritize safety and awareness on the road. 
-Be mentally present. Commit to being fully engaged and focused on driving. Turn off distractions 
-like your phone and in-car entertainment systems. 
-Be prepared. Anticipate hazards by scanning the road ahead. Maintain awareness of your 
-surroundings. 
-Be proactive. Adjust your speed and driving behavior based on road conditions, weather, and 
-traffic. 
-Attention 
-Your full attention is essential for safe driving. Your brain can only focus on one thing at a time. 
-Choose to actively pay attention when you’re behind the wheel. Align your mental attention and 
-visual focus. Your attention is the most valuable asset on the road. 
-Eliminate internal and external distractions. Distractions, even for a few seconds, can have 
-devastating consequences. By staying focused and avoiding distractions, you can significantly 
-reduce your risk of being involved in a crash. 
-Field of vision 
-You’ll use three types of vision while you’re driving. Higher speeds reduce the quality of each 
-type of vision. 
-Central vision allows you to see detail straight in front of you. It’s the vision you’re using to read 
-these words. 
-Fringe vision is what you use to see the edges of the driver guide pages. You can see it, but it 
-may not be very focused. 
+5.2  |  SPACE
+Judging space when you’re driving is a valuable skill. It can take 
+time and practice before you’re proficient, which is why novice 
+drivers are at a greater risk. You can judge space by distance or 
+time, but you need to constantly evaluate your position on the 
+road. Try to keep plenty of space around you as you drive. 
+You can reduce your risk and give yourself time to determine 
+an alternative path, if needed, by leaving enough space around 
+your vehicle. It will provide additional room to take action should 
+there be a problem in your path of travel. 
+When you’re driving near other vehicles, it’s important to leave a 
+distance that’s at least twice the length of your vehicle between 
+you and the vehicle ahead. When merging, give yourself 
+enough space so you safely apply your hazard management 
+routine to plan, communicate, check, execute, and evaluate.
+Illustrat
 
-Peripheral vision is what you can see to the side of you without losing focus on the words. It 
-could be the walls of the room you’re in or someone walking past you. 
-Path of travel 
-Your path of travel is the route or course you drive to get from one place to another. 
-You’ll likely need to change your path at some point. You might need to adjust because of a 
-hazard, weather conditions, or because you need to travel in a new direction. You’ll need to 
-visualize your new target area and intended path of travel. 
-A big part of driving is constantly shifting your visual focus and mental attention between where 
-you are and where you want to be. 
-Line of sight 
-Once you pick the area where you want to be, your line of sight is what’s between you and that 
-target. You will switch your visual and mental attention between your path of travel and line of 
-sight quickly and repeatedly. 
-Recognize you will divide visual focus and mental attention among: 
-Your path of travel 
-Your line of sight 
-Your intended target area 
-Present and potential hazards 
-Your vehicle (interior and exterior) 
-Other road users 
-Yourself 
-Information gathering 
-Intentional focus and active attention help you gather the information you need to make wise 
-decisions behind the wheel. Scanning your path of travel and line of sight is a continuous 
-process that can sometimes feel overwhelming, especially when you’re first learning to drive. 
-Set yourself up for success by forming habits and routines involving constant vigilance and 
-minimal distractions. 
-5.6: Road and driving conditions 
-Part of driving means following speed limits and adjusting for road conditions. For example, you 
-slow down before a sharp curve, when the roadway is slippery, or when there is water on the 
-road to help you maintain control of your vehicle. Your hazard awareness, decision-making, and 
-wise choices have a huge impact on how safely you travel in different conditions. 
-Night driving 
-It’s harder to see at night, and you should: 
-Drive at a speed that will allow you to stop within the glow of your headlights (usually 400 feet). 
+5.3  |  MERGING
+When you’re merging, enter traffic with enough space so you 
+don’t cause the people around you to swerve, slow, or stop. 
+Trying to merge into a space that is too small can be dangerous, 
+especially if the driver in front needs to stop or slow down. The image depicts two cars on a highway, showing a lane change scenario. The road has two lanes with a green car in the left lane traveling straight and a red car 
+Drivers already on the 
+interstate have the 
+right-of-way, so creating 
+space to merge might 
+require you to adjust 
+your speed, faster or 
+slower. Use the entire 
+on-ramp, your turn 
+signal, and your mirrors 
+to merge into a safe 
+space on the interstate.
+ZIPPER MERGING
+When traffic is moving slowly or is stopped due to a lane 
+closure, it’s important to merge smoothly and efficiently. Zipper 
+merging is a technique that:
+•	
+Improves traffic flow by 60 percent.
+•	
+Creates a predictable merging pattern, reducing the risk of 
+collisions caused by sudden lane changes.
+•	
+Helps avoid the frustration of long lines and the temptation 
+to cut in line.
+ 
+How to zipper merge:
+•	
+Stay in your lane. Continue using both lanes until you 
+reach the designated merge area.
 
-Use your high beams whenever there are no oncoming vehicles. Switch back to your regular 
-headlights when there is approaching traffic. 
-Use your regular headlights when following another vehicle. 
-Avoid looking directly into oncoming headlights. Keep your eyes searching the road in front of 
-your vehicle. 
-Try to search beyond your headlight beams. Look for dark shapes or shadows on the roadway. 
-Glance occasionally to the sides to find the edge of the pavement and to spot hazards that 
-might come from the sides. 
-Do not wear sunglasses or colored lenses when driving at night or on overcast days. Tinted or 
-colored lenses reduce your vision. 
-Increase your following distance for night driving conditions and driving on unfamiliar roadways 
-at night. 
-If a vehicle comes toward you with its high beams on, look toward the right side of the road to 
-keep from being distracted by the headlights. 
-Curves 
-Driving around curves requires awareness of the road and control of your vehicle. Smooth 
-steering and smart driving habits give you some control over your road position and balance. 
-The laws of motion, which are out of your control, also impact road position and balance. 
-Approaching a curve 
-Watch your speed. Reduce your speed before entering the curve. This helps maintain traction 
-and prevents your vehicle from skidding or veering off the road. Uphill curves could require 
-more acceleration, while downhill curves might require more braking. 
-Look ahead. Scan the road ahead to anticipate the sharpness and length of the curve. This will 
-help you determine the appropriate speed and steering adjustments. 
-Choose the best lane position. Position your vehicle slightly to the outside of the lane as you 
-approach the curve. This will give you more room to maneuver and improve your visibility 
-around the curve. 
-In the curve 
-Maintain a steady speed. Avoid braking or accelerating suddenly while in the curve. This can 
-disrupt your vehicle’s balance and lead to a loss of control. 
-Gentle steering. Steer smoothly and gradually through the curve. Avoid oversteering or jerky 
-movements, which can cause your vehicle to skid. 
-Be prepared to adjust. Be ready to adjust your speed or steering based on road conditions, 
-visibility, and the behavior of other drivers. 
-Exiting the curve 
+•	
+Take turns. Alternate merging with vehicles from the other 
+lane, like the teeth of a zipper coming together.
+•	
+Be courteous. Allow one vehicle from the ending lane to 
+merge in front of you, then merge into the open lane.
+•	
+Maintain speed. Continue merging at a steady pace, 
+matching the speed of traffic in the open lane.
+5.4  |  TIME
+To reduce risk, give yourself plenty of time to evaluate and move 
+through traffic. You can use a technique, like eye-lead time, 
+which allows you to scan the road ahead for potential hazards. 
+Eye-lead time is an important part of defensive driving. It gives 
+you time to see, analyze, and respond to hazards. Scan as far 
+as you can see ahead and to the sides. Use your mirrors to 
+scan behind. The earlier you identify a hazard, the more time 
+you have to prepare for it and the more time those around you 
+have to adjust to your changes. This is a proactive approach 
+to driving. It’s less risky than relying on your reactions to avoid 
+danger.
+COUNT SECONDS
+Practice judging the space your vehicle will travel in a short 
+amount of time using this simple exercise: 
+1.	 Pick out a marker, such as a road sign or utility pole, that 
+you think is 15 seconds ahead of your vehicle.
+2.	 Count until you reach the marker.
+Guessing before you count helps you develop the ability 
+to correctly estimate the distance your vehicle will travel in 
+seconds. Your accuracy will improve as you continue to practice 
+this method.
+It is crucial to give yourself time to stop or maneuver around 
+obstacles and in unpredictable traffic situations. With enough 
 
-Accelerate gradually. As you exit the curve, gently accelerate back to your desired speed. This 
-will help you maintain stability and transition smoothly back into traveling straight. 
-Check your mirrors. Scan your mirrors to ensure you have adequate space to merge or change 
-lanes if needed. 
-Laws of motion 
-When driving on curved roads, it’s important to understand the forces affecting your vehicle and 
-adjust your driving to stay in control. 
-Roll and yaw. Roll affects how much your vehicle tilts during a turn, yaw affects side-to-side 
-movement, and both are important for maintaining control. Adjusting your speed and steering 
-can help balance your roll and yaw while driving through curves. 
-Momentum. When you’re driving in a straight line, your vehicle has momentum in that direction. 
-However, when you enter a curve, you need to change the direction and momentum of your 
-vehicle. 
-Inertia. In a curve, your vehicle will want to pull a little to keep you moving in a straight line. If 
-you suddenly turn the steering wheel, inertia will try to keep the car moving straight. This is why 
-you must carefully steer to smoothly make the turn. 
-Kinetic energy. Higher speeds create more energy, requiring more time and space to stop or 
-change direction. Slowing down for curves lowers your vehicle’s kinetic energy and helps you 
-make the turn without losing traction or control. 
-Friction. Friction is the force between the tires and the road. It allows your vehicle to grip the 
-surface. The more friction there is, the better your tires can grip the road. This helps you slow 
-down, speed up, or turn safely. Slippery roads due to rain, snow, or ice can significantly reduce 
-friction in curves. Slow down even more and avoid sudden movements in these conditions. 
-Slippery roads 
-Washington weather can cause slippery roads. Rain, snow, and sleet create dangers on the 
-roadway. When the road is slippery, you must adjust your driving for the conditions, which might 
-require you to drive below the posted speed limit. 
-If it starts to rain on a hot day, the pavement can be very slippery for the first few minutes. Heat 
-causes the oil in the asphalt to come to the surface. The road is slippery until the oil washes 
-away. 
-Snowy roads will require a larger following distance and dramatically reduced speed. 
-Use snow tires or chains when it’s required. 
-During winter months, you can improve traction by adding chains to your tires or changing to 
-studded tires. 
-Avoid icy roads as much as possible. If you must drive on icy roads, slow down and leave extra 
-space around your vehicle. 
+time, you can evaluate and prioritize your decisions in traffic. 
+This can help reduce panic and impulsive reactions.
+TURNING IN FRONT OF APPROACHING VEHICLES
+You’ll get better with experience, but it can be challenging to 
+judge how much time you have to turn when facing oncoming 
+traffic. It’s better to give yourself too much time than not 
+enough.The image illustrates a four-way intersection with two lanes of traffic running horizontally and vertically. A blue car is in the left lane heading downward, indicated by a solid green arrow. Opposite the blue car, a red car is positioned in a left-turn lane, indicated by a dashed red arrow pointing left. The intersection is bordered by sidewalks and patches of greenery on the top left. There is a yellow car in the right lane heading upward. Road markings include lane dividers and turning arrows. Two pedestrian crosswalks are visible at the top and bottom of the intersection.
+Remember 
+approaching traffic 
+has the right-of-
+way. You can watch 
+oncoming vehicles 
+pass a marker on the 
+side of the road, like a 
+tree, and count how 
+many seconds it takes 
+until they clear the 
+road you want to turn 
+onto.
+You can use that time frame to estimate how long it will take the 
+next vehicle to travel the same distance. Then you know when 
+you have enough time to turn safely.
+
+Three vehicles in an intersection going in different directions.
+A silver car on a straight road with white dashed lane markings to the right and two solid yellow lane markings to the left.
+A green and white truck on a straight road with white dashed lane markings to the left and two solid yellow lane markings to the right.
+A red car turning at an intersection to the right. A red “YIELD” sign is present in front of the red car.
+There is a surrounding area colored in blue to represent safety area boundaries.
+Turning into the flow 
+of traffic requires 
+something similar. You 
+need time to complete 
+your turn without 
+impacting the flow of 
+traffic you’re entering. 
+You need enough time 
+to make the turn and 
+reach the speed of 
+oncoming traffic.
+5.5  |  FOCUS
+Being mindful will help you prioritize safety and awareness on 
+the road.
+•	
+Be mentally present. Commit to being fully engaged and 
+focused on driving. Turn off distractions like your phone and 
+in-car entertainment systems.
+•	
+Be prepared. Anticipate hazards by scanning the road 
+ahead. Maintain awareness of your surroundings.
+•	
+Be proactive. Adjust your speed and driving behavior 
+based on road conditions, weather, and traffic.
+ATTENTION
+Your full attention is essential for safe driving. Your brain can 
+only focus on one thing at a time. Choose to actively pay 
+attention when you’re behind the wheel. Align your mental 
+attention and visual focus. Your attention is the most valuable 
+asset on the road.
+Eliminate internal and external distractions. Distractions, even 
+for a few seconds, can have devastating consequences. By 
+staying focused and avoiding distractions, you can significantly 
+reduce your risk of being involved in a crash.
+
+FIELD OF VISION
+You’ll use three types of vision while you’re driving. Higher 
+speeds reduce the quality of each type of vision.
+1.	 Central vision allows you to see detail straight in front of 
+you. It’s the vision you’re using to read these words.
+2.	 Fringe vision is what you use to see the edges of the 
+driver guide pages. You can see it, but it may not be very 
+focused.
+3.	 Peripheral vision is what you can see to the side of you 
+without losing focus on the words. It could be the walls of 
+the room you’re in or someone walking past you.
+Overhead view of a car with se
+
+PATH OF TRAVEL
+Your path of travel is the route or course you drive to get from 
+one place to another.
+You’ll likely need to change your path at some point. You might 
+need to adjust because of a hazard, weather conditions, or 
+because you need to travel in a new direction. You’ll need to 
+visualize your new target area and intended path of travel.
+A big part of driving is constantly shifting your visual focus and 
+mental attention between where you are and where you want 
+to be. 
+A green car merging onto a main road with other cars, showing path of travel and line of sigh
+LINE OF SIGHT
+Once you pick the area where you want to be, your line of sight 
+is what’s between you and that target. You will switch your visual 
+and mental attention between your path of travel and line of 
+sight quickly and repeatedly. Recognize you will to divide visual 
+focus and mental attention among:
+
+•	
+Your path of travel
+•	
+Your line of sight
+•	
+Your intended target area
+•	
+Present and potential hazards
+•	
+Your vehicle (interior and exterior)
+•	
+Other road users
+•	
+Yourself
+INFORMATION GATHERING
+Intentional focus and active attention help you gather the 
+information you need to make wise decisions behind the wheel. 
+Scanning your path of travel and line of sight is a continuous 
+process that can sometimes feel overwhelming, especially 
+when you’re first learning to drive. Set yourself up for success 
+by forming habits and routines involving constant vigilance and 
+minimal distractions.
+ 
+5.6  |  ROAD AND DRIVING CONDITIONS
+Part of driving means following speed limits and adjusting for 
+road conditions. For example, you slow down before a sharp 
+curve, when the roadway is slippery, or when there is water 
+on the road to help you maintain control of your vehicle. Your 
+hazard awareness, decision-making, and wise choices have a 
+huge impact on how safely you travel in different conditions.
+NIGHT DRIVING
+It’s harder to see at night, and you should:
+•	
+Drive at a speed that will allow you to stop within the glow of 
+your headlights (usually 400 feet).
+•	
+Use your high beams whenever there are no oncoming 
+vehicles. Switch back to your regular headlights when there 
+is approaching traffic.
+
+•	
+Use your regular headlights when following another vehicle.
+•	
+Avoid looking directly into oncoming headlights. Keep your 
+eyes searching the road in front of your vehicle.
+•	
+Try to search beyond your headlight beams. Look for dark 
+shapes or shadows on the roadway.
+•	
+Glance occasionally to the sides to find the edge of the 
+pavement and to spot hazards that might come from the 
+sides.
+•	
+Do not wear sunglasses or colored lenses when driving at 
+night or on overcast days. Tinted or colored lenses reduce 
+your vision.
+•	
+Increase your following distance for night driving conditions 
+and driving on unfamiliar roadways at night.
+If a vehicle comes toward you with its high beams on, 
+look toward the right side of the road to keep from being 
+distracted by the headlights.
+CURVES A car turning with the center of rotation indicated.
+Driving around curves requires 
+awareness of the road and 
+control of your vehicle. Smooth 
+steering and smart driving 
+habits give you some control 
+over your road position and 
+balance. The laws of motion, 
+which are out of your control, 
+also impact road position and 
+balance.
+
+Approaching a curve
+•	
+Watch your speed. Reduce your speed before entering 
+the curve. This helps maintain traction and prevents your 
+vehicle from skidding or veering off the road. Uphill curves 
+could require more acceleration, while downhill curves 
+might require more braking.
+•	
+Look ahead. Scan the road ahead to anticipate the 
+sharpness and length of the curve. This will help you 
+determine the appropriate speed and steering adjustments.
+•	
+Choose the best lane position. Position your vehicle 
+slightly to the outside of the lane as you approach the curve. 
+This will give you more room to maneuver and improve your 
+visibility around the curve.
+In the curve
+•	
+Maintain a steady speed. Avoid braking or accelerating 
+suddenly while in the curve. This can disrupt your vehicle’s 
+balance and lead to a loss of control.
+•	
+Gentle steering. Steer smoothly and gradually through the 
+curve. Avoid oversteering or jerky movements, which can 
+cause your vehicle to skid.
+•	
+Be prepared to adjust. Be ready to adjust your speed 
+or steering based on road conditions, visibility, and the 
+behavior of other drivers.
+Exiting the curve
+•	
+Accelerate gradually. As you exit the curve, gently 
+accelerate back to your desired speed. This will help you 
+maintain stability and transition smoothly back into traveling 
+straight.
+•	
+Check your mirrors. Scan your mirrors to ensure you have 
+adequate space to merge or change lanes if needed.
+
+Laws of motion
+When driving on curved roads, it’s important to understand the 
+forces affecting your vehicle and adjust your driving to stay in 
+control.
+•	
+Roll and yaw. Roll affects how much your vehicle tilts during 
+a turn, yaw affects side-to-side movement, and both are 
+important for maintaining control. Adjusting your speed and 
+steering can help balance your roll and yaw while driving 
+through curves.
+•	
+Momentum. When you’re driving in a straight line, your 
+vehicle has momentum in that direction. However, when 
+you enter a curve, you need to change the direction and 
+momentum of your vehicle.
+•	
+Inertia. In a curve, your vehicle will want to pull a little to 
+keep you moving in a straight line. If you suddenly turn 
+the steering wheel, inertia will try to keep the car moving 
+straight. This is why you must carefully steer to smoothly 
+make the turn.
+•	
+Kinetic energy. Higher speeds create more energy, 
+requiring more time and space to stop or change direction. 
+Slowing down for curves lowers your vehicle’s kinetic energy 
+and helps you make the turn without losing traction or 
+control.
+•	
+Friction. Friction is the force between the tires and the 
+road. It allows your vehicle to grip the surface. The more 
+friction there is, the better your tires can grip the road. This 
+helps you slow down, speed up, or turn safely. Slippery 
+roads due to rain, snow, or ice can significantly reduce 
+friction in curves. Slow down even more and avoid sudden 
+movements in these conditions.
+
+SLIPPERY ROADS“SLIPPERY WHEN WET” sign from chapter four.
+Washington weather can cause 
+slippery roads. Rain, snow, and sleet 
+create dangers on the roadway. 
+When the road is slippery, you 
+must adjust your driving for the 
+conditions, which might require 
+you to drive below the posted 
+speed limit.
+If it starts to rain on a hot day, the pavement can be very 
+slippery for the first few minutes. Heat causes the oil in the 
+asphalt to come to the surface. The road is slippery until the oil 
+washes away.Winter road scene with car collision and skidding. Two triangular warning signs: one with a snowflake and one with
+ 
+Snowy roads will require a larger following distance and 
+dramatically reduced speed.
+
+•	
+Use snow tires or chains when it’s required.
+•	
+During winter months, you can improve traction by adding 
+chains to your tires or changing to studded tires.
+Avoid icy roads as much as possible. If you must drive on icy 
+roads, slow down and leave extra space around your vehicle.
+•	
 On cold, wet days, shady spots can be icy. 
+•	
+Overpasses and other types of bridges can have icy spots 
+even when the rest of the road doesn’t.
+•	
+When below-freezing temperatures warm up to near-
+freezing, ice can melt and become wet. This makes the road 
+more slippery.
+•	
+Black ice refers to a thin coating of ice that is hard for drivers 
+to see. Even if you don’t see ice, pay attention when driving 
+in temperatures near or below freezing. Many drivers crash 
+when they lose control of their vehicles on black ice.
+SKIDDING
+Skids are caused when the tires can no longer grip the road. 
+High speeds and slippery roads increase the possibility of 
+skidding if you turn or stop suddenly. Because you cannot 
+control a vehicle when it’s skidding, it’s best to avoid skidding in 
+the first place.
+If you’re skidding, do the following:
+1.	 Take your foot off the accelerator.
+2.	 Press or pump your brakes. Antilock brakes will help 
+control the rotation of the wheels to slow down faster. 
+They will also allow you to continue steering the vehicle. If 
+you don’t have antilock brakes, quickly pressing the brake 
+pedal down could cause you to skid more.
 
-Overpasses and other types of bridges can have icy spots even when the rest of the road 
-doesn’t. 
-When below-freezing temperatures warm up to near-freezing, ice can melt and become wet. 
-This makes the road more slippery. 
-Black ice refers to a thin coating of ice that is hard for drivers to see. Even if you don’t see ice, 
-pay attention when driving in temperatures near or below freezing. Many drivers crash when 
-they lose control of their vehicles on black ice. 
-Skidding 
-Skids are caused when the tires can no longer grip the road. High speeds and slippery roads 
-increase the possibility of skidding if you turn or stop suddenly. Because you cannot control a 
-vehicle when it’s skidding, it’s best to avoid skidding in the first place. 
-If you’re skidding, do the following: 
-Take your foot off the accelerator. 
-Press or pump your brakes. Antilock brakes will help control the rotation of the wheels to slow 
-down faster. They will also allow you to continue steering the vehicle. If you don’t have antilock 
-brakes, quickly pressing the brake pedal down could cause you to skid more. 
-Steer in the same direction your vehicle is moving. 
-Continue to correct your steering. Adjust the wheel until your tires have regained traction and 
-are going in the direction you’re steering. 
-Assess the situation. After getting control, consider the road conditions and adjust your driving 
-behavior as needed. 
-Hydroplaning 
-Hydroplaning happens when water builds up between your tires and the road surface. This 
-causes the tires to lose traction and skid. The vehicle can feel like it’s floating or sliding, making 
-it hard for you to keep control. The best way to keep from hydroplaning is to slow down when 
-the road is wet. 
-If you hydroplane, it is important to do the following: 
-Take your foot off the accelerator. 
-Gently press the brakes. Antilock brakes will help the vehicle regain contact with the road. If you 
-don’t have antilock brakes, forcefully pressing the brake pedal could cause you to hydroplane 
-more. 
-Keep the steering wheel steady. Avoid overcorrecting or jerking the steering wheel. 
-Look where you want to go. Maintain your focus on the road while you calmly wait for your tires 
-to regain traction. 
-Assess the situation. After getting control, consider the road conditions and adjust your driving 
-behavior as needed. 
+3.	 Steer in the same direction your vehicle is moving. 
+4.	 Continue to correct your steering. Adjust the wheel 
+until your tires have regained traction and are going in the 
+direction you’re steering. 
+5.	 Assess the situation. After getting control, consider 
+the road conditions and adjust your driving behavior as 
+needed.
+HYDROPLANING
+Hydroplaning happens when water builds up between your 
+tires and the road surface. This causes the tires to lose traction 
+and skid. The vehicle can feel like it’s floating or sliding, making 
+it hard for you to keep control. The best way to keep from 
+hydroplaning is to slow down when the road is wet.
+If you hydroplane, it is important to do the following:
+1.	 Take your foot off the accelerator. 
+2.	 Gently press the brakes. Antilock brakes will help the 
+vehicle regain contact with the road. If you don’t have 
+antilock brakes, forcefully pressing the brake pedal could 
+cause you to hydroplane more. 
+3.	 Keep the steering wheel steady. Avoid overcorrecting or 
+jerking the steering wheel. 
+4.	 Look where you want to go. Maintain your focus on the 
+road while you calmly wait for your tires to regain traction.
+5.	 Assess the situation. After getting control, consider 
+the road conditions and adjust your driving behavior as 
+needed.
 
-5.7: Vehicle failures 
-If you have vehicle troubles on the road, remember these tips: 
-Get your vehicle off the road and away from traffic, if possible. 
-Stop where other drivers have a clear view of your vehicle, especially if you can’t get your 
-vehicle off the road. Avoid stopping just over a hill or around a curve. 
-Turn on your emergency flashers and headlights. 
-Warn other road users by placing emergency flares 200 to 300 feet behind the vehicle. 
-Stand somewhere safe, and wave traffic around your vehicle if you don’t have emergency flares 
-or another warning device. 
-Lift the hood or tie a white cloth to the antenna, side mirror, or door handle to signal an 
-emergency. 
-Tires 
-If a tire blows out or suddenly goes flat: 
-Grip the steering wheel firmly and keep the vehicle going straight. 
-Slow down gradually. Take your foot off the accelerator. 
-Do not brake. Allow the vehicle to slow by itself, or brake gently if necessary. 
-Pull off the road in a safe place, if possible, and turn on emergency flashers. If you can’t get to a 
-safe place to change your tire, turn on your hazard warning lights, stay in your vehicle, and call 
-for help. 
-Have the tire repaired or replaced. 
-Power 
-If the engine shuts off while you are driving:  
-Keep a strong grip on the steering wheel. Be aware that the steering wheel might be difficult to 
-turn, but you can turn it. 
-Look for an escape path. Don’t brake hard. Instead, brake with steady pressure on the pedal, 
-slow down, and then pull off the roadway. 
-Stop and try to restart the engine. If unsuccessful, raise the hood and turn on your hazard 
-warning lights. Call for help. 
-Headlights 
-If your headlights suddenly go out: 
-Put on your hazard warning lights, turn signals, or fog lights, if you have them. 
-Pull off the road as soon as possible. 
-Accelerator 
+5.7  |  VEHICLE FAILURES
+If you have vehicle troubles on the road, remember these tips:
+•	
+Get your vehicle off the road and away from traffic, if 
+possible.
+•	
+Stop where other drivers have a clear view of your vehicle, 
+especially if you can’t get your vehicle off the road. Avoid 
+stopping just over a hill or around a curve.
+•	
+Turn on your emergency flashers and headlights.
+•	
+Warn other road users by placing emergency flares 200 to 
+300 feet behind the vehicle.
+•	
+Stand somewhere safe, and wave traffic around your vehicle 
+if you don’t have emergency flares or another warning 
+device.
+•	
+Lift the hood or tie a white cloth to the antenna, side mirror, 
+or door handle to signal an emergency.
+TIRES
+If a tire blows out or suddenly goes flat:
+•	
+Grip the steering wheel firmly and keep the vehicle going 
+straight.
+•	
+Slow down gradually. Take your foot off the accelerator.
+•	
+Do not brake. Allow the vehicle to slow by itself, or brake 
+gently if necessary.
+•	
+Pull off the road in a safe place, if possible, and turn on 
+emergency flashers. If you can’t get to a safe place to 
+change your tire, turn on your hazard warning lights, stay in 
+your vehicle, and call for help.
+•	
+Have the tire repaired or replaced.
 
-If the vehicle keeps going faster and faster: 
-Keep your eyes on the road. 
-Quickly shift to neutral. 
-Pull off the road when safe to do so. 
-Turn off the engine. 
-5.8: Communicating risk 
-Risk is everywhere: in city and country communities, on highways, back roads, in parking lots 
-and driveways. Keep yourself informed of all present and potential risks. There might be times 
-when you’ll need to communicate to others that a risk is present. Thoughtful use of your lights, 
-horn, and hand signals can vary depending on the situation —but can be effective ways to 
-communicate with other road users. 
-5.9: Collisions 
-All drivers eventually will find themselves in an emergency situation. As careful as you are, there 
-are situations that could cause problems for you. All drivers have the responsibility to prevent 
-crashes. Sometimes this will require you to use evasive maneuvers, but a basic understanding 
-of the laws of physics can also help you avoid crashing. No matter how well you drive, you can 
-still become involved in a collision.  
+POWER
+If the engine shuts off while you are driving:
+•	
+Keep a strong grip on the steering wheel. Be aware that the 
+steering wheel might be difficult to turn, but you can turn it.
+•	
+Look for an escape path. Don’t brake hard. Instead, brake 
+with steady pressure on the pedal, slow down, and then pull 
+off the roadway.
+•	
+Stop and try to restart the engine. If unsuccessful, raise the 
+hood and turn on your hazard warning lights. Call for help.
+HEADLIGHT
+If your headlights suddenly go out:
+•	
+Put on your hazard warning lights, turn signals, or fog lights, 
+if you have them.
+•	
+Pull off the road as soon as possible.
+ACCELERATOR
+If the vehicle keeps going faster and faster:
+•	
+Keep your eyes on the road.
+•	
+Quickly shift to neutral.
+•	
+Pull off the road when safe to do so.
+•	
+Turn off the engine.
+5.8  |  COMMUNICATING RISKS
+Risk is everywhere: in city and country communities, on 
+highways, back roads, in parking lots and driveways. Keep 
+yourself informed of all present and potential risks. There might 
+be times when you’ll need to communicate to others that a risk 
+is present. Thoughtful use of your lights, horn, and hand signals 
+can vary depending on the situation —but can be effective 
+ways to communicate with other road users. 
+
+Red SUV and an orange car have collided at an intersection in a city.
+5.9  |  COLLISIONS
+All drivers eventually will find themselves in an emergency 
+situation. As careful as you are, there are situations that could 
+cause problems for you. All drivers have the responsibility to 
+prevent crashes. Sometimes this will require you to use evasive 
+maneuvers, but a basic understanding of the laws of physics 
+can also help you avoid crashing. No matter how well you drive, 
+you can still become involved in a collision. 
 Collisions typically have three causes: 
-Too much speed 
-Too little space 
-Insufficient situational awareness. 
-Crashing a vehicle 
-Do not drive away. If anyone is injured or killed, call 911. Law enforcement must be notified. 
-Move the vehicle to the side of the road, but near the collision site, as soon as possible. 
-Don’t stand or walk in traffic lanes. You could be struck by another vehicle. 
-Use flares or other warning devices to alert other drivers of the collision. 
+1.	 Too much speed
+2.	 Too little space
+3.	 Insufficient situational awareness. 
+CRASHING A VEHICLE
+•	
+Do not drive away. If anyone is injured or killed, call 911. Law 
+enforcement must be notified.
+•	
+Move the vehicle to the side of the road, but near the 
+collision site, as soon as possible. 
+•	
+Don’t stand or walk in traffic lanes. You could be struck by 
+another vehicle.
+
+•	
+Use flares or other warning devices to alert other drivers of 
+the collision.
+•	
 Turn off wrecked vehicles. 
-Don’t smoke around wrecked vehicles. Fuel could have spilled, and fire is a real danger. 
-If the collision involves a parked vehicle, you must try to locate the owner. If you cannot, leave a 
-note in a place where they can easily see it. Include the date and time of collision and your 
-contact information. 
-Reporting a crash 
-After a collision, gather information that will help you report the incident. 
-
-Collect information from others involved. You should also share your information. You’ll need to 
-exchange your name, contact information, and driver license number and insurance company 
-and policy number. 
+•	
+Don’t smoke around wrecked vehicles. Fuel could have 
+spilled, and fire is a real danger.
+•	
+If the collision involves a parked vehicle, you must try to 
+locate the owner. If you cannot, leave a note in a place 
+where they can easily see it. Include the date and time of 
+collision and your contact information.
+REPORTING A CRASH
+After a collision, gather information that will help you report the 
+incident.
+•	
+Collect information from others involved. You should also 
+share your information. You’ll need to exchange:
+	
+☐Name, contact information, and driver license number
+	
+☐Insurance company and policy number
+•	
 Take photos or videos of any damage to the vehicles. 
-Provide information to the police or other emergency officials if requested. 
-File a collision report form, within 4 days of a crash, if a law enforcement officer doesn’t do this 
-for you. The form is required by state law. 
-Reporting an injury 
-Injuries can add more stress after a crash. Do your best to stay calm, assess yourself, and then 
-help others. 
-Call 911. 
-Do not move injured people unless they’re in a burning vehicle or otherwise in immediate 
-danger. 
-Help anyone who isn’t already walking and talking. Check for breathing, then check for bleeding. 
+•	
+Provide information to the police or other emergency 
+officials if requested.
+•	
+File a collision report form, within 4 days of a crash, if a law 
+enforcement officer doesn’t do this for you. The form is 
+required by state law. Go to dol.wa.gov and search collision 
+report form.
+REPORTING AN INJURY
+Injuries can add more stress after a crash. Do your best to stay 
+calm, assess yourself, and then help others.
+•	
+Call 911.
+•	
+Do not move injured people unless they’re in a burning 
+vehicle or otherwise in immediate danger.
+
+•	
+Help anyone who isn’t already walking and talking. Check for 
+breathing, then check for bleeding.
+•	
 Follow these steps if you see bleeding: 
-Apply pressure with hands. 
-Apply bandage/dressing. 
-Apply a tourniquet. 
-Do not give injured people anything to drink — not even water. 
-Cover injured people with a blanket or coat to keep them warm and to help prevent them from 
-going into shock. 
-Calling 911 
-It’s important to call 911 in the event of a car crash to get emergency help. Remember to: 
-Stay calm. Try to remain calm and composed. This will help you give clear and accurate 
-information to the dispatcher. 
-Assess the situation. Quickly assess how serious the crash is and any injuries to you or others. 
-When talking to a 911 dispatcher, you should: 
-Provide location. Clearly state your location to the dispatcher, including any close landmarks or 
-mile markers. If you aren’t sure about your location, try to provide as much detail as possible to 
-help emergency responders find you. 
-Describe the situation. Give a brief description of the crash, including the number of vehicles 
-involved, the damage, and any injuries. 
-Follow dispatcher instructions. The dispatcher might ask questions to assess the situation and 
-provide instructions. 
+	
+☐Apply pressure with hands.
+	
+☐Apply bandage/dressing.
+	
+☐Apply a tourniquet.
+•	
+Do not give injured people anything to drink — not even 
+water.
+•	
+Cover injured people with a blanket or coat to keep them 
+warm and to help prevent them from going into shock.
+CALLING 911
+It’s important to call 911 in the event of a car crash to get 
+emergency help. Remember to:
+1.	 Stay calm. Try to remain calm and composed. This will 
+help you give clear and accurate information to the 
+dispatcher.
+2.	 Assess the situation. Quickly assess how serious the 
+crash is and any injuries to you or others.
+When talking to a 911 dispatcher, you should:
+1.	 Provide location. Clearly state your location to the 
+dispatcher, including any close landmarks or mile markers. 
+If you aren’t sure about your location, try to provide as 
+much detail as possible to help emergency responders 
+find you.
+2.	 Describe the situation. Give a brief description of the 
+crash, including the number of vehicles involved, the 
+damage, and any injuries. 
+3.	 Follow dispatcher instructions. The dispatcher might 
+ask questions to assess the situation and provide 
+instructions. 
 
-Provide details. Be prepared to give more details if needed. These details could include the 
-vehicle types, license plate numbers, and any hazards. 
-Stay on the phone. Stay on the phone with the dispatcher until help arrives. 
-Encountering power lines 
-If a power line comes in contact with your vehicle, do not get out of the vehicle. 
-If a collision involves power lines, you need to take special precautions. Turn off your engine, 
-call 911, and stay inside your vehicle until emergency responders arrive. You never know how, 
-when, or if a power line is charged, but assume they’re all energized. 
-If you accidentally drive over a power line, stop immediately. Moving forward or reversing puts 
-you at risk of being electrocuted. Call 911 and stay inside your vehicle until you are told it’s safe 
-to exit.   
-If power lines fall on your vehicle, or if you hit a transformer box, stay in your vehicle and call 
-911. The ground around your vehicle could also be energized. When possible, encourage 
-people to stay at least 35 feet away. 
-If your vehicle comes in contact with power lines and a fire starts, you want to evacuate the 
-vehicle. It’s very important that you jump clear of the vehicle. Open your door, and perch on the 
-ledge of the doorway. Jump away from your vehicle, with your arms at your sides. Be careful not 
-to touch the vehicle. Make sure both feet land together. To avoid electric shock, shuffle 35 feet 
-away to safety. Do not go back inside the vehicle for any belongings until advised that it’s safe to 
-do so. 
-Witnessing a crash 
-Do not block emergency responders. 
-Follow directions given by police, firefighters, and other persons authorized to direct traffic at the 
-scene. 
-Keep emergency responders and people involved at the collision scene safe by focusing on 
-your driving as you pass. Slowing down to stare at the scene creates traffic congestion. 
-Emergency kit 
-It’s a good idea to keep an emergency kit in your vehicle. Here are some items you might want 
-to have in an emergency: 
-First aid kit 
-Flashlight 
-Blanket 
-Water 
-Jumper cables 
-Tool kit or multipurpose utility tool 
+4.	 Provide details. Be prepared to give more details if 
+needed. These details could include the vehicle types, 
+license plate numbers, and any hazards.
+5.	 Stay on the phone. Stay on the phone with the 
+dispatcher until help arrives. 
+ENCOUNTERING POWER LINES 
+If a power line comes in contact with your vehicle, do not 
+get out of the vehicle.
+If a collision involves power lines, you need to take special 
+precautions. Turn off your engine, call 911, and stay inside your 
+vehicle until emergency responders arrive. You never know 
+how, when, or if a power line is charged, but assume they’re all 
+energized.
+If you accidentally drive over a power line, stop immediately. 
+Moving forward or reversing puts you at risk of being 
+electrocuted. Call 911 and stay inside your vehicle until you are 
+told it’s safe to exit.  
+If power lines fall on your vehicle, or if you hit a transformer box, 
+stay in your vehicle and call 911. The ground around your vehicle 
+could also be energized. When possible, encourage people to 
+stay at least 35 feet away.
+If your vehicle comes in contact with power lines and a fire 
+starts, you want to evacuate the vehicle. It’s very important that 
+you jump clear of the vehicle. Open your door, and perch on the 
+ledge of the doorway. Jump away from your vehicle, with your 
+arms at your sides. Be careful not to touch the vehicle. Make 
+sure both feet land together. To avoid electric shock, shuffle 35 
+feet away to safety. Do not go back inside the vehicle for any 
+belongings until advised that it’s safe to do so.
 
-Backup phone charger or power source 
-Spare tire, wheel wrench, jack 
-Reflective triangles or flares 
-It’s a good idea to keep a paper copy of important numbers (family members, insurance 
-providers). The paper copy will be helpful if your phone battery dies and you need to call from a 
-different phone. 
-5.10: Law enforcement 
-Washington roads are managed by police and state agencies. Throughout your travels, you 
-might encounter state, county, or local law enforcement, as well as emergency responders.   
-Getting pulled over 
-Police vehicles attempting to stop drivers will do so by turning on flashing lights and/or a siren. If 
-a law enforcement officer pulls you over, remember to: 
-Use your turn signal and pull to the right side of the road as soon as it’s safe. 
-Turn off the engine and any audio devices, like radios. 
-Stay in your vehicle unless directed by the officer to get out. 
-Turn on your interior lights if you’re pulled over at night. Officers might use a spotlight for 
-additional visibility. 
-Keep your hands on the steering wheel. 
-Follow all instructions the officer gives you or your passengers. 
-The officer could approach either side of the vehicle. When the officer approaches the vehicle, 
-remember to: 
-Lower the corresponding window so you and the officer can communicate. 
-Let the officer know right away if you have a weapon in the vehicle. 
-Wait for the officer’s instructions before reaching for your driver license or vehicle documents. 
-If you’re pulled over, an officer will typically: 
-Explain why you were stopped. 
-Ask for your: 
-Driver license 
-Proof of insurance 
-Vehicle registration 
-Tell the officer where these documents are located before reaching for them. 
+WITNESSING A CRASH 
+•	
+Do not block emergency responders.
+•	
+Follow directions given by police, firefighters, and other
+persons authorized to direct traffic at the scene.
+•	
+Keep emergency responders and people involved at the
+collision scene safe by focusing on your driving as you 
+pass. Slowing down to stare at the scene creates traffic 
+congestion.
+EMERGENCY KIT
+It’s a good idea to keep an emergency kit in your vehicle. Here 
+are some items you might want to have in an emergency:
+	
+ First aid kit
+	
+ Flashlight
+	
+ Blanket
+	
+ Water
+	
+ Jumper cables
+	
+ Tool kit or multipurpose utility tool
+	
+ Backup phone charger or power source
+	
+ Spare tire, wheel wrench, jack
+	
+ Reflective triangles or flares
+It’s a good idea to keep a paper copy of important numbers 
+(family members, insurance providers). The paper copy will be 
+helpful if your phone battery dies and you need to call from a 
+different phone.
 
-Explain what action they’re taking (issuing a warning or ticket or making an arrest). If the officer 
-doesn’t explain the action they’re taking, you can ask them to do so. 
-You are allowed to respectfully ask the officer questions. If you disagree with the officer’s 
-decision or course of action, do not prolong the contact by arguing with the officer. You may 
-seek to contest the decision in court.  
-If you believe the officer acted inappropriately or have questions regarding their conduct, you 
-can call or contact the officer’s agency and request a supervisor. This is best done as soon as 
-possible after getting pulled over. 
-Getting a ticket 
-If you get a ticket, you are required to sign for it. Your acceptance and signature isn’t an 
-admission of guilt. However, refusing to sign a traffic ticket could result in your arrest. 
-You need to follow the instructions on the back of the ticket within 15 days to avoid having your 
-driving privileges suspended. Driving with a suspended license could result in losing your 
-vehicle and/or getting arrested. 
- 
-Conclusion 
-Washington roads connect every community throughout our state. We use them to commute to 
-work, deliver goods, and explore the beauty of the Pacific Northwest. Smart driving habits are 
-the foundation of a safe and enjoyable driving experience.  
-Good drivers are: 
-Alert. Always aware of their surroundings and potential hazards. 
-Buckled. Properly restrained with seat belts for every trip. 
-Calm. Avoiding aggressive behavior and managing emotions behind the wheel. 
-Focused. Eliminating distractions and concentrating on driving. 
-Sober. Never driving under the influence of alcohol or drugs. 
-Experience will build confidence; however, be careful to avoid complacency. Driving requires 
-continuous learning and adaptation as laws, vehicles, and driving conditions change.  
-Welcome to Washington’s shared driving community. Let’s work together to keep the roads safe 
-for everyone. 
- 
-Glossary 
-Anti-lock Braking System (ABS): Vehicle safety feature that helps you maintain control and stop 
-safely. 
-Advanced Driver Assistance Systems (ADAS): Vehicle safety technology that intervenes, warns, 
-or assists drivers. 
+5.10  |  LAW ENFORCEMENT 
+Washington roads are managed by police and state agencies. 
+Throughout your travels, you might encounter state, county, or 
+local law enforcement, as well as emergency responders. 
+Red barn and silo in a rural are
+GETTING PULLED OVER
+Police vehicles attempting to stop drivers will do so by turning 
+on flashing lights and/or a siren. If a law enforcement officer 
+pulls you over, remember to:Two arrows, one teal pointing left and one yellow with green outline pointing right, side by side.
+1.	 Use your turn signal and pull to 
+the right side of the road as soon 
+as it’s safe. Two icons: a key turning in a keyhole and an engine with a lightning bolt symbol.
+2.	 Turn off the engine and any audio 
+devices, like radios. Front-facing car icon with driver, green to blue gradient.
+3.	 Stay in your vehicle unless 
+directed by the officer to get out. 
 
-Aggressive driving: Driving behavior that is angry, risky, or impatient, like speeding or tailgating. 
-Agricultural permit: Permission for a person under the age of 18 to drive tractors and other 
-vehicles used in farming. 
-Angle parking: Parking a car diagonally to the curb instead of parallel. 
-At-fault collision: When a crash happens, and it’s determined that one driver is mostly 
-responsible for causing it. 
-Backing: Driving a vehicle in reverse. 
-Balanced weight: Even distribution of weight in a vehicle to maintain stability. 
-Blind area, spot, or zone: Areas around a vehicle where the driver’s view is obstructed, and they 
-cannot see other vehicles. 
-Booster seat: A special seat designed for children who have outgrown their car seats but are still 
-too small to properly fit in a regular seatbelt. 
+Stylized icon of an interior dome light source
+4.	 Turn on your interior lights if 
+you’re pulled over at night. 
+Officers might use a spotlight for 
+additional visibility.Green and white logo with a face, driving gloves, and a steering wheel.
+5.	 Keep your hands on the steering 
+wheel.Two overlapping teal speech bubbles, one with white lines inside.
+6.	 Follow all instructions the officer 
+gives you or your passengers.
+The officer could approach either side of the vehicle. 
+When the officer approaches the vehicle, remember to:
+1.	 Lower the corresponding window so you and the officer can 
+communicate.
+2.	 Let the officer know right away if you have a weapon in the 
+vehicle.
+3.	 Wait for the officer’s instructions before reaching for your 
+driver license or vehicle documents.
+If you’re pulled over, an officer will typically:
+•	
+Explain why you were stopped.
+•	
+Ask for your:
+	
+☐Driver license
+	
+☐Proof of insurance
+	
+☐Vehicle registration
+Tell the officer where these documents are located before 
+reaching for them.
+•	
+Explain what action they’re taking (issuing a warning or 
+ticket, or making an arrest). If the officer doesn’t explain the 
+action they’re taking, you can ask them to do so.
+
+You are allowed to respectfully ask the officer questions. If you 
+disagree with the officer’s decision or course of action, do not 
+prolong the contact by arguing with the officer. You may seek to 
+contest the decision in court. 
+If you believe the officer acted inappropriately or have 
+questions regarding their conduct, you can call or contact the 
+officer’s agency and request a supervisor. This is best done as 
+soon as possible after getting pulled over.
+GETTING A TICKET
+If you get a ticket, you are required to sign for it. Your 
+acceptance and signature isn’t an admission of guilt. However, 
+refusing to sign a traffic ticket could result in your arrest.
+You need to follow the instructions on the back of the 
+ticket within 15 days to avoid having your driving privileges 
+suspended. Driving with a suspended license could result in 
+losing your vehicle and/or getting arrested. 
+
+CONCLUSION
+Washington roads connect every community throughout our 
+state. We use them to commute to work, deliver goods, and 
+explore the beauty of the Pacific Northwest. 
+Remember smart driving habits are the foundation of a safe and 
+enjoyable driving experience. 
+Good drivers are:
+•	
+Alert. Always aware of their surroundings and potential 
+hazards.
+•	
+Buckled. Properly restrained with seat belts for every trip.
+•	
+Calm. Avoiding aggressive behavior and managing 
+emotions behind the wheel.
+•	
+Focused. Eliminating distractions and concentrating on 
+driving.
+•	
+Sober. Never driving under the influence of alcohol or 
+drugs.
+Experience will build confidence; however, be careful to 
+avoid complacency. Driving requires continuous learning and 
+adaptation as laws, vehicles, and driving conditions change. 
+Welcome to Washington’s shared driving community.  
+Let’s work together to keep the roads safe for everyone.
+
+GLOSSARY
+Anti-lock Braking System (ABS): Vehicle safety feature that helps 
+you maintain control and stop safely. 
+Advanced Driver Assistance Systems (ADAS): Vehicle safety 
+technology that intervenes, warns, or assists drivers.
+Aggressive driving: Driving behavior that is angry, risky, or impatient, 
+like speeding or tailgating. 
+Agricultural permit: Permission for a person under the age of 18 to 
+drive tractors and other vehicles used in farming.
+Angle parking: Parking a car diagonally to the curb instead of 
+parallel. 
+At-fault collision: When a crash happens, and it’s determined that 
+one driver is mostly responsible for causing it.
+Backing: Driving a vehicle in reverse.
+Balanced weight: Even distribution of weight in a vehicle to maintain 
+stability.  
+Blind area, spot, or zone: Areas around a vehicle where the driver’s 
+view is obstructed, and they cannot see other vehicles. 
+Booster seat: A special seat designed for children who have 
+outgrown their car seats but are still too small to properly fit in a 
+regular seatbelt. 
 Brake failure: When the brakes of a vehicle stop working properly. 
-Brake lights: The red lights on the back of a vehicle that turn on when the driver presses the 
-brake pedal, signaling to other drivers that the vehicle is slowing down or stopping. 
+Brake lights: The red lights on the back of a vehicle that turn on 
+when the driver presses the brake pedal, signaling to other drivers 
+that the vehicle is slowing down or stopping.
 Carpool: When 2 or more people are in a vehicle while it’s moving. 
-Certificate of ownership: A document showing who owns the vehicle or vessel. 
-Child safety seat or child restraint: A special seat for children in a vehicle to keep them safe in 
-case of a crash. 
-Collision or crash: When two or more vehicles or objects collide with each other. 
-Complex intersections: Intersections with multiple lanes or unusual traffic patterns. 
-Crash involvement: Being part of a collision or crash. 
-Cruise or speed control: A system in a car that maintains a set speed without the driver needing 
-to press the accelerator pedal. 
-Distracted driving: Anything that takes your focus away from driving, like your phone or 
-multitasking behind the wheel. 
-Driver licensing office: Location that provides customer services related to licensing. 
-Department of Licensing (DOL): State agency issuing driver licenses, ID cards, license plates, 
-and vehicle and boat registrations. 
-Driving record: A record of a person’s driving history, including any violations or collisions. 
-Driving under the influence (DUI): Operating a vehicle while impaired by alcohol or drugs. 
-Fatigue: Feeling very tired. 
-Financial responsibility: Being held responsible for paying for something if damage occurs. 
+Certificate of ownership: A document showing who owns the 
+vehicle or vessel.  
+Child safety seat or child restraint: A special seat for children in a 
+vehicle to keep them safe in case of a crash.  
 
-Forward-facing seat: A type of car seat that is positioned to face the front of the vehicle, suitable 
-for children who have outgrown rear facing seats. 
-Hand-to-hand steering: Technique of moving hands around the steering wheel without crossing 
-them. 
-Hazard lights: Indicator lights on the front and back of a car showing other drivers and 
-pedestrians to use caution when near the vehicle. 
-Hazard perception: The ability to recognize and respond to potential dangers while driving. 
-High occupancy vehicle (HOV): Lane reserved for carpooling vehicles with 2 or more people 
-inside. 
-Headlights: The lights on the front of a vehicle that illuminate the road ahead, allowing the driver 
-to see and be seen in low-light conditions or at night. 
+Collision or crash: When two or more vehicles or objects collide with 
+each other. 
+Complex intersections: Intersections with multiple lanes or unusual 
+traffic patterns. 
+Crash involvement: Being part of a collision or crash. 
+Cruise or speed control: A system in a car that maintains a set 
+speed without the driver needing to press the accelerator pedal.
+Distracted driving: Anything that takes your focus away from driving, 
+like your phone or multitasking behind the wheel.  
+Driver licensing office: Location that provides customer services 
+related to licensing.
+Department of Licensing (DOL): State agency issuing driver 
+licenses, ID cards, license plates, and vehicle and boat registrations. 
+Driving record: A record of a person’s driving history, including any 
+violations or collisions.
+Driving under the influence (DUI): Operating a vehicle while 
+impaired by alcohol or drugs.
+Fatigue: Feeling very tired. 
+Financial responsibility: Being held responsible for paying for 
+something if damage occurs.
+Forward-facing seat: A type of car seat that is positioned to face the 
+front of the vehicle, suitable for children who have outgrown rear-
+facing seats.
+Hand-to-hand steering: Technique of moving hands around the 
+steering wheel without crossing them.  
+Hazard lights: Indicator lights on the front and back of a car showing 
+other drivers and pedestrians to use caution when near the vehicle. 
+Hazard perception: The ability to recognize and respond to potential 
+dangers while driving.
+
+High occupancy vehicle (HOV): Lane reserved for carpooling 
+vehicles with 2 or more people inside.
+Headlights: The lights on the front of a vehicle that illuminate the 
+road ahead, allowing the driver to see and be seen in low-light 
+conditions or at night.
 Hydroplaning: When a vehicle loses traction on a wet road and skids. 
-Identification (ID): Document with personal information such as your name, date of birth, or 
-photograph. 
-Identity: Who a person is, including their name, date of birth, and other personal information. 
-Impaired driving: Operating a vehicle while under the influence of alcohol, drugs, or other 
-substances that affect judgment and coordination. 
-Implied consent law: Laws that require drivers to submit to certain tests, like breathalyzer tests, 
-if suspected of driving under the influence. 
+Identification (ID): Document with personal information such as your 
+name, date of birth, or photograph.
+Identity: Who a person is, including their name, date of birth, and 
+other personal information.
+Impaired driving: Operating a vehicle while under the influence 
+of alcohol, drugs, or other substances that affect judgment and 
+coordination. 
+Implied consent law: Laws that require drivers to submit to certain 
+tests, like breathalyzer tests, if suspected of driving under the 
+influence.
 Interchange: Place where 2 or more roads connect. 
 Joining traffic: Merging into moving traffic. 
 Juvenile: A person who is not yet considered an adult by law, typically 
-under the age of 18. 
-Knowledge exam: An assessment that evaluates a person’s understanding of driving rules, 
-signs, and other important information needed to drive safely. 
+under the age of 18.
+Knowledge exam: An assessment that evaluates a person’s 
+understanding of driving rules, signs, and other important information 
+needed to drive safely.
 Lane change: Moving from one lane to another. 
-License Express: An online service where you can renew your driver’s license, vehicle tabs, 
-business license, or report when you sell a vehicle. You can find License Express here at 
-secure.dol.wa.gov. 
-License plate: A metal or plastic plate with numbers and letters on it, attached to the front and 
-back of a vehicle, used to identify the vehicle to law enforcement and others. 
-Moving violation: a ticket issued if a law is broken while the vehicle is moving. 
-Non-resident: Someone who doesn’t permanently live in a particular place, like a city or state. 
-Occupant protection systems: Safety features in vehicles, like airbags and seat belts. 
-One-hand steering: Steering with one hand. 
+License Express: An online service where you can renew your 
+driver’s license, vehicle tabs, business license, or report when you sell 
+a vehicle. You can find License Express here at secure.dol.wa.gov.
+License plate: A metal or plastic plate with numbers and letters on 
+it, attached to the front and back of a vehicle, used to identify the 
+vehicle to law enforcement and others.
 
-Open container law: A law that prohibits drivers and passengers from having open containers of 
-alcoholic beverages in a vehicle, to prevent drinking and driving. 
-Organ donor: Someone who has agreed to donate their organs after they die to help save the 
-lives of others in need of transplants. 
+Moving violation: a ticket issued if a law is broken while the vehicle is 
+moving.
+Non-resident: Someone who doesn’t permanently live in a particular 
+place, like a city or state.
+Occupant protection systems: Safety features in vehicles, like 
+airbags and seat belts.  
+One-hand steering: Steering with one hand.  
+Open container law: A law that prohibits drivers and passengers 
+from having open containers of alcoholic beverages in a vehicle, to 
+prevent drinking and driving.
+Organ donor: Someone who has agreed to donate their organs after 
+they die to help save the lives of others in need of transplants.
 Parallel parking: Parking between two vehicles along the curb. 
 Parent or guardian: A legal adult in charge of caring for a minor. 
 Pass or passing: Going past another vehicle. 
 Pedestrian: A person walking on or near the road. 
-Peripheral vision: Seeing objects to the side while looking straight ahead. 
-Perpendicular parking: Parking at a right angle to the curb. 
-Pedestrian safety zone: An area where drivers can’t go to ensure people have a safe space 
-away from traffic. 
-Pitch of vehicle: The angle of a vehicle’s front or back. 
-Polydrug use: Consuming or using more than 1 kind of drug at the same time. 
-Proactive: Responding to a situation you anticipate. 
-Reactive: Responding to a situation you see. 
-Reference points: Lines on the road or objects near your vehicle that help you know your 
-location on the road. 
-Right-of-way: The legal right to proceed first in traffic; for example, the first vehicle to stop at an 
-intersection has the right-of-way. 
-Risk: Chance of something bad happening. 
-Roll of vehicle: Side-to-side movement of a vehicle. 
-Roundabout: A circular barrier that controls traffic at an intersection, also known as a traffic 
-circle. 
-Selective Service registration: signing up for this makes a person assigned male at birth 
-between ages 18 and 25 eligible to be drafted in the military in case of a national emergency. 
-Signaling: Using turn signals to indicate intentions to other drivers. 
-Situational awareness: Your ability to be fully aware of your surroundings while you’re driving 
-that helps you make safe driving decisions. 
-Skid: Loss of traction causing a vehicle to slide out of control. 
-Skills exam: An assessment that determines a person’s ability to perform practical driving tasks, 
-such as parking and maneuvering. 
-Speed limits: Maximum legal speeds allowed on roads. 
+Peripheral vision: Seeing objects to the side while looking straight 
+ahead. 
+Perpendicular parking: Parking at a right angle to the curb.
+Pedestrian safety zone: An area where drivers can’t go to ensure 
+people have a safe space away from traffic. 
+Pitch of vehicle: The angle of a vehicle’s front or back.  
+Polydrug use: Consuming or using more than 1 kind of drug at the 
+same time.
+Proactive: Responding to a situation you anticipate.
+Reactive: Responding to a situation you see.
+Reference points: Lines on the road or objects near your vehicle that 
+help you know your location on the road.
 
-Standard sign colors: Colors used for traffic signs to convey specific meanings. 
+Right-of-way: The legal right to proceed first in traffic; for example, 
+the first vehicle to stop at an intersection has the right-of-way. 
+Risk: Chance of something bad happening. 
+Roll of vehicle: Side-to-side movement of a vehicle.  
+Roundabout: A circular barrier that controls traffic at an intersection, 
+also known as a traffic circle.
+Selective Service registration: signing up for this makes a person 
+assigned male at birth between ages 18 and 25 eligible to be drafted 
+in the military in case of a national emergency.
+Signaling: Using turn signals to indicate intentions to other drivers.
+Situational awareness: Your ability to be fully aware of your 
+surroundings while you’re driving that helps you make safe driving 
+decisions. 
+Skid: Loss of traction causing a vehicle to slide out of control. 
+Skills exam: An assessment that determines a person’s ability to 
+perform practical driving tasks, such as parking and maneuvering.
+Speed limits: Maximum legal speeds allowed on roads. 
+Standard sign colors: Colors used for traffic signs to convey specific 
+meanings. 
 Stop sign: A sign indicating drivers must come to a complete stop. 
-Stopping distance: The distance traveled from the moment a driver applies the brakes until the 
-vehicle comes to a stop. 
-Stopping position: The place where a vehicle comes to a stop. 
-Studded Tires: Winter tires with metal pieces, called studs, that can be used for driving in frozen 
-conditions. 
-Tailgating: Following the vehicle in front of you too closely. 
-Tire blowout: Sudden loss of air pressure in a tire while driving. 
+Stopping distance: The distance traveled from the moment a driver 
+applies the brakes until the vehicle comes to a stop. 
+Stopping position: The place where a vehicle comes to a stop.
+Studded Tires: Winter tires with metal pieces, called studs, that can 
+be used for driving in frozen conditions. 
+Tailgating: Following the vehicle in front of you too closely.
+Tire blowout: Sudden loss of air pressure in a tire while driving.
 Tourniquet: Tight wrapping that helps control bleeding. 
+
 Traction loss: Reduced grip between tires and the road. 
 Traction: The grip between tires and the road surface. 
-Traditional intersection: A standard intersection where roads meet at right angles. 
-Traffic control devices: Signs, signals, and markings used to regulate traffic. 
+Traditional intersection: A standard intersection where roads meet 
+at right angles. 
+Traffic control devices: Signs, signals, and markings used to 
+regulate traffic. 
 Traffic flow: How vehicles move on roads. 
 Traffic laws: Rules that govern how vehicles must operate on roads. 
-Traffic sign shapes: Different shapes of signs that have specific meanings. 
+Traffic sign shapes: Different shapes of signs that have specific 
+meanings. 
 Traffic signal: A light that controls traffic flow at intersections. 
 Traffic volume: The amount of traffic on a road. 
 Traffic: Vehicles moving on roads. 
 Trip or route planning: Planning the route for a journey. 
+Turn signals: The blinking lights on the front and back of a vehicle 
+that indicate the driver’s intention to turn left or right, or to change 
+lanes.
 Turn: Changing direction while driving. 
-Turn signals: The blinking lights on the front and back of a vehicle that indicate the driver’s 
-intention to turn left or right, or to change lanes. 
-Twin registry: A list of twins’ names and some information about them, often used for research. 
-Uncontrolled intersection: An intersection without traffic signals or signs. 
-Understeer: When a vehicle doesn’t turn as much as the driver intends. 
-Vehicle insurance: Coverage that helps pay for damage or injuries from crashes. 
-Vehicle maneuvers: Actions performed while driving, like turning or stopping. 
-Vehicle registration: Official documentation proving ownership of a vehicle. 
+Twin registry: A list of twins’ names and some information about 
+them, often used for research.
+Uncontrolled intersection: An intersection without traffic signals or 
+signs. 
+Understeer: When a vehicle doesn’t turn as much as the driver 
+intends. 
+Vehicle insurance: Coverage that helps pay for damage or injuries 
+from crashes.
+Vehicle maneuvers: Actions performed while driving, like turning 
+or stopping. 
+
+Vehicle registration: Official documentation proving ownership of 
+a vehicle.
 Visibility: How well you can see surrounding objects. 
-
-Vision screening: A test to check how well you can see and if your eyes are healthy. 
-Visual search: Deliberately looking for current or potential hazards. 
-Visitor: Someone who is in a place for a brief or limited amount of time. 
-Voter registration: document showing when a resident has signed up to be able to vote in local 
-and national elections. 
-Vehicle licensing office: Where you go for vehicle certificates, tabs, and registration help. 
-Vehicle Safety Technology (VST): Vehicle features that use sensors or cameras to intervene, 
-warn, or assist you in driving safely. 
+Vision screening: A test to check how well you can see and if your 
+eyes are healthy.
+Visual search: Deliberately looking for current or potential hazards.
+Visitor: Someone who is in a place for a brief or limited amount 
+of time.
+Voter registration: document showing when a resident has signed 
+up to be able to vote in local and national elections.
+Vehicle licensing office: Where you go for vehicle certificates, tabs, 
+and registration help.
+Vehicle Safety Technology (VST): Vehicle features that use sensors 
+or cameras to intervene, warn, or assist you in driving safely.
 Weather conditions: What the weather is like. 
-Yaw: The side-to-side movement of a vehicle. 
- 
-Accessibility and Accommodations 
-DOL will provide reasonable accommodations upon request to those customers who need them 
-to access our facilities and services. If you require an accommodation to access our programs, 
-facilities, or services, call 360-902-3900 or staff in our community-based licensing offices can 
-assist you. If you are unable to get an accommodation or have an ADA complaint, contact our 
-ADA Compliance Manager at ada@dol.wa.gov. If you need assistance in a language other than 
-English, contact our Language Access team at languageaccess@dol.wa.gov. If you believe 
-you’ve been discriminated against in receiving services from DOL, based on your protected 
-group as indicated in Title VI of the Civil Rights Act of 1964, please reach out to our Civil Rights 
-Compliance Coordinator at CivilRtsCoord@dol.wa.gov. 
- 
-Disclaimer 
-The Washington State Department of Licensing (DOL) produces the official Washington State 
-Driver Guide. This guide refers to many Washington laws and provides safety advice that might 
-not be in the laws. All information is as accurate as possible at the time of publication. However, 
-the guide might not reflect the most recent changes made by the Washington Legislature. 
-The Washington State Driver Guide is not a legal authority and is not intended for use in court. 
-The guide cannot be used as a basis for legal claims or actions. Traffic regulations in cities, 
-towns, and countries may go beyond state laws, but cannot conflict with them. If you are 
-interested in specific laws relating to motor vehicle operation and driver licensing, refer to Title 
-46 RCW, Motor Vehicles. 
-Material in this guide is intended for education or research purposes. Unless otherwise 
-identified, all content is the copyrighted property of Washington State Department of Licensing 
-(DOL). Commercial or political use of this material is prohibited without written consent from the 
-DOL. If you have a suggestion or question about the information supplied in this guide, or a 
-situation not covered, please email tse@dol.wa.gov. 
+Yaw: The side-to-side movement of a vehicle.  
 
-This work is protected by U.S. Copyright Law. The Washington State Department of Licensing 
-(DOL) owns the copyright to this work. 
-© Copyright 2025, Washington State Department of Licensing All rights reserved. 
+ACCESSIBILITY AND ACCOMMODATIONS
+DOL will provide reasonable accommodations upon request to those 
+customers who need them to access our facilities and services.
+•	
+If you require an accommodation to access our programs, 
+facilities, or services, call 360-902-3900 or staff in our 
+community-based licensing offices can assist you. If you are 
+unable to get an accommodation or have an ADA complaint, 
+contact our ADA Compliance Manager at ada@dol.wa.gov.
+•	
+If you need assistance in a language other than 
+English, contact our Language Access team at 
+languageaccess@dol.wa.gov. 
+•	
+If you believe you’ve been discriminated against in receiving 
+services from DOL, based on your protected group as 
+indicated in Title VI of the Civil Rights Act of 1964, please 
+reach out to our Civil Rights Compliance Coordinator at 
+CivilRtsCoord@dol.wa.gov. 
+DISCLAIMER
+The Washington State Driver Guide is not a legal authority and is 
+not intended for use in court. The guide cannot be used as a basis 
+for legal claims or actions. Traffic regulations in cities, towns, and 
+countries may go beyond state laws, but cannot conflict with them. If 
+you are interested in specific laws relating to motor vehicle operation 
+and driver licensing, refer to Title 46 RCW, Motor Vehicles. 
+Material in this guide is intended for education or research purposes. 
+Unless otherwise identified, all content is the copyrighted property 
+of Washington State Department of Licensing (DOL). Commercial or 
+political use of this material is prohibited without written consent from 
+the DOL. If you have a suggestion or question about the information 
+supplied in this guide, or a situation not covered, please email 
+tse@dol.wa.gov. 
  
+This work is protected by U.S. Copyright Law. The Washington State 
+Department of Licensing (DOL) owns the copyright to this work. 
+© Copyright 2025, Washington State Department of Licensing All 
+rights reserved. 
+

--- a/data/states/wa/questions_en.yaml
+++ b/data/states/wa/questions_en.yaml
@@ -1,6 +1,6 @@
 metadata:
   source: 2025 Washington Driver Guide (dol.wa.gov)
-  total_questions: 376
+  total_questions: 367
   categories:
   - alcohol_drugs_health
   - defensive_driving
@@ -242,30 +242,6 @@ questions:
   answer: B
   explanation: The text explicitly lists 'Submit your DUI hearing request' under the
     online record services.
-- id: 20
-  category: safe_driving_rules
-  question: Under the 'Before You Drive' section, which of the following is listed
-    as a necessary step?
-  choices:
-    A: Checking the vehicle's exhaust emissions
-    B: Securing your load
-    C: Upgrading your headlights
-    D: Rotating your tires
-  answer: B
-  explanation: The Table of Contents lists 'Secure Your Load' as a topic under the
-    'Before You Drive' chapter.
-- id: 21
-  category: safe_driving_rules
-  question: Which of the following topics is covered under the 'Rules of the Road'
-    section?
-  choices:
-    A: Tire Blowout
-    B: Hot Lanes & Express Toll Lanes
-    C: Brake Failure
-    D: Certificate of Ownership
-  answer: B
-  explanation: The Table of Contents lists 'Hot Lanes & Express Toll Lanes' under
-    the 'Rules of the Road' chapter.
 - id: 22
   category: vehicle_information
   question: According to the Table of Contents, where would you look to find information
@@ -278,30 +254,6 @@ questions:
   answer: B
   explanation: Information on 'Low-speed Battery Electric Vehicles' is located in
     the 'Rules of the Road' section of the manual.
-- id: 23
-  category: safe_driving_rules
-  question: The topics of 'Distracted Driving' and 'Personal Electronic Devices' are
-    found in which section of the manual?
-  choices:
-    A: Safe Driving Tips
-    B: Emergencies
-    C: Vehicle Licensing
-    D: Before You Drive
-  answer: A
-  explanation: The Table of Contents places 'Distracted Driving' and 'Personal Electronic
-    Devices' under the 'Safe Driving Tips' chapter.
-- id: 24
-  category: defensive_driving
-  question: If you experience a situation where the 'Gas Pedal Sticks', which section
-    of the manual provides guidance?
-  choices:
-    A: Rules of the Road
-    B: Safe Driving Tips
-    C: Emergencies
-    D: In Shape to Drive
-  answer: C
-  explanation: The 'Gas Pedal Sticks' topic is listed under the 'Emergencies' chapter
-    in the Table of Contents.
 - id: 25
   category: alcohol_drugs_health
   question: According to the 'In Shape to Drive' section, which of the following topics
@@ -314,64 +266,6 @@ questions:
   answer: B
   explanation: The 'In Shape to Drive' chapter specifically lists 'Marijuana' and
     'Other Drugs' immediately following the 'Drinking Alcohol and Driving' topics.
-- id: 26
-  category: vehicle_information
-  question: Which of the following is listed as a specific topic under 'Vehicle Licensing'?
-  choices:
-    A: Report of Sale
-    B: Adjusting Seat and Mirrors
-    C: Reversible Lanes
-    D: Avoiding Collisions
-  answer: A
-  explanation: The Table of Contents lists 'Report of Sale' under the 'Vehicle Licensing'
-    chapter.
-- id: 27
-  category: sharing_the_road
-  question: Under the 'Safe Driving Tips' section, which specific groups' responsibilities
-    are highlighted alongside sharing the road?
-  choices:
-    A: Pedestrian Responsibilities
-    B: Bicyclist and Motorcycle Responsibilities
-    C: Commercial Truck Driver Responsibilities
-    D: Law Enforcement Responsibilities
-  answer: B
-  explanation: The Table of Contents lists 'Bicyclist Responsibilities' and 'Motorcycle
-    Responsibilities' under the 'Safe Driving Tips' chapter.
-- id: 28
-  category: license_system
-  question: The manual includes a specific section on 'Sex-Offender/Kidnapping Offender
-    Registration' under which main chapter?
-  choices:
-    A: Rules of the Road
-    B: The Driver License
-    C: In Shape to Drive
-    D: Emergencies
-  answer: B
-  explanation: The Table of Contents places 'Sex-Offender/Kidnapping Offender Registration'
-    in 'The Driver License' chapter.
-- id: 29
-  category: defensive_driving
-  question: According to the Table of Contents, which of the following is considered
-    part of the 'Emergencies' chapter?
-  choices:
-    A: Adjusting to Traffic
-    B: Dealing with Skids
-    C: Keeping Right Except to Pass
-    D: Scanning
-  answer: B
-  explanation: The topic 'Dealing with Skids' is listed under the 'Emergencies' chapter.
-- id: 30
-  category: vehicle_information
-  question: Which of the following documents is specifically discussed in the 'Vehicle
-    Licensing' section?
-  choices:
-    A: Proof of Identity
-    B: Certificate of Ownership (Title)
-    C: Real ID
-    D: Probationary License
-  answer: B
-  explanation: The Table of Contents lists 'Certificate of Ownership (Title)' under
-    the 'Vehicle Licensing' chapter.
 - id: 31
   category: license_system
   question: How many days do new residents have to get a Washington State driver license

--- a/data/states/wa/questions_es.yaml
+++ b/data/states/wa/questions_es.yaml
@@ -1,7 +1,7 @@
 metadata:
   source: 2025 Washington Driver Guide (dol.wa.gov)
   source_original: 2025 Washington Driver Guide (dol.wa.gov)
-  total_questions: 392
+  total_questions: 383
   language: es
   categories:
   - alcohol_drugs_health
@@ -257,29 +257,6 @@ questions:
   answer: B
   explanation: El texto enumera explícitamente 'Enviar su solicitud de audiencia por
     DUI' en los servicios de registros en línea.
-- id: 20
-  category: safe_driving_rules
-  question: En la sección 'Antes de conducir', ¿cuál de los siguientes se enumera
-    como un paso necesario?
-  choices:
-    A: Comprobar las emisiones de escape del vehículo
-    B: Asegurar su carga
-    C: Mejorar sus faros delanteros
-    D: Rotar sus neumáticos
-  answer: B
-  explanation: El índice enumera 'Asegurar su carga' como un tema bajo el capítulo
-    'Antes de conducir'.
-- id: 21
-  category: safe_driving_rules
-  question: ¿Cuál de los siguientes temas se trata en la sección 'Reglas de la carretera'?
-  choices:
-    A: Reventón de neumático
-    B: Carriles HOT y carriles de peaje exprés
-    C: Falla de frenos
-    D: Certificado de propiedad
-  answer: B
-  explanation: El índice enumera 'Carriles HOT y carriles de peaje exprés' en el capítulo
-    'Reglas de la carretera'.
 - id: 22
   category: vehicle_information
   question: Según el índice, ¿dónde buscaría información sobre 'Vehículos eléctricos
@@ -292,30 +269,6 @@ questions:
   answer: B
   explanation: La información sobre 'Vehículos eléctricos de batería de baja velocidad'
     se encuentra en la sección 'Reglas de la carretera' del manual.
-- id: 23
-  category: safe_driving_rules
-  question: ¿En qué sección del manual se encuentran los temas de 'Conducción distraída'
-    y 'Dispositivos electrónicos personales'?
-  choices:
-    A: Consejos para una conducción segura
-    B: Emergencias
-    C: Licenciamiento de vehículos
-    D: Antes de conducir
-  answer: A
-  explanation: El índice ubica 'Conducción distraída' y 'Dispositivos electrónicos
-    personales' en el capítulo 'Consejos para una conducción segura'.
-- id: 24
-  category: defensive_driving
-  question: Si experimenta una situación en la que el 'pedal del acelerador se queda
-    pegado', ¿qué sección del manual ofrece orientación?
-  choices:
-    A: Reglas de la carretera
-    B: Consejos para una conducción segura
-    C: Emergencias
-    D: En condiciones para conducir
-  answer: C
-  explanation: El tema 'El pedal del acelerador se queda pegado' aparece en el capítulo
-    'Emergencias' del índice.
 - id: 25
   category: alcohol_drugs_health
   question: Según la sección 'En condiciones para conducir', ¿cuál de los siguientes
@@ -329,65 +282,6 @@ questions:
   explanation: El capítulo 'En condiciones para conducir' enumera específicamente
     'Marihuana' y 'Otras drogas' inmediatamente después de los temas de 'Consumo de
     alcohol y conducción'.
-- id: 26
-  category: vehicle_information
-  question: ¿Cuál de los siguientes aparece como un tema específico bajo 'Licenciamiento
-    de vehículos'?
-  choices:
-    A: Informe de venta
-    B: Ajuste de asiento y espejos
-    C: Carriles reversibles
-    D: Cómo evitar colisiones
-  answer: A
-  explanation: El índice enumera 'Informe de venta' en el capítulo 'Licenciamiento
-    de vehículos'.
-- id: 27
-  category: sharing_the_road
-  question: En la sección 'Consejos para una conducción segura', ¿las responsabilidades
-    de qué grupos específicos se destacan junto con el hecho de compartir la carretera?
-  choices:
-    A: Responsabilidades de los peatones
-    B: Responsabilidades de ciclistas y motociclistas
-    C: Responsabilidades de los conductores de camiones comerciales
-    D: Responsabilidades de las fuerzas del orden
-  answer: B
-  explanation: El índice enumera 'Responsabilidades de los ciclistas' y 'Responsabilidades
-    de los motociclistas' en el capítulo 'Consejos para una conducción segura'.
-- id: 28
-  category: license_system
-  question: ¿En qué capítulo principal incluye el manual una sección específica sobre
-    el 'Registro de delincuentes sexuales/delincuentes por secuestro'?
-  choices:
-    A: Reglas de la carretera
-    B: La licencia de conducir
-    C: En condiciones para conducir
-    D: Emergencias
-  answer: B
-  explanation: El índice ubica el 'Registro de delincuentes sexuales/delincuentes
-    por secuestro' en el capítulo 'La licencia de conducir'.
-- id: 29
-  category: defensive_driving
-  question: Según el índice, ¿cuál de los siguientes se considera parte del capítulo
-    'Emergencias'?
-  choices:
-    A: Ajustarse al tráfico
-    B: Cómo lidiar con derrapes
-    C: Mantenerse a la derecha excepto para rebasar
-    D: Exploración visual (Scanning)
-  answer: B
-  explanation: El tema 'Cómo lidiar con derrapes' aparece en el capítulo 'Emergencias'.
-- id: 30
-  category: vehicle_information
-  question: ¿Cuál de los siguientes documentos se analiza específicamente en la sección
-    'Licenciamiento de vehículos'?
-  choices:
-    A: Prueba de identidad
-    B: Certificado de propiedad (Título)
-    C: Real ID
-    D: Licencia probatoria
-  answer: B
-  explanation: El índice enumera 'Certificado de propiedad (Título)' en el capítulo
-    'Licenciamiento de vehículos'.
 - id: 31
   category: license_system
   question: ¿Cuántos días tienen los nuevos residentes para obtener una licencia de


### PR DESCRIPTION
Resolves issue surfaced by verifier PR #33: on-disk manual.pdf was the abridged plain-text variant, so 7 questions referencing full-PDF content couldn't grep-match. Replaces with the full WA Driver Guide; re-runs quiz_gates.py. Also drops 9 TOC/structure questions per verifier recommendation.

## Changes
- Replaced `data/states/wa/manual.pdf`: 318 KB / 81 pages (plain-text variant) -> 33 MB / 191 pages (full 2025 Washington Driver Guide from dol.wa.gov).
- Re-extracted `manual_text.txt` via PyMuPDF: 173,065 -> 222,096 chars.
- Updated `manual_provenance.json` with new sha256s, page count, char count.
- Updated `config.json` `manual_url` to the working download URL (the previous one only resolves through redirects to an HTML page).
- Dropped 9 TOC/structure questions (Q20, Q21, Q23, Q24, Q26-Q30) from `questions_en.yaml` (376 -> 367) and `questions_es.yaml` (392 -> 383).

## Verification
- `python3 tools/audit_questions.py wa`: 0 issues
- `python3 tools/bundle.py`: success (49 states, 116 language files)
- `ruff check .` and `ruff format --check .`: clean
- `python3 tools/quiz_gates.py wa --block-on-fail --sample 30`: faithfulness still HARD_FAIL but for different/new questions — the underlying 2025 manual is a structurally different edition than what the questions were originally generated from, so several questions reference content (Tacoma Narrows cash tolls, 5 Ds, snowmobile titling, deferred prosecution, etc.) that is not present in the current full guide. That is a separate quality issue beyond the scope of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)