### PR TITLE
fix(ca): re-extract from real PDF + regenerate bank (was Precision F)

### DIFF
--- a/data/states/ca/config.json
+++ b/data/states/ca/config.json
@@ -2,7 +2,7 @@
   "code": "ca",
   "name": "California",
   "agency": "DMV",
-  "manual_url": "https://www.dmv.ca.gov/portal/handbook/california-driver-handbook/",
+  "manual_url": "https://www.dmv.ca.gov/portal/file/california-driver-handbook-pdf/",
   "passing_score_pct": 83,
   "test_question_count": 46,
   "source": "2025 California Driver Handbook (dmv.ca.gov)"

--- a/data/states/ca/manual_provenance.json
+++ b/data/states/ca/manual_provenance.json
@@ -6,7 +6,7 @@
   "manual_url": "https://www.dmv.ca.gov/portal/file/california-driver-handbook-pdf/",
   "edition": "",
   "source_description": "2025 California Driver Handbook (dmv.ca.gov)",
-  "downloaded_at": "2026-04-29T12:00:00Z",
+  "downloaded_at": "2026-05-26T01:49:07Z",
   "extracted_with": "PyMuPDF 1.27.2",
   "pdf": {
     "filename": "manual.pdf",

--- a/data/states/ca/questions_en.yaml
+++ b/data/states/ca/questions_en.yaml
@@ -1,6 +1,6 @@
 metadata:
   source: 2025 California Driver Handbook (dmv.ca.gov)
-  total_questions: 284
+  total_questions: 252
   categories:
   - alcohol_drugs_health
   - defensive_driving
@@ -14,803 +14,2658 @@ metadata:
   - vehicle_information
 questions:
 - id: 1
-  category: safe_driving_rules
-  question: What is the speed limit in a school zone when children are present, unless
-    otherwise posted?
-  choices:
-    A: 15 mph
-    B: 20 mph
-    C: 25 mph
-    D: 30 mph
-  answer: C
-  explanation: According to the California Driver's Handbook, the speed limit is 25
-    mph when driving within 500 feet of a school while children are outside or crossing
-    the street, unless otherwise posted.
-- id: 2
-  category: safe_driving_rules
-  question: 'California''s ''Basic Speed Law'' states that you must:'
-  choices:
-    A: Never drive faster than the posted speed limit
-    B: Never drive faster than is safe for current conditions
-    C: Always drive at the flow of traffic
-    D: Keep your speed close to other vehicles
-  answer: B
-  explanation: The Basic Speed Law states you may never drive faster than is safe
-    for current conditions, regardless of the posted speed limit.
-- id: 3
-  category: alcohol_drugs_health
-  question: It is illegal for a person 21 years of age or older to drive with a Blood
-    Alcohol Concentration (BAC) that is ___ or higher.
-  choices:
-    A: 0.04%
-    B: 0.06%
-    C: 0.08%
-    D: 0.10%
-  answer: C
-  explanation: California law makes it illegal for anyone 21 or older to drive with
-    a BAC of 0.08% or higher.
-- id: 4
-  category: sharing_the_road
-  question: 'When a school bus with its red lights flashing is stopped ahead on your
-    side of the road, you must:'
-  choices:
-    A: Stop until you think all children are unloaded
-    B: Stop until the red lights stop flashing
-    C: Change lanes, drive slowly, and pass carefully
-    D: Slow down to 15 mph as you pass
-  answer: B
-  explanation: You must stop for a school bus with flashing red lights and remain
-    stopped until the lights stop flashing. Failing to do so can result in a fine
-    and suspended license.
-- id: 5
-  category: sharing_the_road
-  question: 'You must yield the right-of-way to an emergency vehicle by:'
-  choices:
-    A: Driving as near to the right edge of the road as possible and stopping
-    B: Moving into the right lane and driving slowly
-    C: Stopping immediately in your current lane
-    D: Speeding up to get out of its way
-  answer: A
-  explanation: When you hear a siren or see flashing red lights from an emergency
-    vehicle, you must pull over to the right edge of the road and stop until it passes.
-- id: 6
-  category: driver_responsibility
-  question: Under California law, when can you use a handheld cell phone while driving?
-  choices:
-    A: When stopped at a red light
-    B: Only in an emergency to call for assistance
-    C: When traffic is moving at less than 15 mph
-    D: When you are driving on a rural highway
-  answer: B
-  explanation: You may only use a handheld cell phone while driving in an emergency
-    situation to call law enforcement, a medical provider, the fire department, or
-    other emergency services.
-- id: 7
-  category: safe_driving_rules
-  question: 'When parking uphill on a two-way street with no curb, your front wheels
-    should be:'
-  choices:
-    A: Turned to the left (toward the street)
-    B: Turned to the right (away from the street)
-    C: Parallel with the edge of the road
-    D: Pointing straight ahead
-  answer: B
-  explanation: When parking uphill or downhill with no curb, turn your wheels to the
-    right (toward the side of the road) so the vehicle will roll away from the center
-    of the road if the brakes fail.
-- id: 8
-  category: signs_and_signals
-  question: 'A flashing red traffic light at an intersection means:'
-  choices:
-    A: Slow down before entering
-    B: Stop before entering, then proceed when safe
-    C: Stop and wait for the green light
-    D: Yield to all traffic before entering
-  answer: B
-  explanation: A flashing red traffic signal light means 'STOP.' After stopping, you
-    may proceed when it is safe, observing the right-of-way rules.
-- id: 9
-  category: signs_and_signals
-  question: 'Two solid yellow lines in the center of the roadway mean:'
-  choices:
-    A: Passing is permitted from either direction
-    B: Passing is permitted only if you are on the right side
-    C: No passing is permitted from either direction
-    D: The road narrows ahead
-  answer: C
-  explanation: Two solid yellow lines indicate no passing. You may not drive over
-    these lines to pass other vehicles.
-- id: 10
-  category: defensive_driving
-  question: 'To avoid tailgating, the California Driver''s Handbook recommends using
-    the:'
-  choices:
-    A: 2-second rule
-    B: 3-second rule
-    C: 4-second rule
-    D: 5-second rule
-  answer: B
-  explanation: To avoid tailgating, use the '3-second rule' to ensure you have enough
-    space to stop safely if the vehicle in front of you brakes suddenly.
-- id: 11
-  category: penalties_and_points
-  question: 'You must notify the DMV within 10 days if you are in a collision that
-    causes:'
-  choices:
-    A: Any vehicle damage
-    B: More than $500 in damage
-    C: More than $1,000 in damage or anyone is injured or killed
-    D: Your vehicle to be towed
-  answer: C
-  explanation: You (or your insurance agent, broker, or legal representative) must
-    report a collision to the DMV within 10 days if it caused more than $1,000 in
-    property damage or if anyone was injured or killed.
-- id: 12
-  category: sharing_the_road
-  question: 'If a pedestrian is in a crosswalk, you must:'
-  choices:
-    A: Honk your horn to warn them
-    B: Yield the right-of-way to the pedestrian
-    C: Drive around them carefully
-    D: Stop only if they are on your side of the road
-  answer: B
-  explanation: Pedestrians have the right-of-way in marked or unmarked crosswalks.
-    You must yield and allow them to cross safely.
-- id: 13
   category: license_system
-  question: 'With a basic Class C driver''s license, a person may drive:'
+  question: What phone number should individuals who are deaf, hard of hearing, or
+    speech impaired call for DMV assistance?
   choices:
-    A: A 3-axle vehicle if the Gross Vehicle Weight is less than 6,000 pounds
-    B: Any commercial vehicle
-    C: A vehicle pulling two trailers
-    D: A motorcycle
-  answer: A
-  explanation: A Class C driver's license allows you to drive a 2-axle vehicle with
-    a GVWR of 26,000 lbs. or less, or a 3-axle vehicle weighing 6,000 lbs. or less
-    gross.
-- id: 14
-  category: defensive_driving
-  question: 'When changing lanes, you should check your blind spots by:'
-  choices:
-    A: Looking in your rearview mirror
-    B: Looking in your side mirrors
-    C: Turning your head and looking over your shoulder
-    D: Using your backup camera
-  answer: C
-  explanation: Mirrors do not show your blind spots. You must turn your head and look
-    over your shoulder to ensure a lane is clear before changing lanes.
-- id: 15
-  category: safe_driving_rules
-  question: What is the fundamental principle of California's 'Basic Speed Law'?
-  choices:
-    A: You may never drive faster than the posted speed limit.
-    B: You may never drive faster than is safe for current conditions.
-    C: You must always drive at the flow of traffic, regardless of the speed limit.
-    D: You must drive at least 10 mph below the speed limit in bad weather.
+    A: 1-800-777-0133
+    B: 1-800-368-4327
+    C: 1-800-555-0199
+    D: 1-800-DMV-HELP
   answer: B
-  explanation: California's 'Basic Speed Law' states that you may never drive faster
-    than is safe for current conditions, regardless of the posted speed limit.
-- id: 16
-  category: alcohol_drugs_health
-  question: What is the legal Blood Alcohol Concentration (BAC) limit for a driver
-    who is 21 years of age or older?
+  explanation: According to the DMV Services section, individuals who are deaf, hard
+    of hearing, or speech impaired may call 1-800-368-4327 for assistance.
+- id: 2
+  category: license_system
+  question: What type of driver's license do most people need to drive a standard
+    passenger vehicle in California?
   choices:
-    A: 0.04%
-    B: 0.06%
-    C: 0.08%
-    D: 0.10%
+    A: Commercial Class A
+    B: Noncommercial Class B
+    C: Noncommercial Class C
+    D: Commercial Class C
   answer: C
-  explanation: It is illegal for any person 21 years of age or older to operate a
-    vehicle with a Blood Alcohol Concentration (BAC) of 0.08% or higher.
+  explanation: The manual states that you must have the correct license to drive your
+    vehicle type, and most people need a noncommercial Class C driver's license.
+- id: 3
+  category: license_system
+  question: Beginning May 2025, what will a REAL ID compliant driver's license or
+    ID card allow you to do?
+  choices:
+    A: Drive commercial vehicles across state lines
+    B: Board an airplane for domestic flights
+    C: Travel internationally without a passport
+    D: Vote in federal elections
+  answer: B
+  explanation: Beginning May 2025, your driver's license or ID card must be REAL ID
+    compliant if you use it to board an airplane for domestic flights, enter military
+    bases, or enter most federal facilities.
+- id: 4
+  category: license_system
+  question: Which of the following is true regarding driver's licenses for undocumented
+    residents in California?
+  choices:
+    A: They are only issued for commercial driving purposes.
+    B: They are not available in the state of California.
+    C: California offers driver's licenses for all residents regardless of immigration
+      status.
+    D: They are only valid for a maximum of 6 months.
+  answer: C
+  explanation: The manual explicitly states that California offers driver's licenses
+    for all residents regardless of immigration status.
+- id: 5
+  category: license_system
+  question: What is a restriction of a California Identification (ID) card?
+  choices:
+    A: It is only issued to individuals over 18 years old.
+    B: It does not permit you to drive.
+    C: It cannot be used for official identification purposes.
+    D: It requires passing a vision and knowledge test.
+  answer: B
+  explanation: ID cards are issued for identification purposes to eligible persons
+    of any age, but the manual notes that they do not permit you to drive.
+- id: 6
+  category: license_system
+  question: When applying for an instruction permit or driver's license, how many
+    proofs of California residency are generally required?
+  choices:
+    A: One
+    B: Two
+    C: Three
+    D: Four
+  answer: B
+  explanation: To apply for an instruction permit or driver's license, you must provide
+    two proofs of residency to prove you live in California (though exceptions may
+    apply).
+- id: 7
+  category: driver_testing
+  question: Which of the following is a requirement to apply for a Class C instruction
+    permit?
+  choices:
+    A: Pass a behind-the-wheel drive test
+    B: Pay a refundable application fee
+    C: Pass a vision test
+    D: Own a registered vehicle
+  answer: C
+  explanation: Applying for a Class C instruction permit requires you to complete
+    an application, provide documents, pay a non-refundable fee, pass your knowledge
+    test(s), and pass a vision test.
+- id: 8
+  category: license_system
+  question: What is the minimum age requirement to apply for an instruction permit
+    if you are under 18 years old?
+  choices:
+    A: 15 years old
+    B: 15½ years old
+    C: 16 years old
+    D: 16½ years old
+  answer: B
+  explanation: If you are under 18 years old, you need to be at least 15½ years old
+    to apply for an instruction permit.
+- id: 9
+  category: driver_testing
+  question: If you are under 18, when can you start using your instruction permit
+    to practice driving?
+  choices:
+    A: Immediately after passing the written knowledge test
+    B: After you start behind-the-wheel driver training with an instructor who validates
+      the permit
+    C: As soon as your parent or guardian signs the permit
+    D: After you have held the permit for at least 30 days
+  answer: B
+  explanation: Minors must wait to use their instruction permit until they start behind-the-wheel
+    driver training with an instructor who will validate the permit.
+- id: 10
+  category: driver_testing
+  question: What must instructors at DMV-licensed driving schools carry with them?
+  choices:
+    A: A commercial driver's license
+    B: A copy of the California Vehicle Code
+    C: An instructor's ID card
+    D: Proof of dual-control vehicle insurance
+  answer: C
+  explanation: The manual states that driving school instructors must carry an instructor's
+    ID card, and you should ask to see it.
+- id: 11
+  category: driver_testing
+  question: If you are an adult practicing driving with an instruction permit, who
+    must accompany you in the vehicle?
+  choices:
+    A: A California-licensed driver who is at least 18 years old
+    B: A California-licensed driver who is at least 25 years old
+    C: Any licensed driver from any state
+    D: A DMV-certified driving instructor
+  answer: A
+  explanation: To get your driver's license, you need to practice driving with a California-licensed
+    driver who is at least 18 years old (or 25 for minors).
+- id: 12
+  category: driver_testing
+  question: If you are under 18, how many hours of practice driving must you complete
+    before applying for a driver's license?
+  choices:
+    A: 30 hours
+    B: 40 hours
+    C: 50 hours
+    D: 60 hours
+  answer: C
+  explanation: Minors must practice driving for at least 50 hours with a California-licensed
+    driver who is at least 25 years old.
+- id: 13
+  category: driver_testing
+  question: Of the required practice driving hours for minors, how many must be completed
+    at night?
+  choices:
+    A: 5 hours
+    B: 10 hours
+    C: 15 hours
+    D: 20 hours
+  answer: B
+  explanation: The manual specifies that of the 50 required practice hours for minors,
+    ten hours must be at night.
+- id: 14
+  category: driver_testing
+  question: If you are under 18, how long must you hold your instruction permit before
+    scheduling your behind-the-wheel drive test?
+  choices:
+    A: At least 3 months
+    B: At least 6 months
+    C: At least 9 months
+    D: At least 12 months
+  answer: B
+  explanation: Minors must have an instruction permit from California or another state
+    for at least 6 months (or turn 18 years old) before scheduling the behind-the-wheel
+    drive test.
+- id: 15
+  category: driver_responsibility
+  question: When a minor (under 18) is practicing driving with an instruction permit,
+    the accompanying California-licensed driver must be at least what age?
+  choices:
+    A: 18 years old
+    B: 21 years old
+    C: 25 years old
+    D: 30 years old
+  answer: C
+  explanation: Minors must practice driving with a California-licensed driver who
+    is at least 25 years old.
+- id: 16
+  category: license_system
+  question: How many hours of practice driving must a minor complete before scheduling
+    a behind-the-wheel drive test?
+  choices:
+    A: 30 hours
+    B: 40 hours
+    C: 50 hours
+    D: 60 hours
+  answer: C
+  explanation: Minors must practice driving for at least 50 hours with a California-licensed
+    driver who is at least 25 years old, and 10 of those hours must be at night.
 - id: 17
+  category: license_system
+  question: During the first 12 months of holding a provisional license, a minor is
+    restricted from driving between what hours?
+  choices:
+    A: 10 p.m. and 5 a.m.
+    B: 11 p.m. and 5 a.m.
+    C: Midnight and 6 a.m.
+    D: 11 p.m. and 6 a.m.
+  answer: B
+  explanation: As a provisional driver, you cannot drive between 11 p.m. and 5 a.m.
+    during the first 12 months you have your license.
+- id: 18
+  category: license_system
+  question: If a provisional driver needs to drive during restricted hours for work
+    reasons, what must they carry?
+  choices:
+    A: A note signed by a physician
+    B: A note signed by their school principal
+    C: A note signed by their employer confirming employment
+    D: A copy of their most recent pay stub
+  answer: C
+  explanation: If you must drive for work reasons during restricted hours, you must
+    carry a note signed by your employer that confirms your employment.
+- id: 19
+  category: driver_testing
+  question: How long must a minor wait to retake a failed knowledge test?
+  choices:
+    A: 3 days
+    B: 7 days
+    C: 14 days
+    D: 30 days
+  answer: B
+  explanation: Minors must wait seven days to retake a failed knowledge test, not
+    including the day of the failure.
+- id: 20
+  category: vehicle_information
+  question: What is the minimum required tire tread depth for a vehicle used in the
+    behind-the-wheel drive test?
+  choices:
+    A: 1/16-inch
+    B: 1/32-inch
+    C: 2/32-inch
+    D: 1/8-inch
+  answer: B
+  explanation: The manual states that the tires must have at least 1/32-inch of uniformed
+    tread depth, and donut tires are not allowed.
+- id: 21
+  category: vehicle_information
+  question: 'During the pre-drive inspection, your vehicle''s horn must be loud enough
+    to be heard from a distance of at least:'
+  choices:
+    A: 100 feet
+    B: 200 feet
+    C: 300 feet
+    D: 500 feet
+  answer: B
+  explanation: The vehicle's horn must be designed for the vehicle, in proper working
+    condition, and loud enough to be heard from a distance of at least 200 feet.
+- id: 22
+  category: driver_testing
+  question: Which of the following vehicle technologies is permitted to be used during
+    the behind-the-wheel drive test?
+  choices:
+    A: Automated parallel parking
+    B: Lane departure warnings
+    C: Adaptive cruise control
+    D: Backup cameras
+  answer: D
+  explanation: Vehicle safety technology, such as backup cameras and blind spot monitors,
+    may be used on the drive test, but advanced driver assistance systems like automated
+    parallel parking are not permitted.
+- id: 23
+  category: license_system
+  question: If you move, how many days do you have to notify the DMV of your new address?
+  choices:
+    A: 5 days
+    B: 10 days
+    C: 14 days
+    D: 30 days
+  answer: B
+  explanation: If you move, you must notify the DMV of your new address within ten
+    days.
+- id: 24
+  category: license_system
+  question: 'If you are out-of-state and cannot renew your driver''s license, you
+    may request an extension for up to:'
+  choices:
+    A: 30 days
+    B: 6 months
+    C: 1 year
+    D: 2 years
+  answer: C
+  explanation: If you are out-of-state and cannot renew, you may request a one-year
+    extension of your driver's license by submitting a request to the DMV.
+- id: 25
   category: safe_driving_rules
-  question: What is the speed limit at a blind intersection?
+  question: When it comes to hearing and driving, which of the following is illegal
+    in California?
+  choices:
+    A: Listening to the radio at a high volume
+    B: Wearing a headset or earplugs in both ears while driving
+    C: Driving if you are completely deaf
+    D: Using a hands-free earpiece in one ear
+  answer: B
+  explanation: According to the manual, it is illegal to wear a headset or earplugs
+    in both ears while driving.
+- id: 26
+  category: alcohol_drugs_health
+  question: Physicians are required to report patients to the DMV for medical conditions
+    that may affect their ability to drive safely if the patient is at least what
+    age?
+  choices:
+    A: 14 years old
+    B: 16 years old
+    C: 18 years old
+    D: 21 years old
+  answer: A
+  explanation: Physicians are required to report patients who are at least 14 years
+    old to the DMV for medical conditions that may affect their ability to drive safely,
+    such as a lapse of consciousness.
+- id: 27
+  category: safe_driving_rules
+  question: When using the hand-to-hand (push/pull) steering method, where should
+    your hands start on the steering wheel?
+  choices:
+    A: 10 and 2 o'clock
+    B: 9 and 3 o'clock or 8 and 4 o'clock
+    C: 11 and 1 o'clock
+    D: 7 and 5 o'clock
+  answer: B
+  explanation: To use the hand-to-hand steering method, you should start with your
+    hands at 9 and 3 o'clock or 8 and 4 o'clock.
+- id: 28
+  category: driver_testing
+  question: Who is generally allowed to accompany you in the vehicle during the behind-the-wheel
+    drive test?
+  choices:
+    A: A parent or guardian
+    B: A licensed driving instructor
+    C: An interpreter
+    D: Only the examiner
+  answer: D
+  explanation: Only the examiner is allowed to accompany you during the drive test.
+    Exceptions are made for training, service animals, and certain law enforcement
+    situations.
+- id: 29
+  category: vehicle_information
+  question: How many rearview mirrors are required on your vehicle for the behind-the-wheel
+    drive test?
+  choices:
+    A: At least one on the left side
+    B: At least two, with one of them on the left side
+    C: At least two, with one on the right side
+    D: Three mirrors (left, right, and center)
+  answer: B
+  explanation: The pre-drive inspection requires at least two rearview mirrors, and
+    one of them must be on the left side of your vehicle.
+- id: 30
+  category: vehicle_information
+  question: What is the recommended starting hand position for the hand-to-hand (push/pull)
+    steering method?
+  choices:
+    A: 10 and 2 o'clock
+    B: 9 and 3 o'clock or 8 and 4 o'clock
+    C: 12 and 6 o'clock
+    D: 11 and 1 o'clock
+  answer: B
+  explanation: For hand-to-hand steering, the manual states to start with your hands
+    at 9 and 3 o'clock or 8 and 4 o'clock.
+- id: 31
+  category: vehicle_information
+  question: When is it appropriate to use one-hand steering with your hand at the
+    12 o'clock position?
+  choices:
+    A: When driving on the freeway
+    B: When recovering from a skid
+    C: When turning while backing up to see where you are going
+    D: When parking at low speeds
+  answer: C
+  explanation: The manual states you may use one-hand steering with your hand at the
+    12 o'clock position when you are turning while backing up to see where you are
+    going behind you.
+- id: 32
+  category: safe_driving_rules
+  question: How far in advance should you signal before changing lanes on a freeway?
+  choices:
+    A: At least 50 feet
+    B: At least 100 feet
+    C: At least three seconds
+    D: At least five seconds
+  answer: D
+  explanation: You should signal at least five seconds before you change lanes on
+    a freeway.
+- id: 33
+  category: defensive_driving
+  question: You should use your horn to alert oncoming traffic on narrow mountain
+    roads if you cannot see at least how far ahead?
+  choices:
+    A: 100 feet
+    B: 200 feet
+    C: 300 feet
+    D: 500 feet
+  answer: B
+  explanation: Use your horn to alert oncoming traffic on narrow mountain roads where
+    you cannot see at least 200 feet ahead.
+- id: 34
+  category: safe_driving_rules
+  question: When must you dim your high-beam headlights to low beams when following
+    another vehicle?
+  choices:
+    A: Within 200 feet
+    B: Within 300 feet
+    C: Within 400 feet
+    D: Within 500 feet
+  answer: B
+  explanation: You must dim your high-beam headlights to low beams within 300 feet
+    of a vehicle you are following.
+- id: 35
+  category: safe_driving_rules
+  question: What must you do if adverse weather conditions require you to use your
+    windshield wipers?
+  choices:
+    A: Turn on your high-beam headlights
+    B: Turn on your emergency flashers
+    C: Turn on your low-beam headlights
+    D: Drive using only your parking lights
+  answer: C
+  explanation: If you need to use your windshield wipers due to fog, rain, or snow,
+    you must turn on your low-beam headlights.
+- id: 36
+  category: defensive_driving
+  question: If you see a collision ahead and want to warn drivers behind you, which
+    of the following is an approved method?
+  choices:
+    A: Honk your horn continuously
+    B: Lightly tap your brake pedal three or four times
+    C: Turn on your high-beam headlights
+    D: Swerve slightly from side to side
+  answer: B
+  explanation: To warn drivers behind you of a collision or hazard ahead, you can
+    turn on your emergency flashers, lightly tap your brake pedal three or four times,
+    or use a hand signal.
+- id: 37
+  category: signs_and_signals
+  question: What does it mean when you see two sets of solid double yellow lines spaced
+    two or more feet apart?
+  choices:
+    A: It is a center left turn lane
+    B: It is a designated passing zone
+    C: It is considered a barrier and you may not drive on or over it
+    D: It indicates an upcoming carpool lane
+  answer: C
+  explanation: Two sets of solid double yellow lines spaced two or more feet apart
+    are considered a barrier. Do not drive on or over this barrier except at designated
+    openings.
+- id: 38
+  category: signs_and_signals
+  question: Which statement is true regarding double solid white lines?
+  choices:
+    A: You may cross them to enter a carpool lane
+    B: They separate traffic going in opposite directions
+    C: You should never change lanes over them
+    D: They indicate a turnout area
+  answer: C
+  explanation: Double solid white lines indicate a lane barrier between a regular
+    use and a preferential use lane. You should never change lanes over double solid
+    white lines.
+- id: 39
+  category: signs_and_signals
+  question: How is a yield line marked on the road?
+  choices:
+    A: A line of solid white triangles pointing towards approaching vehicles
+    B: Large broken white lines
+    C: A single solid yellow line
+    D: A line of solid white diamonds
+  answer: A
+  explanation: A yield line is a line of solid white triangles that shows approaching
+    vehicles where to yield or stop. The triangles point towards approaching vehicles.
+- id: 40
+  category: safe_driving_rules
+  question: If a road has multiple lanes traveling in the same direction, what is
+    the far left lane (Number 1 Lane) primarily used for?
+  choices:
+    A: Entering or exiting traffic
+    B: Driving slowly
+    C: Passing or turning left
+    D: Parking
+  answer: C
+  explanation: You should use the left lane (Number 1 Lane) to pass or turn left.
+- id: 41
+  category: safe_driving_rules
+  question: When preparing to change lanes, which of the following is true?
+  choices:
+    A: You must slow down before starting the lane change
+    B: It is not necessary to slow down before a lane change
+    C: You only need to check your mirrors, not your blind spots
+    D: You should weave in and out of traffic to find the best lane
+  answer: B
+  explanation: When changing lanes, be sure there is enough space for your vehicle
+    in the next lane. It is not necessary to slow down before a lane change.
+- id: 42
+  category: sharing_the_road
+  question: Which of the following vehicles is generally permitted to use a High-Occupancy
+    Vehicle (HOV) lane without meeting a minimum passenger requirement?
+  choices:
+    A: Any vehicle towing a trailer
+    B: A motorcycle
+    C: A single-occupant gas-powered sedan
+    D: A commercial delivery truck
+  answer: B
+  explanation: To use an HOV lane, you must meet the minimum passenger requirement,
+    drive a low/zero emission vehicle with a special decal, or be riding a motorcycle
+    (unless otherwise posted).
+- id: 43
+  category: safe_driving_rules
+  question: What is the maximum distance you may drive in a center left turn lane?
+  choices:
+    A: 50 feet
+    B: 100 feet
+    C: 200 feet
+    D: 300 feet
+  answer: C
+  explanation: You may only drive for 200 feet in the center left turn lane before
+    making a left turn or U-turn.
+- id: 44
+  category: safe_driving_rules
+  question: When must you use a turnout area or lane to let other vehicles pass?
+  choices:
+    A: When you are driving slowly on a two-lane road, passing is unsafe, and there
+      are five or more vehicles following you
+    B: When you need to stop and make a phone call
+    C: When you are driving on a freeway and want to exit
+    D: When there are three vehicles following you closely
+  answer: A
+  explanation: You must use a turnout area or lane to let other vehicles pass when
+    you are driving slowly on a two-lane road, where passing is unsafe, and there
+    are five or more vehicles following you.
+- id: 45
+  category: sharing_the_road
+  question: How far in advance of an intersection are you permitted to drive in a
+    bicycle lane to make a turn?
+  choices:
+    A: Within 50 feet
+    B: Within 100 feet
+    C: Within 200 feet
+    D: Within 300 feet
+  answer: C
+  explanation: It is illegal to drive in a bicycle lane unless you are parking, entering/leaving
+    the road, or turning (within 200 feet of an intersection).
+- id: 46
+  category: sharing_the_road
+  question: What is the minimum distance that must be maintained between a vehicle
+    and a bicyclist on a shared roadway?
+  choices:
+    A: Two (2) feet
+    B: Three (3) feet
+    C: Four (4) feet
+    D: Five (5) feet
+  answer: B
+  explanation: Three (3) feet of distance must be maintained between the car and cyclist.
+- id: 47
+  category: safe_driving_rules
+  question: How far before a turn should you start signaling?
+  choices:
+    A: About 50 feet before the turn
+    B: About 100 feet before the turn
+    C: About 200 feet before the turn
+    D: About 400 feet before the turn
+  answer: B
+  explanation: To make a right or left turn, you should start signaling about 100
+    feet before the turn.
+- id: 48
+  category: signs_and_signals
+  question: Are you allowed to make a right turn against a red arrow light?
+  choices:
+    A: Yes, after coming to a complete stop.
+    B: Yes, if there are no pedestrians in the crosswalk.
+    C: No, you must wait until the light changes to green.
+    D: No, unless you are in a dedicated right turn lane.
+  answer: C
+  explanation: You may not turn right if you are stopped at a red arrow light. Wait
+    until the light changes to green before making your turn.
+- id: 49
+  category: sharing_the_road
+  question: Can you cross a designated public transit bus lane to make a right turn?
+  choices:
+    A: Yes, you may cross a bus lane to make a right turn.
+    B: No, it is illegal to enter a bus lane at any time.
+    C: Yes, but only if you are driving a public transit vehicle.
+    D: No, unless the traffic light is green.
+  answer: A
+  explanation: It is illegal to drive, stop, park, or leave a vehicle in an area designated
+    for public transit buses. However, you may cross a bus lane to make a right turn.
+- id: 50
+  category: defensive_driving
+  question: How should your wheels be positioned while waiting to make a left turn?
+  choices:
+    A: Pointed to the left
+    B: Pointed to the right
+    C: Pointed straight ahead
+    D: Turned slightly toward the curb
+  answer: C
+  explanation: Keep your wheels pointed straight ahead until it is safe to start your
+    turn. If your wheels are pointed to the left and a vehicle hits you from behind,
+    you could be pushed into oncoming traffic.
+- id: 51
+  category: safe_driving_rules
+  question: Under what condition may you turn left against a red light?
+  choices:
+    A: When turning from a two-way street onto a one-way street.
+    B: When turning from a one-way street onto a one-way street.
+    C: When turning from a one-way street onto a two-way street.
+    D: Left turns against a red light are never permitted.
+  answer: B
+  explanation: You may turn left against a red light when you are turning from a one-way
+    street onto a one-way street, provided there is no sign prohibiting the turn.
+- id: 52
+  category: safe_driving_rules
+  question: When is it legal to make a U-turn in a residential district?
+  choices:
+    A: At any time, regardless of approaching traffic.
+    B: If no vehicles are approaching you within 100 feet.
+    C: If no vehicles are approaching you within 200 feet.
+    D: U-turns are strictly prohibited in all residential districts.
+  answer: C
+  explanation: You may make a U-turn in a residential district if no vehicles are
+    approaching you within 200 feet.
+- id: 53
+  category: safe_driving_rules
+  question: In which of the following locations is it NEVER legal to make a U-turn?
+  choices:
+    A: Across a double yellow line.
+    B: At an intersection on a green traffic light.
+    C: On a divided highway if a center divider opening is provided.
+    D: At or on a railroad crossing.
+  answer: D
+  explanation: You must never make a U-turn at or on a railroad crossing.
+- id: 54
+  category: defensive_driving
+  question: When stopping behind another vehicle at an intersection, how much space
+    should you leave?
+  choices:
+    A: Exactly one car length.
+    B: Enough space to see their rear wheels.
+    C: Three seconds of space.
+    D: At least 10 feet.
+  answer: B
+  explanation: When stopping behind a vehicle, leave enough space to see their rear
+    wheels.
+- id: 55
+  category: safe_driving_rules
+  question: When merging onto a highway, at what speed should you be driving?
+  choices:
+    A: 10 mph below the posted speed limit.
+    B: At or near the speed of traffic.
+    C: The exact posted speed limit.
+    D: 5 mph faster than highway traffic.
+  answer: B
+  explanation: When you enter a highway, you will need to be at or near the speed
+    of traffic.
+- id: 56
+  category: safe_driving_rules
+  question: How long before you exit a highway should you signal?
+  choices:
+    A: Two seconds
+    B: Three seconds
+    C: Five seconds (approximately 400 feet)
+    D: Ten seconds (approximately 800 feet)
+  answer: C
+  explanation: When in the proper lane, signal five seconds (approximately 400 feet)
+    before you exit.
+- id: 57
+  category: safe_driving_rules
+  question: When making a left turn from a two-way street onto a one-way street with
+    three or more lanes, which lane may you end your turn in?
+  choices:
+    A: Only the far-left lane.
+    B: Only the center lane.
+    C: Only the far-right lane.
+    D: Any lane that is open.
+  answer: D
+  explanation: When making a left turn from a two-way street onto a one-way street,
+    if there are three or more lanes in your direction of travel, you may end your
+    turn in any lane that is open.
+- id: 58
+  category: sharing_the_road
+  question: Which type of bikeway is physically separated from motor vehicle traffic
+    and for the exclusive use of bicyclists?
+  choices:
+    A: Buffered bike lane
+    B: Bicycle boulevard
+    C: Separated bikeway
+    D: Shared roadway
+  answer: C
+  explanation: A separated bikeway is physically separated from motor vehicle traffic
+    and for exclusive use of bicyclists. They are also known as a cycle track or protected
+    bike lanes.
+- id: 59
+  category: safe_driving_rules
+  question: When preparing to exit a highway, approximately how far in advance should
+    you signal?
+  choices:
+    A: 100 feet
+    B: 200 feet
+    C: 300 feet
+    D: 400 feet
+  answer: D
+  explanation: The manual states that when in the proper lane, you should signal five
+    seconds (approximately 400 feet) before you exit.
+- id: 60
+  category: safe_driving_rules
+  question: 'When entering traffic from a full stop on a city street, you need a space
+    that is approximately:'
+  choices:
+    A: 50 feet
+    B: 100 feet
+    C: 150 feet
+    D: 300 feet
+  answer: C
+  explanation: To merge, enter, or exit traffic, you need a space that is half a block
+    on city streets, which is about 150 feet.
+- id: 61
+  category: defensive_driving
+  question: You are waiting to turn left and an oncoming vehicle has its right turn
+    signal on. What should you do?
+  choices:
+    A: Begin your turn immediately since they are turning.
+    B: Wait for the vehicle to start its turn before beginning your left turn.
+    C: Honk your horn to ensure they see you before turning.
+    D: Turn right instead to avoid a collision.
+  answer: B
+  explanation: The manual advises not to assume an oncoming vehicle with its right
+    turn signal on is turning before it reaches you. You should wait for the vehicle
+    to start its turn before beginning the left turn.
+- id: 62
+  category: safe_driving_rules
+  question: To safely pass another vehicle when approaching a hill or curve, the hill
+    or curve should be at least how far ahead?
+  choices:
+    A: One-quarter of a mile
+    B: One-third of a mile
+    C: One-half of a mile
+    D: One full mile
+  answer: B
+  explanation: According to the manual, to safely pass, the hill or curve should be
+    at least one-third of a mile ahead.
+- id: 63
+  category: safe_driving_rules
+  question: It is dangerous and illegal to pass another vehicle within how many feet
+    of an intersection, bridge, tunnel, or railroad crossing?
+  choices:
+    A: 50 feet
+    B: 100 feet
+    C: 200 feet
+    D: 300 feet
+  answer: B
+  explanation: You must not pass within 100 feet of an intersection, bridge, tunnel,
+    railroad crossing, or other hazardous area.
+- id: 64
+  category: safe_driving_rules
+  question: Under which of the following circumstances are you permitted to pass a
+    vehicle on the right?
+  choices:
+    A: When the driver ahead of you is signaling a right turn.
+    B: When you are driving on an unpaved shoulder.
+    C: When the driver ahead of you is turning left and you can safely pass on the
+      right.
+    D: Whenever the vehicle ahead is driving below the speed limit.
+  answer: C
+  explanation: You may pass on the right only when the driver ahead of you is turning
+    left and you can safely pass on the right, on a one-way street, or on an open
+    highway with two or more lanes going in your direction.
+- id: 65
+  category: sharing_the_road
+  question: If another vehicle is passing you, what should you do?
+  choices:
+    A: Speed up to prevent them from passing.
+    B: Slow down drastically and move to the shoulder.
+    C: Maintain your lane position and your speed.
+    D: Turn on your hazard lights.
+  answer: C
+  explanation: If a vehicle is passing you or signals that they plan on passing, allow
+    the vehicle to pass by maintaining your lane position and your speed.
+- id: 66
+  category: safe_driving_rules
+  question: 'When you have successfully parallel parked, your vehicle should be parallel
+    to the curb and within:'
+  choices:
+    A: 12 inches of the curb.
+    B: 18 inches of the curb.
+    C: 24 inches of the curb.
+    D: 36 inches of the curb.
+  answer: B
+  explanation: When straightening out during parallel parking, your vehicle should
+    be parallel and within 18 inches of the curb.
+- id: 67
+  category: safe_driving_rules
+  question: How should you turn your front wheels when parking headed uphill next
+    to a curb?
+  choices:
+    A: Turn your front wheels away from the curb.
+    B: Turn your front wheels toward the curb.
+    C: Keep your front wheels perfectly straight.
+    D: Turn your front wheels to the right.
+  answer: A
+  explanation: When headed uphill, you should turn your front wheels away from the
+    curb (left-towards the center of the road) and let your vehicle roll back a few
+    inches so the wheel gently touches the curb.
+- id: 68
+  category: signs_and_signals
+  question: What does a curb painted yellow indicate?
+  choices:
+    A: Stop only long enough to pick up or drop off passengers.
+    B: Parking is reserved for disabled persons.
+    C: No stopping, standing, or parking at any time.
+    D: Load and unload passengers and freight for a limited time.
+  answer: D
+  explanation: A yellow painted curb means you may load and unload passengers and
+    freight. You must not stop longer than the time posted, and drivers of noncommercial
+    vehicles are usually required to stay with their vehicle.
+- id: 69
+  category: safe_driving_rules
+  question: It is illegal to park or leave your vehicle within how many feet of a
+    fire hydrant or fire station driveway?
+  choices:
+    A: 10 feet
+    B: 15 feet
+    C: 20 feet
+    D: 25 feet
+  answer: B
+  explanation: You must never park or leave your vehicle within 15 feet of a fire
+    hydrant or fire station driveway.
+- id: 70
+  category: penalties_and_points
+  question: 'If you must stop on a freeway in an emergency, your vehicle may be removed
+    if it is left standing for more than:'
+  choices:
+    A: 2 hours.
+    B: 4 hours.
+    C: 12 hours.
+    D: 24 hours.
+  answer: B
+  explanation: A vehicle that is stopped, parked, or left standing on a freeway for
+    more than four hours may be removed.
+- id: 71
+  category: vehicle_information
+  question: Which of the following is a recommended practice to maximize your fuel
+    efficiency and lower emissions?
+  choices:
+    A: Accelerate and brake as quickly as possible.
+    B: Keep extra weight in your vehicle for better traction.
+    C: Get rid of extra weight in your vehicle.
+    D: Use lower octane fuel than recommended.
+  answer: C
+  explanation: To drive green and maximize fuel efficiency, the manual recommends
+    getting rid of extra weight in your vehicle, driving at a steady speed, and regularly
+    inflating your tires.
+- id: 72
+  category: driver_responsibility
+  question: What should you do when a law enforcement officer requires you to stop
+    while you are driving in the carpool/HOV lane?
+  choices:
+    A: Stop immediately in the carpool lane.
+    B: Move completely onto the right shoulder.
+    C: Move to the center median.
+    D: Exit the highway at the next available off-ramp before stopping.
+  answer: B
+  explanation: During a law enforcement stop, you should move completely onto the
+    right shoulder, even if you are in the carpool/HOV lane.
+- id: 73
+  category: driver_responsibility
+  question: During a traffic stop, what must a law enforcement officer generally do
+    before beginning any questioning related to a traffic violation?
+  choices:
+    A: Ask for your vehicle registration and insurance.
+    B: Ask if you know why you were pulled over.
+    C: State the reason for the traffic or pedestrian stop.
+    D: Issue a written warning or citation.
+  answer: C
+  explanation: Law enforcement officers must state the reason for a traffic or pedestrian
+    stop before they begin any questioning related to a criminal investigation or
+    traffic violation, unless there is an imminent threat.
+- id: 74
+  category: driver_responsibility
+  question: What three documents must a driver produce when stopped by law enforcement?
+  choices:
+    A: Driver's license, passport, and vehicle registration
+    B: Driver's license, proof of insurance, and vehicle registration
+    C: Driver's license, birth certificate, and proof of insurance
+    D: Vehicle registration, proof of insurance, and a smog certificate
+  answer: B
+  explanation: The manual states that the driver of a stopped vehicle must produce
+    a driver's license, proof of insurance, and vehicle registration when stopped
+    by law enforcement.
+- id: 75
+  category: driver_responsibility
+  question: If a California state or local law enforcement officer asks about your
+    immigration status during a traffic stop, what should you know?
+  choices:
+    A: You are legally required to answer the question truthfully.
+    B: State and local officers are required by law to ask this question.
+    C: California law prohibits state and local officers from asking drivers or passengers
+      about their immigration status.
+    D: Only state officers can ask this question, while local officers cannot.
+  answer: C
+  explanation: In California, only federal law enforcement officers can ask about
+    immigration status. California law prohibits state and local officers from asking
+    drivers or passengers about their immigration status.
+- id: 76
+  category: driver_responsibility
+  question: 'During a traffic stop, if an officer tells you and your passengers to
+    exit the vehicle, you must:'
+  choices:
+    A: Refuse to exit unless the officer has a search warrant.
+    B: Exit the vehicle as instructed.
+    C: Ask for a supervisor to arrive before exiting the vehicle.
+    D: Exit the vehicle yourself but tell your passengers to stay inside.
+  answer: B
+  explanation: During a traffic stop, an officer can legally require the driver and
+    all passengers to exit or stay inside the vehicle. If you are told to exit the
+    vehicle or stay inside, you must do so.
+- id: 77
+  category: safe_driving_rules
+  question: Under what conditions can you make a right turn at a solid red traffic
+    signal light?
+  choices:
+    A: You may turn right immediately without stopping if the intersection is clear.
+    B: You may never turn right on a solid red light.
+    C: You may turn right if there is no 'NO TURN ON RED' sign, after you stop at
+      the limit line and yield to pedestrians.
+    D: You may turn right only if a green arrow is also illuminated.
+  answer: C
+  explanation: A red traffic signal light means STOP. You can turn right at a red
+    light if there is not a NO TURN ON RED sign posted, you stop at the stop or limit
+    line, yield for pedestrians, and turn when it is safe.
+- id: 78
+  category: safe_driving_rules
+  question: 'When approaching a flashing red traffic signal light, you must:'
+  choices:
+    A: Slow down and proceed with caution without stopping.
+    B: Stop, and then you may go when it is safe.
+    C: Yield the right-of-way to all traffic on your right without stopping.
+    D: Wait for the light to turn solid green before proceeding.
+  answer: B
+  explanation: A flashing red signal light means STOP. After stopping, you may go
+    when it is safe.
+- id: 79
+  category: safe_driving_rules
+  question: What should you do if you approach an intersection and the traffic light
+    is not working?
+  choices:
+    A: Proceed through the intersection without stopping if you are on the main road.
+    B: Yield to traffic on your right and proceed cautiously.
+    C: Stop as if the intersection is controlled by STOP signs in all directions.
+    D: Wait at the intersection until law enforcement arrives to direct traffic.
+  answer: C
+  explanation: When a traffic light is not working, stop as if the intersection is
+    controlled by STOP signs in all directions. Then proceed cautiously when it is
+    safe to do so.
+- id: 80
+  category: safe_driving_rules
+  question: What does a flashing yellow traffic signal light indicate?
+  choices:
+    A: You must stop and wait for a green light.
+    B: The light is about to turn red, so you should speed up.
+    C: It is a warning to proceed with caution; you do not need to stop.
+    D: You have a protected turn in the direction you are traveling.
+  answer: C
+  explanation: A flashing yellow traffic signal light is a warning to PROCEED WITH
+    CAUTION. Slow down and be alert. You do not need to stop.
+- id: 81
+  category: safe_driving_rules
+  question: 'If a traffic signal is displaying a flashing yellow arrow, it means:'
+  choices:
+    A: Your turn is protected from other traffic.
+    B: You must stop and wait for a solid green arrow.
+    C: You can turn, but your turn is not protected, so you must yield to oncoming
+      traffic.
+    D: The intersection is completely closed to turning vehicles.
+  answer: C
+  explanation: A flashing yellow arrow means you can turn, but your turn is not protected
+    from other traffic. Proceed to turn left after yielding to oncoming traffic and
+    proceed with caution.
+- id: 82
+  category: safe_driving_rules
+  question: 'When you see a solid green traffic signal light, you should:'
+  choices:
+    A: Enter the intersection immediately without checking for cross traffic.
+    B: Go, but only proceed if you have enough space without creating a danger to
+      any oncoming vehicle, bicyclist, or pedestrian.
+    C: Come to a complete stop first, then proceed through the intersection.
+    D: Speed up to ensure you clear the intersection before the light turns yellow.
+  answer: B
+  explanation: A green traffic signal light means GO. However, you should still stop
+    for any vehicle, bicyclist, or pedestrian in the intersection and only proceed
+    if you have enough space without creating a danger.
+- id: 83
+  category: sharing_the_road
+  question: What does a flashing 'DON'T WALK' or flashing raised hand pedestrian signal
+    mean?
+  choices:
+    A: Pedestrians should start crossing the street immediately.
+    B: Pedestrians may not start crossing the street because the traffic signal is
+      about to change.
+    C: Drivers can proceed through the crosswalk without yielding to pedestrians.
+    D: The pedestrian push button is broken and needs repair.
+  answer: B
+  explanation: A Flashing DON'T WALK or Flashing Raised Hand means do not start crossing
+    the street. The traffic signal light is about to change.
+- id: 84
+  category: driver_responsibility
+  question: 'If you choose to record an interaction with law enforcement during a
+    traffic stop, you should:'
+  choices:
+    A: Hide your recording device so the officer does not see it.
+    B: Reach into a concealed area to retrieve your device without asking the officer.
+    C: Immediately make it clear that you are recording.
+    D: Refuse to provide your driver's license until the recording is finished.
+  answer: C
+  explanation: If you are recording, you should immediately make that clear. You should
+    not reach into concealed areas to retrieve your recording device without the officer's
+    permission.
+- id: 85
+  category: signs_and_signals
+  question: What must you do when approaching a red YIELD sign?
+  choices:
+    A: Come to a complete stop every time, regardless of traffic.
+    B: Slow down and be ready to stop to let any vehicle, bicyclist, or pedestrian
+      pass before you proceed.
+    C: Maintain your speed and merge smoothly with traffic.
+    D: Stop only if there is a marked crosswalk present.
+  answer: B
+  explanation: A Red YIELD Sign means you must slow down and be ready to stop to let
+    any vehicle, bicyclist, or pedestrian pass before you proceed.
+- id: 86
+  category: signs_and_signals
+  question: What does a red arrow traffic signal mean?
+  choices:
+    A: Stop, then you may turn cautiously in the direction of the arrow.
+    B: Stop, and do not turn until a green traffic signal light or green arrow appears.
+    C: Yield to oncoming traffic before making your turn.
+    D: The protected turning time is ending, so complete your turn quickly.
+  answer: B
+  explanation: A red arrow means STOP. Do not turn at a red arrow. Remain stopped
+    until a green traffic signal light or green arrow appears.
+- id: 87
+  category: vehicle_information
+  question: Which of the following transactions can be completed at a DMV Kiosk?
+  choices:
+    A: Taking a written driver's knowledge test.
+    B: Submitting proof of insurance and completing a vehicle registration renewal.
+    C: Applying for a first-time California driver's license.
+    D: Paying a traffic ticket citation.
+  answer: B
+  explanation: DMV Kiosks offer transactions such as completing vehicle registration
+    renewal, receiving a replacement registration card/sticker, submitting proof of
+    insurance, filing for PNO status, and obtaining driver/vehicle records.
+- id: 88
+  category: driver_responsibility
+  question: 'Before beginning any questioning related to a criminal investigation
+    or traffic violation, a law enforcement officer must:'
+  choices:
+    A: Ask for your permission to search your vehicle.
+    B: State the reason for the traffic or pedestrian stop, unless there is an imminent
+      threat.
+    C: Check your immigration status.
+    D: Confiscate your cellular phone.
+  answer: B
+  explanation: Law enforcement officers must state the reason for a traffic or pedestrian
+    stop before they begin any questioning related to a criminal investigation or
+    traffic violation, unless they reasonably believe withholding the reason is necessary
+    to protect life or property from imminent threat.
+- id: 89
+  category: signs_and_signals
+  question: What does a 5-sided traffic sign indicate?
+  choices:
+    A: You are approaching a railroad crossing.
+    B: You are near a school.
+    C: You are going the wrong way.
+    D: You must yield to oncoming traffic.
+  answer: B
+  explanation: According to the manual, a 5-sided sign means you are near a school.
+    You should drive slowly and stop for children in the crosswalk.
+- id: 90
+  category: signs_and_signals
+  question: How can you tell if you are driving the wrong way on a roadway at night?
+  choices:
+    A: The road reflectors will shine red in your headlights.
+    B: The streetlights will flash yellow.
+    C: The painted lines will appear solid white.
+    D: The road reflectors will shine bright white.
+  answer: A
+  explanation: The manual states that if you are driving at night, you will know you
+    are going the wrong way if the road reflectors shine red in your headlights.
+- id: 91
+  category: safe_driving_rules
+  question: Who has the right-of-way at a T-intersection without STOP or YIELD signs?
+  choices:
+    A: The vehicle on the road that ends.
+    B: Vehicles, bicyclists, and pedestrians on the through road.
+    C: The vehicle that is turning left.
+    D: Whichever vehicle is traveling at a higher speed.
+  answer: B
+  explanation: At T-intersections without STOP or YIELD signs, vehicles, bicyclists,
+    and pedestrians on the through road (continuing to go straight) have the right-of-way.
+- id: 92
+  category: safe_driving_rules
+  question: If you and another vehicle arrive at an intersection without STOP or YIELD
+    signs at the same time, who has the right-of-way?
+  choices:
+    A: The vehicle on the left.
+    B: The vehicle on the right.
+    C: The vehicle traveling straight.
+    D: The vehicle making a turn.
+  answer: B
+  explanation: If a vehicle, pedestrian, or bicyclist gets to an uncontrolled intersection
+    at the same time as you, you must give the right-of-way to the vehicle, pedestrian,
+    or bicyclist on your right.
+- id: 93
+  category: safe_driving_rules
+  question: In which direction does traffic travel in a roundabout?
+  choices:
+    A: Clockwise.
+    B: Counterclockwise.
+    C: In a figure-eight pattern.
+    D: In the direction of the largest gap in traffic.
+  answer: B
+  explanation: When using a roundabout, you must travel in a counterclockwise direction
+    and do not stop or pass.
+- id: 94
+  category: defensive_driving
+  question: Why should you never pass a vehicle stopped at a crosswalk?
+  choices:
+    A: The stopped vehicle may suddenly back up.
+    B: You may not be able to see a pedestrian crossing the street.
+    C: It is illegal to change lanes within 100 feet of an intersection.
+    D: The stopped vehicle has the right-of-way to proceed first.
+  answer: B
+  explanation: You should not pass a vehicle stopped at a crosswalk because you may
+    not be able to see a pedestrian crossing the street.
+- id: 95
+  category: sharing_the_road
+  question: What does it usually mean when a blind pedestrian pulls in their cane
+    and steps away from the intersection?
+  choices:
+    A: They need assistance crossing the street.
+    B: They are waiting for the traffic light to change.
+    C: You may go.
+    D: You must honk your horn to acknowledge them.
+  answer: C
+  explanation: When a blind person pulls in their cane and steps away from the intersection,
+    this gesture usually means you may go.
+- id: 96
+  category: safe_driving_rules
+  question: If two vehicles meet on a steep, narrow mountain road and neither can
+    pass, which vehicle has the right-of-way?
+  choices:
+    A: The vehicle facing downhill.
+    B: The vehicle facing uphill.
+    C: The larger of the two vehicles.
+    D: The vehicle that arrived last.
+  answer: B
+  explanation: If two vehicles meet on a steep narrow road and neither can pass, the
+    vehicle facing uphill has the right-of-way because the vehicle facing downhill
+    has more control when backing up the hill.
+- id: 97
+  category: sharing_the_road
+  question: Approximately how long does it take a large vehicle traveling at 55 mph
+    to stop?
+  choices:
+    A: 200 feet
+    B: 300 feet
+    C: 400 feet
+    D: 500 feet
+  answer: C
+  explanation: According to the manual, a large vehicle traveling at 55 mph can take
+    up to 400 feet to stop, compared to 300 feet for an average passenger vehicle.
+- id: 98
+  category: sharing_the_road
+  question: Why do large vehicles and truck drivers often swing wide to complete a
+    turn?
+  choices:
+    A: Their steering wheels have a limited turning radius.
+    B: The rear wheels follow a shorter path than the front wheels.
+    C: They need to check their blind spots before turning.
+    D: To prevent smaller vehicles from passing them on the inside.
+  answer: B
+  explanation: When a vehicle turns, the rear wheels follow a shorter path than the
+    front wheels. The longer the vehicle, the greater the difference, which is why
+    large vehicles must often swing wide to complete a turn.
+- id: 99
+  category: sharing_the_road
+  question: When driving near large vehicles and trucks, on which side should you
+    pass them?
+  choices:
+    A: Always pass on the right side.
+    B: Always pass on the left side.
+    C: Pass on whichever side has a wider shoulder.
+    D: Pass on the side with the smallest blind spot.
+  answer: B
+  explanation: The manual states that you should always pass a large vehicle on the
+    left side and move ahead of it after passing.
+- id: 100
+  category: sharing_the_road
+  question: What is the maximum speed you may pass a bus, streetcar, or trolley that
+    is stopped at a safety zone or traffic light?
+  choices:
+    A: 5 mph
+    B: 10 mph
+    C: 15 mph
+    D: 20 mph
+  answer: B
+  explanation: When a bus, streetcar, or trolley is stopped at a safety zone or traffic
+    light, you may pass at no more than 10 mph.
+- id: 101
+  category: signs_and_signals
+  question: What is the purpose of a diamond-shaped traffic sign?
+  choices:
+    A: To communicate important rules you must obey.
+    B: To indicate a railroad crossing ahead.
+    C: To warn you of specific road conditions and dangers ahead.
+    D: To mark a school zone.
+  answer: C
+  explanation: A diamond-shaped sign warns you of specific road conditions and dangers
+    ahead.
+- id: 102
+  category: safe_driving_rules
+  question: When is it legal to stop and block an intersection?
+  choices:
+    A: When you are turning left on a green light.
+    B: When traffic is backed up and you are following the vehicle ahead.
+    C: When yielding to a pedestrian in an unmarked crosswalk.
+    D: It is never legal; it is against the law to stop or block an intersection if
+      there is not enough space to completely cross.
+  answer: D
+  explanation: It is against the law to stop or block an intersection where there
+    is not enough space to completely cross before the traffic signal light turns
+    red.
+- id: 103
+  category: sharing_the_road
+  question: What does it indicate if a pedestrian makes eye contact with you while
+    you are driving?
+  choices:
+    A: They are admiring your vehicle.
+    B: They are ready to cross the street and you should yield.
+    C: They are waiting for you to pass before crossing.
+    D: They are signaling that you have the right-of-way.
+  answer: B
+  explanation: If a pedestrian makes eye contact with you, they are ready to cross
+    the street, and you should yield to them.
+- id: 104
+  category: sharing_the_road
+  question: Under which of the following conditions is it legal to overtake and pass
+    a light rail vehicle or streetcar on the left side?
+  choices:
+    A: When you are driving in a residential district.
+    B: When you are on a one-way street.
+    C: When the streetcar is traveling at less than 15 mph.
+    D: When there are no pedestrians present in the crosswalk.
+  answer: B
+  explanation: The manual states you must not overtake and pass a light rail vehicle
+    or streetcar on the left side unless you are on a one-way street, the tracks are
+    too close to the right side, or a traffic officer directs you to do so.
+- id: 105
+  category: sharing_the_road
+  question: What is the recommended following distance when driving behind a motorcyclist?
+  choices:
+    A: One-second
+    B: Two-second
+    C: Three-second
+    D: Four-second
+  answer: C
+  explanation: To safely share the road with motorcyclists, the manual advises allowing
+    a safe three-second following distance to avoid hitting them if they brake suddenly
+    or fall.
+- id: 106
+  category: safe_driving_rules
+  question: What should you do if you are in an intersection when you see an emergency
+    vehicle using a siren and red lights?
+  choices:
+    A: Stop immediately in the middle of the intersection.
+    B: Reverse out of the intersection to clear the way.
+    C: Continue through the intersection, then drive to the right and stop.
+    D: Pull over to the left side of the intersection and stop.
+  answer: C
+  explanation: If you are in an intersection when you see an emergency vehicle, you
+    should continue through the intersection, then drive to the right as soon as it
+    is safe and stop.
+- id: 107
+  category: safe_driving_rules
+  question: It is against the law to follow within how many feet of an emergency vehicle
+    when its siren or flashing lights are on?
+  choices:
+    A: 100 feet
+    B: 200 feet
+    C: 300 feet
+    D: 500 feet
+  answer: C
+  explanation: It is against the law to follow within 300 feet of any fire engine,
+    law enforcement vehicle, ambulance, or other emergency vehicle when their siren
+    or flashing lights are on.
+- id: 108
+  category: signs_and_signals
+  question: What type of marking is found on the back of some slow-moving vehicles,
+    such as road maintenance vehicles?
+  choices:
+    A: A yellow and black diamond
+    B: An orange and red triangle
+    C: A white and black rectangle
+    D: A red and white octagon
+  answer: B
+  explanation: Some slow-moving vehicles have an orange and red triangle on their
+    back, which usually indicates they travel at 25 mph or less.
+- id: 109
+  category: safe_driving_rules
+  question: 'Neighborhood Electric Vehicles (NEVs) and Low-speed Vehicles (LSVs) are
+    restricted from operating on roads where the speed limit is greater than:'
+  choices:
+    A: 25 mph
+    B: 35 mph
+    C: 45 mph
+    D: 55 mph
+  answer: B
+  explanation: NEVs and LSVs reach a maximum speed of 25 mph and are restricted from
+    roads where the speed limit is greater than 35 mph.
+- id: 110
+  category: sharing_the_road
+  question: At what age is a bicyclist required by law to wear a helmet?
+  choices:
+    A: Under 16 years old
+    B: Under 18 years old
+    C: Under 21 years old
+    D: All bicyclists must wear a helmet regardless of age
+  answer: B
+  explanation: As a bicyclist, you must wear a helmet if you are under 18 years old.
+- id: 111
+  category: vehicle_information
+  question: When bicycling at night, a bicycle must be equipped with a front lamp
+    featuring a white light visible from what distance?
+  choices:
+    A: 100 feet
+    B: 200 feet
+    C: 300 feet
+    D: 500 feet
+  answer: C
+  explanation: When it is dark out, a bicycle must have a front lamp with a white
+    light visible from 300 feet.
+- id: 112
+  category: sharing_the_road
+  question: When you cannot change lanes to pass a bicyclist, what is the minimum
+    distance you must allow between your vehicle and the bicyclist?
+  choices:
+    A: One foot
+    B: Two feet
+    C: Three feet
+    D: Four feet
+  answer: C
+  explanation: If you cannot change lanes to pass a bicyclist, you must allow at least
+    three feet between your vehicle and the bicyclist. If you cannot give three feet
+    of space, do not pass.
+- id: 113
+  category: safe_driving_rules
+  question: When preparing to make a turn, what is the maximum distance before the
+    turn that you may enter a bike lane?
+  choices:
+    A: 50 feet
+    B: 100 feet
+    C: 200 feet
+    D: 300 feet
+  answer: C
+  explanation: You should enter a bike lane no more than 200 feet before starting
+    a turn.
+- id: 114
+  category: penalties_and_points
+  question: 'Fines for traffic violations in a work zone can be:'
+  choices:
+    A: $250 or more
+    B: $500 or more
+    C: $750 or more
+    D: $1,000 or more
+  answer: D
+  explanation: Fines for traffic violations in a work zone can be $1,000 or more.
+- id: 115
+  category: penalties_and_points
+  question: What is the penalty for anyone convicted of assaulting a highway worker?
+  choices:
+    A: Fines up to $500 and up to 30 days imprisonment
+    B: Fines up to $1,000 and up to 6 months imprisonment
+    C: Fines up to $2,000 and imprisonment for up to one year
+    D: Fines up to $5,000 and imprisonment for up to two years
+  answer: C
+  explanation: Anyone convicted of assaulting a highway worker faces fines of up to
+    $2,000 and imprisonment for up to one year.
+- id: 116
+  category: sharing_the_road
+  question: Where may a bicyclist ride on a one-way road with two or more lanes?
+  choices:
+    A: They must always ride as close to the right curb as possible.
+    B: They may ride near the left curb or edge of the road.
+    C: They must ride in the exact center of the left lane.
+    D: Bicycles are not permitted on one-way roads.
+  answer: B
+  explanation: On a one-way road with two or more lanes, a bicyclist may ride near
+    the left curb or edge of the road.
+- id: 117
+  category: defensive_driving
+  question: Under what conditions may you drive through a safety zone set aside for
+    pedestrians?
+  choices:
+    A: When no pedestrians are present.
+    B: When you are traveling at 10 mph or less.
+    C: When yielding the right-of-way to a streetcar.
+    D: Under no condition.
+  answer: D
+  explanation: 'Safety zones are spaces set aside for pedestrians. The manual explicitly
+    states: ''Do not drive through a safety zone under any condition.'''
+- id: 118
+  category: penalties_and_points
+  question: What happens to traffic fines in highway construction or maintenance zones
+    when workers are present?
+  choices:
+    A: They are reduced by half.
+    B: They remain the same as normal zones.
+    C: They are doubled.
+    D: They are tripled.
+  answer: C
+  explanation: According to the manual, fines are doubled in highway construction
+    or maintenance zones when workers are present.
+- id: 119
+  category: sharing_the_road
+  question: If you are towing a trailer on a highway with four lanes in your direction
+    and no lanes are marked for slower vehicles, which lanes may you drive in?
+  choices:
+    A: Any of the four lanes.
+    B: Only the far-left lane.
+    C: The two lanes closest to the right edge of the road.
+    D: The two lanes closest to the left edge of the road.
+  answer: C
+  explanation: If no lanes are marked and there are four or more lanes in your direction,
+    a vehicle towing a trailer or a truck with three or more axles may only drive
+    in the two lanes closest to the right edge of the road.
+- id: 120
+  category: safe_driving_rules
+  question: When must you stop for a school bus with flashing red lights?
+  choices:
+    A: Only if you are traveling in the same direction as the bus.
+    B: From either direction, unless the bus is on the other side of a divided or
+      multilane highway.
+    C: Only if children are actively crossing in front of your vehicle.
+    D: You are never required to stop, but you must slow down to 15 mph.
+  answer: B
+  explanation: When a school bus flashes red lights, you must stop from either direction
+    until the children are safely across. However, if the bus is on the other side
+    of a divided or multilane highway (two or more lanes in each direction), you do
+    not need to stop.
+- id: 121
+  category: safe_driving_rules
+  question: What is the speed limit for a blind intersection?
   choices:
     A: 10 mph
     B: 15 mph
     C: 20 mph
     D: 25 mph
   answer: B
-  explanation: The speed limit for a blind intersection is 15 mph. An intersection
-    is considered 'blind' if there are no stop signs at any corner and you cannot
-    see for 100 feet in either direction during the last 100 feet before crossing.
-- id: 18
+  explanation: An intersection is considered blind if it has no stop signs at any
+    corner and your view is blocked. The speed limit for a blind intersection is 15
+    mph.
+- id: 122
   category: safe_driving_rules
-  question: What is the maximum speed limit in most business or residential districts
-    in California?
+  question: What is the speed limit within 100 feet of a railroad crossing if you
+    cannot see the tracks for 400 feet in both directions and the crossing is not
+    controlled by gates or a signal?
   choices:
-    A: 25 mph
+    A: 10 mph
+    B: 15 mph
+    C: 20 mph
+    D: 25 mph
+  answer: B
+  explanation: The speed limit is 15 mph within 100 feet of a railroad crossing if
+    you cannot see the tracks for 400 feet in both directions, unless the crossing
+    is controlled by gates, a warning signal, or a flagman.
+- id: 123
+  category: vehicle_information
+  question: If cargo extends more than 4 feet from the back-rear bumper of your vehicle
+    during the day, what must be displayed on it?
+  choices:
+    A: Two red lights
+    B: A 12-inch red or fluorescent orange square flag
+    C: A white flashing strobe light
+    D: A yellow diamond-shaped sign
+  answer: B
+  explanation: Cargo that extends more than 4 feet from the back-rear bumper of the
+    vehicle must display a 12-inch red or fluorescent orange square flag. At night,
+    this cargo must be marked with two red lights.
+- id: 124
+  category: penalties_and_points
+  question: What is the penalty for a person convicted of manslaughter resulting from
+    evading law enforcement during a pursuit?
+  choices:
+    A: Imprisonment in a county jail for one year or less
+    B: A maximum fine of $1,000 and a 30-day vehicle impoundment
+    C: Imprisonment in a state prison for a minimum of 4 to 10 years
+    D: A mandatory traffic violator school course
+  answer: C
+  explanation: A person convicted of manslaughter resulting from evading law enforcement
+    during a pursuit is subject to imprisonment in a state prison for a minimum of
+    4 to 10 years.
+- id: 125
+  category: penalties_and_points
+  question: As an adult, your driver's license may be suspended if your driver's record
+    shows which of the following point totals?
+  choices:
+    A: 2 points in 12 months
+    B: 3 points in 24 months
+    C: 4 points in 12 months
+    D: 5 points in 36 months
+  answer: C
+  explanation: As an adult, your license may be suspended if your driver's record
+    shows 4 points in 12 months, 6 points in 24 months, or 8 points in 36 months.
+- id: 126
+  category: driver_responsibility
+  question: How often can you attend a traffic violator school to have a one-point
+    traffic violation not reported to your insurance company?
+  choices:
+    A: Once in any 12-month period
+    B: Once in any 18-month period
+    C: Once in any 24-month period
+    D: Once in any 36-month period
+  answer: B
+  explanation: If you are given a one-point traffic violation, you can choose to attend
+    a traffic violator school to have the citation not reported to your insurance
+    company once in any 18-month period.
+- id: 127
+  category: safe_driving_rules
+  question: What is the speed limit in an alley?
+  choices:
+    A: 10 mph
+    B: 15 mph
+    C: 20 mph
+    D: 25 mph
+  answer: B
+  explanation: An alley is any road no wider than 25 feet used to access the rear
+    or side entrances of buildings or properties. The speed limit in an alley is 15
+    mph.
+- id: 128
+  category: driver_responsibility
+  question: What may happen if an unlicensed person is caught driving your vehicle?
+  choices:
+    A: The vehicle may be impounded for 30 days.
+    B: The vehicle will be permanently confiscated.
+    C: You will receive 2 points on your driver's record.
+    D: Your license will be automatically revoked for one year.
+  answer: A
+  explanation: According to the manual, if an unlicensed person is caught driving
+    your vehicle, it may be impounded for 30 days.
+- id: 129
+  category: vehicle_information
+  question: Where are you legally permitted to affix a 5-inch square electronic toll
+    payment device on your windshield?
+  choices:
+    A: In the center uppermost portion of the windshield
+    B: In the center of the driver's line of sight
+    C: On the upper corner of the passenger's side windshield
+    D: Anywhere on the windshield as long as it is transparent
+  answer: A
+  explanation: Objects may only be affixed in specific locations, including a 5-inch
+    square located in the center uppermost portion of your windshield for an electronic
+    toll payment device.
+- id: 130
+  category: sharing_the_road
+  question: Which of the following statements is true regarding funeral processions?
+  choices:
+    A: You may briefly interrupt a funeral procession if you are in a hurry.
+    B: Vehicles in a funeral procession must drive with their headlights off.
+    C: A funeral procession is led by a traffic officer and has the right-of-way.
+    D: Funeral processions must yield the right-of-way to all other civilian traffic.
+  answer: C
+  explanation: A funeral procession is led by a traffic officer and has the right-of-way.
+    All vehicles taking part have windshield markers and headlights on. You can be
+    ticketed if you interrupt a funeral procession.
+- id: 131
+  category: driver_responsibility
+  question: What is the rule regarding smoking in a vehicle when a minor is present?
+  choices:
+    A: It is allowed if the windows are rolled down.
+    B: It is allowed only if the minor is in the back seat.
+    C: It is not allowed, and you can be fined.
+    D: It is allowed if the vehicle is parked.
+  answer: C
+  explanation: The manual states that you must not smoke when a minor is in the vehicle,
+    and you can be fined for doing so.
+- id: 132
+  category: safe_driving_rules
+  question: What is the speed limit in a business or residential district unless otherwise
+    posted?
+  choices:
+    A: 15 mph
+    B: 25 mph
+    C: 30 mph
+    D: 35 mph
+  answer: B
+  explanation: The speed limit in business or residential districts is 25 mph, unless
+    otherwise posted.
+- id: 133
+  category: penalties_and_points
+  question: What is the penalty if a minor receives two at-fault collisions or traffic
+    violation convictions within their first 12 months of driving?
+  choices:
+    A: Their license is permanently revoked.
+    B: They cannot drive for 30 days unless accompanied by a licensed adult at least
+      25 years old.
+    C: Their driving privilege is suspended for six months.
+    D: They must retake the written and driving tests.
+  answer: B
+  explanation: According to the manual, if a minor has two at-fault collisions, two
+    traffic violation convictions, or one of each, they cannot drive for 30 days unless
+    a licensed adult, at least 25 years old, rides with them.
+- id: 134
+  category: penalties_and_points
+  question: If a minor has three at-fault collisions or traffic violation convictions,
+    what action will the DMV take?
+  choices:
+    A: Suspend the driving privilege for six months and place them on probation for
+      one year.
+    B: Suspend the driving privilege for 30 days.
+    C: Revoke the driving privilege until they turn 18.
+    D: Require them to install an ignition interlock device.
+  answer: A
+  explanation: The manual states that for three at-fault collisions or traffic violation
+    convictions, a minor's driving privilege will be suspended for six months and
+    they will be on probation for one year.
+- id: 135
+  category: driver_responsibility
+  question: How many days do you have to request an administrative hearing from the
+    date a notice of proposed action against your driving privilege is mailed?
+  choices:
+    A: 10 days
+    B: 14 days
+    C: 30 days
+    D: 60 days
+  answer: B
+  explanation: You must request a hearing within 10 days of being served or 14 days
+    from the date the notice is mailed. If you do not make a timely request, your
+    right to a hearing will be lost.
+- id: 136
+  category: license_system
+  question: Which of the following pieces of information in your driver's record is
+    kept confidential and is NOT available to the public?
+  choices:
+    A: Traffic violation convictions
+    B: License suspension history
+    C: Physical or mental conditions
+    D: At-fault collisions
+  answer: C
+  explanation: Most information in your driver's record is available to the public,
+    except physical or mental conditions, address, and social security number.
+- id: 137
+  category: safe_driving_rules
+  question: To give yourself time to react and avoid last-minute moves, how far ahead
+    should you scan the road?
+  choices:
+    A: At least 5 seconds ahead
+    B: At least 10 seconds ahead
+    C: At least 15 seconds ahead
+    D: At least 20 seconds ahead
+  answer: B
+  explanation: To give yourself time to react, avoid last minute moves and hazards,
+    always keep your eyes moving and scan the road at least 10 seconds ahead of your
+    vehicle.
+- id: 138
+  category: defensive_driving
+  question: What should you do if another vehicle merges in front of you too closely?
+  choices:
+    A: Honk your horn and flash your high beams.
+    B: Brake hard to create immediate space.
+    C: Take your foot off the accelerator.
+    D: Swerve into the adjacent lane.
+  answer: C
+  explanation: If a vehicle merges in front of you too closely, take your foot off
+    the accelerator. This creates space between you and the vehicle ahead.
+- id: 139
+  category: sharing_the_road
+  question: 'When following a motorcyclist on a metal surface like a bridge grating,
+    you should:'
+  choices:
+    A: Create more space in front of your vehicle.
+    B: Honk to let them know you are behind them.
+    C: Pass them immediately.
+    D: Turn on your high-beam headlights.
+  answer: A
+  explanation: You should create more space in front of your vehicle when following
+    motorcyclists on metal surfaces (bridge gratings, railroad tracks, etc.), and
+    gravel.
+- id: 140
+  category: safe_driving_rules
+  question: What is the proper way to check your blind spots before changing lanes?
+  choices:
+    A: Look into your rearview mirror only.
+    B: Turn your whole body to look out the back window.
+    C: Look over your right and left shoulders out of your side windows.
+    D: Rely solely on your side mirrors.
+  answer: C
+  explanation: To check your blind spots, look over your right and left shoulders
+    out of your side windows. Only turn your head when you look; do not turn your
+    whole body or steering wheel.
+- id: 141
+  category: safe_driving_rules
+  question: If an oncoming vehicle's lights are too bright at night, where should
+    you look?
+  choices:
+    A: Directly into the oncoming headlights.
+    B: Toward the right edge of your lane.
+    C: Toward the center line of the road.
+    D: Down at your dashboard.
+  answer: B
+  explanation: If another vehicle's lights are too bright, do not look directly into
+    the oncoming headlights. Instead, look toward the right edge of your lane.
+- id: 142
+  category: safe_driving_rules
+  question: When it is raining, which lights are you required to use while driving?
+  choices:
+    A: High-beam headlights
+    B: Low-beam headlights
+    C: Only your parking lights
+    D: Hazard lights
+  answer: B
+  explanation: When it is raining, use your low-beam headlights. Do not drive using
+    only your parking lights.
+- id: 143
+  category: defensive_driving
+  question: 'If a vehicle with only one light is driving toward you at night, you
+    should:'
+  choices:
+    A: Flash your high beams to warn them.
+    B: Drive as far to the left as possible.
+    C: Drive as far to the right as possible.
+    D: Stop your vehicle in the lane.
+  answer: C
+  explanation: When a vehicle with one light drives toward you, drive as far to the
+    right as possible. It could be a bicyclist, motorcyclist, or vehicle with a missing
+    headlight.
+- id: 144
+  category: vehicle_information
+  question: What should you do before going down a steep hill to help prevent skidding
+    on slippery surfaces?
+  choices:
+    A: Shift to a higher gear.
+    B: Shift to a low gear.
+    C: Ride the brakes all the way down.
+    D: Put the vehicle in neutral.
+  answer: B
+  explanation: To prevent skidding on slippery surfaces, you should shift to low gear
+    before going down a steep hill.
+- id: 145
+  category: defensive_driving
+  question: If your vehicle starts to skid on a slippery surface, which of the following
+    is the correct action to take?
+  choices:
+    A: Slam on the brakes immediately.
+    B: Turn the steering wheel in the opposite direction of the skid.
+    C: Slowly remove your foot from the accelerator and do not use the brakes.
+    D: Accelerate quickly to regain traction.
+  answer: C
+  explanation: If you start to skid, you should slowly remove your foot from the accelerator,
+    do not use the brakes, and turn the steering wheel in the direction of the skid.
+- id: 146
+  category: vehicle_information
+  question: How should you recover from a locked wheel skid if your vehicle is equipped
+    with a four-wheel antilock braking system (ABS)?
+  choices:
+    A: Pump the brake pedal rapidly.
+    B: Apply firm pressure on the brake pedal.
+    C: Pull the emergency brake.
+    D: Turn off the ignition.
+  answer: B
+  explanation: To get out of a locked wheel skid if your vehicle is equipped with
+    a four-wheel antilock braking system (ABS), apply firm pressure on the brake pedal.
+- id: 147
+  category: penalties_and_points
+  question: What happens to existing restrictions, suspensions, or probation sentences
+    on a minor's driver's license when they turn 18 years old?
+  choices:
+    A: They are immediately erased.
+    B: They are reduced by half.
+    C: They do not erase or end.
+    D: They are converted to a fine.
+  answer: C
+  explanation: 'The manual notes: Turning 18 years old does not erase or end existing
+    restrictions, suspensions, or probation sentences.'
+- id: 148
+  category: vehicle_information
+  question: How can you dry your brakes if they get wet while driving?
+  choices:
+    A: Pump the brake pedal rapidly for one minute.
+    B: Lightly press the accelerator and brake pedals at the same time.
+    C: Shift into a lower gear and coast to a stop.
+    D: Apply the emergency brake while driving at a low speed.
+  answer: B
+  explanation: According to the manual, if your brakes get wet, you can dry them by
+    lightly pressing the accelerator and brake pedals at the same time until the brakes
+    dry.
+- id: 149
+  category: safe_driving_rules
+  question: How much should you reduce your speed when driving on a road with packed
+    snow?
+  choices:
+    A: Reduce your speed by 5 to 10 mph.
+    B: Reduce your speed to no more than 5 mph.
+    C: Reduce your speed by half.
+    D: Reduce your speed by 15 mph.
+  answer: C
+  explanation: The manual states that you should adjust your speed for different conditions,
+    specifically reducing your speed by half when driving on packed snow.
+- id: 150
+  category: safe_driving_rules
+  question: 'If you cannot see farther than 100 feet in a heavy rainstorm or snowstorm,
+    it is not safe to drive faster than:'
+  choices:
+    A: 20 mph
     B: 30 mph
-    C: 35 mph
-    D: 40 mph
-  answer: A
-  explanation: Unless otherwise posted, the maximum speed limit in most business and
-    residential districts is 25 mph.
-- id: 19
-  category: safe_driving_rules
-  question: How should you turn your wheels when parking uphill next to a curb?
-  choices:
-    A: Turn your wheels toward the curb.
-    B: Turn your wheels away from the curb.
-    C: Keep your wheels perfectly straight.
-    D: Turn your wheels parallel to the street.
+    C: 40 mph
+    D: 50 mph
   answer: B
-  explanation: When parking uphill next to a curb, you should turn your front wheels
-    away from the curb and let your vehicle roll back a few inches until the back
-    of the front wheel gently touches the curb.
-- id: 20
-  category: signs_and_signals
-  question: What does a flashing red traffic signal mean?
-  choices:
-    A: Slow down and yield to traffic.
-    B: Stop, then proceed when it is safe.
-    C: Stop and wait for a green light.
-    D: The traffic signal is broken; proceed with caution.
-  answer: B
-  explanation: A flashing red traffic signal means 'STOP.' After stopping, you may
-    proceed when it is safe, observing the right-of-way rules.
-- id: 21
-  category: signs_and_signals
-  question: What do two sets of solid, double, yellow lines that are two or more feet
-    apart represent?
-  choices:
-    A: A carpool lane.
-    B: A passing zone.
-    C: A solid wall; do not drive on or over them.
-    D: A shared center turn lane.
-  answer: C
-  explanation: Two sets of solid, double, yellow lines that are two or more feet apart
-    are considered a barrier. Do not drive on or over this barrier, make a left turn,
-    or a U-turn across it.
-- id: 22
-  category: sharing_the_road
-  question: Who has the right-of-way at a crosswalk?
-  choices:
-    A: Vehicles have the right-of-way if the pedestrian is jaywalking.
-    B: Pedestrians always have the right-of-way in marked or unmarked crosswalks.
-    C: Vehicles have the right-of-way if the crosswalk is unmarked.
-    D: Bicycles have the right-of-way over pedestrians.
-  answer: B
-  explanation: Pedestrians have the right-of-way in marked or unmarked crosswalks.
-    Drivers must yield and reduce their speed or stop if necessary to ensure the pedestrian's
-    safety.
-- id: 23
+  explanation: The manual advises that if you cannot see farther than 100 feet in
+    a heavy rainstorm or snowstorm, it is not safe to drive faster than 30 mph.
+- id: 151
   category: defensive_driving
-  question: What is the recommended minimum following distance under normal driving
-    conditions to avoid a rear-end collision?
+  question: What should you do if your vehicle starts to hydroplane?
   choices:
-    A: 1 second
-    B: 2 seconds
-    C: 3 seconds
-    D: 5 seconds
+    A: Apply the brakes firmly and steer straight.
+    B: Pump the brakes quickly to regain traction.
+    C: Slow down gradually and do not use the brakes.
+    D: Accelerate slightly to push through the water.
   answer: C
-  explanation: To avoid tailgating and rear-end collisions, you should use the '3-second
-    rule' to maintain a safe following distance under normal driving conditions.
-- id: 24
-  category: driver_responsibility
-  question: When must you report a traffic collision to the DMV?
-  choices:
-    A: Only if someone is killed.
-    B: Within 10 days if the damage is over $1,000 or if anyone is injured or killed.
-    C: Within 5 days if the damage is over $500.
-    D: Only if the police do not file a report.
-  answer: B
-  explanation: You (or your insurance agent, broker, or legal representative) must
-    report a collision to the DMV within 10 days if there is more than $1,000 in damage
-    to the property of any person, or if anyone is injured (no matter how slightly)
-    or killed.
-- id: 25
-  category: safe_driving_rules
-  question: When are you required to turn on your vehicle's headlights?
-  choices:
-    A: Only when driving on unlit roads.
-    B: From 30 minutes after sunset until 30 minutes before sunrise.
-    C: From 1 hour after sunset until 1 hour before sunrise.
-    D: Only when you cannot see 500 feet ahead of you.
-  answer: B
-  explanation: You must turn on your headlights 30 minutes after sunset and leave
-    them on until 30 minutes before sunrise, or anytime you cannot clearly recognize
-    a person or vehicle from a distance of 1,000 feet.
-- id: 26
-  category: sharing_the_road
-  question: What should you do when an emergency vehicle with a siren and flashing
-    lights approaches from behind?
-  choices:
-    A: Speed up to stay ahead of the emergency vehicle.
-    B: Stop immediately in your current lane.
-    C: Pull over to the right edge of the road and stop.
-    D: Move to the left lane to let them pass on the right.
-  answer: C
-  explanation: You must yield the right-of-way to any police vehicle, fire engine,
-    ambulance, or other emergency vehicle using a siren and red lights. Drive to the
-    right edge of the road and stop until the emergency vehicle(s) have passed.
-- id: 27
-  category: signs_and_signals
-  question: What does a solid yellow traffic light indicate?
-  choices:
-    A: The light is about to turn green.
-    B: 'CAUTION: The red signal is about to appear.'
-    C: Stop immediately, regardless of your position in the intersection.
-    D: Speed up to clear the intersection quickly.
-  answer: B
-  explanation: A solid yellow traffic signal light means 'CAUTION.' The red traffic
-    signal light is about to appear. When you see the yellow traffic signal light,
-    stop if you can do so safely. If you cannot stop safely, cross the intersection
-    cautiously.
-- id: 28
-  category: driver_responsibility
-  question: When interacting with the DMV Virtual Assistant, what type of information
-    should you avoid including?
-  choices:
-    A: Vehicle make and model
-    B: Personal information
-    C: General driving questions
-    D: Website feedback
-  answer: B
-  explanation: 'The General Disclaimer states: ''When interacting with the Department
-    of Motor Vehicles (DMV) Virtual Assistant, please do not include any personal
-    information.'''
-- id: 29
-  category: license_system
-  question: If a discrepancy arises between the English content and a third-party
-    translation on the DMV website, which version is legally binding?
-  choices:
-    A: The translated version
-    B: Both versions are equally binding
-    C: The English version
-    D: Neither version
-  answer: C
-  explanation: The Third-Party Translation Disclaimer notes that the English content
-    is the official source, and any discrepancies in translation 'are not binding
-    and have no legal effect for compliance or enforcement purposes.'
-- id: 30
+  explanation: If your vehicle starts to hydroplane, the manual instructs you to slow
+    down gradually and not use the brakes, as sudden braking may cause you to lose
+    control of your vehicle.
+- id: 152
   category: vehicle_information
-  question: Which of the following is a service provided under the Vehicle Registration
-    section?
+  question: Which of the following is a recommended step if your vehicle gets stuck
+    in the snow or mud?
   choices:
-    A: Join the mDL Pilot
-    B: Submit Proof of Insurance
-    C: Pay Reinstatement Fee
-    D: Online Testing
+    A: Shift into a high gear and spin the wheels quickly.
+    B: Shift into a low gear and keep the front wheels straight.
+    C: Turn the steering wheel sharply from side to side while accelerating.
+    D: Apply the emergency brake before stepping on the accelerator.
   answer: B
-  explanation: According to the primary navigation menu, 'Submit Proof of Insurance'
-    is listed as a service under Vehicle Registration.
-- id: 31
-  category: license_system
-  question: Under the Driver's Licenses & IDs services, which pilot program are users
-    invited to join?
-  choices:
-    A: The mDL Pilot
-    B: The Virtual Office Pilot
-    C: The Safe Driver Pilot
-    D: The Online Testing Pilot
-  answer: A
-  explanation: The navigation menu for Driver's Licenses & IDs includes an option
-    to 'Join the mDL Pilot.'
-- id: 32
-  category: penalties_and_points
-  question: Which of the following penalty-related fees can be paid through the DMV's
-    online payment system?
-  choices:
-    A: Speeding ticket fines
-    B: Parking citations
-    C: Dishonored Check Payment
-    D: Court administrative fees
-  answer: C
-  explanation: The 'Make a Payment' section explicitly lists 'Dishonored Check Payment'
-    and 'Pay Reinstatement Fee' as online payment options.
-- id: 33
-  category: driver_testing
-  question: Which section of the California Driver's Handbook covers 'The Testing
-    Process'?
-  choices:
-    A: Section 1
-    B: Section 2
-    C: Section 3
-    D: Section 4
-  answer: C
-  explanation: 'The Table of Contents lists ''Section 3: The Testing Process'' in
-    the California Driver''s Handbook.'
-- id: 34
+  explanation: When stuck in snow or mud, the manual recommends shifting into a low
+    gear and keeping the front wheels straight, while gently stepping on the accelerator
+    and avoiding spinning the wheels.
+- id: 153
   category: safe_driving_rules
-  question: According to the California Driver's Handbook table of contents, which
-    section is dedicated to 'Laws and Rules of the Road'?
+  question: Why should you avoid using cruise control when driving in high winds?
   choices:
-    A: Section 5
-    B: Section 6
-    C: Section 7
-    D: Section 8
+    A: It prevents the vehicle from shifting into a lower gear.
+    B: It drains the vehicle's battery faster in windy conditions.
+    C: You need to maintain maximum control of the accelerator if a gust occurs.
+    D: It causes the steering wheel to lock up during sudden gusts.
   answer: C
-  explanation: 'The Table of Contents explicitly lists ''Section 7: Laws and Rules
-    of the Road.'''
-- id: 35
+  explanation: The manual states that you should not use cruise control in high winds
+    so you can maintain maximum control of the accelerator if a gust occurs.
+- id: 154
   category: defensive_driving
-  question: Which section of the California Driver's Handbook introduces the topic
-    of 'Safe Driving'?
+  question: Which lights should you use when driving in heavy fog or smoke?
   choices:
-    A: Section 5
-    B: Section 6
-    C: Section 7
-    D: Section 8
-  answer: D
-  explanation: 'The Table of Contents outlines ''Section 8: Safe Driving'' for the
-    California Driver''s Handbook.'
-- id: 36
-  category: driver_testing
-  question: What resources are available under the DMV's online Testing menu to help
-    prepare for a driver's test?
-  choices:
-    A: Live virtual instructors
-    B: Practice Tests and How-To Videos
-    C: Behind-the-wheel simulators
-    D: Expedited grading services
+    A: High-beam headlights
+    B: Low-beam headlights
+    C: Only your parking lights
+    D: Only your fog lights
   answer: B
-  explanation: The Testing menu includes options for 'Practice Tests,' 'How-To Videos,'
-    'Driver Handbooks,' and 'Specialty Driver Guides.'
-- id: 37
+  explanation: When driving in heavy fog or smoke, you should use your low-beam headlights.
+    High-beam headlights will reflect back and cause glare, and you should never drive
+    using only parking or fog lights.
+- id: 155
+  category: sharing_the_road
+  question: What should you do when a law enforcement officer conducts a traffic break
+    by weaving across lanes with emergency lights on?
+  choices:
+    A: Speed up to pass the patrol vehicle before it blocks your lane.
+    B: Turn on your emergency flashers and slowly decrease your speed.
+    C: Brake suddenly to stop your vehicle as quickly as possible.
+    D: Pull over to the shoulder and wait for the officer to pass.
+  answer: B
+  explanation: During a traffic break, you should turn on your emergency flashers
+    to warn other drivers and slowly decrease your speed to the same speed as the
+    officer.
+- id: 156
   category: driver_responsibility
-  question: What must a user do to activate the DMV Virtual Assistant chatbot?
+  question: Under what circumstance can you get a ticket if your passenger is not
+    wearing a seat belt?
   choices:
-    A: Create a MyDMV account
-    B: Agree to the disclaimers
-    C: Enter their driver's license number
-    D: Pay a convenience fee
+    A: Only if the passenger is riding in the front seat.
+    B: If the passenger is under 16 years old.
+    C: Only if the passenger is under 18 years old.
+    D: You cannot get a ticket for a passenger's failure to wear a seat belt.
   answer: B
-  explanation: The chatbot interface includes an error state that requires users to
-    check a box stating 'I agree' to the disclaimers to activate the Virtual Assistant.
-- id: 38
-  category: license_system
-  question: Which of the following case statuses can be checked online through the
-    DMV portal?
+  explanation: The manual states that you and your passengers must wear seat belts,
+    and you can get a ticket if a passenger under 16 years old is not wearing their
+    seat belt.
+- id: 157
+  category: driver_responsibility
+  question: How should a pregnant woman wear a seat belt?
   choices:
-    A: Traffic court case status
-    B: Driver Safety Case Status
-    C: Vehicle impound status
-    D: Smog check status
+    A: The lap belt should be worn high across the abdomen.
+    B: The lap belt should be worn as low as possible under the abdomen.
+    C: The shoulder strap should be placed behind the back.
+    D: Pregnant women are exempt from wearing the lap belt.
   answer: B
-  explanation: The 'Check Status' menu provides an option to check the 'Driver Safety
-    Case Status' among other services.
-- id: 39
-  category: license_system
-  question: Which section of the California Driver's Handbook covers 'Changing, Replacing,
-    and Renewing Your Driver’s License'?
+  explanation: If you are pregnant, the manual instructs to wear the lap belt as low
+    as possible under your abdomen and place the shoulder strap between your breasts
+    and to the side of your abdomen's bulge.
+- id: 158
+  category: driver_responsibility
+  question: 'A child must be secured in a rear-facing child passenger restraint system
+    if they are:'
   choices:
-    A: Section 1
-    B: Section 2
-    C: Section 3
-    D: Section 4
-  answer: D
-  explanation: 'The Table of Contents lists ''Section 4: Changing, Replacing, and
-    Renewing Your Driver’s License.'''
-- id: 40
-  category: vehicle_information
-  question: If you need to request a record of your vehicle, under which DMV menu
-    should you look?
-  choices:
-    A: Vehicle Registration
-    B: Driver's Licenses & IDs
-    C: Check Status
-    D: Appointments
+    A: Under 2 years old, under 40 pounds, and under 3 feet 4 inches tall.
+    B: Under 4 years old, under 50 pounds, and under 4 feet tall.
+    C: Under 8 years old and less than 4 feet 9 inches tall.
+    D: Under 1 year old and under 20 pounds.
   answer: A
-  explanation: '''Request Vehicle Record'' is listed as a service under the ''Vehicle
-    Registration'' navigation menu.'
-- id: 41
-  category: license_system
-  question: What service allows customers to secure a place at a DMV office without
-    scheduling a traditional appointment?
-  choices:
-    A: Virtual Office
-    B: Get in Line Now
-    C: MyDMV Fast Track
-    D: Online Testing
-  answer: B
-  explanation: Under the 'Appointments' menu, the DMV offers a 'Get in Line Now' service
-    alongside traditional appointment scheduling.
-- id: 42
-  category: license_system
-  question: According to the translation disclaimer, why does the DMV provide machine
-    translation via third-party vendors?
-  choices:
-    A: To replace the English version entirely
-    B: For purposes of information and convenience only
-    C: To provide legally binding documents in all languages
-    D: To collect data on non-English speakers
-  answer: B
-  explanation: 'The disclaimer states: ''Machine translation is provided for purposes
-    of information and convenience only.'''
-- id: 43
+  explanation: The manual requires children who are under 2 years old, under 40 pounds,
+    and under 3 feet 4 inches tall to be secured in a rear-facing child passenger
+    restraint system.
+- id: 159
   category: driver_responsibility
-  question: 'According to the Secretary''s Message in the California Driver''s Handbook,
-    driving or riding on California roads is considered:'
+  question: When is a child under 8 years old permitted to ride in the front seat
+    of a vehicle in a federally-approved child passenger restraint system?
   choices:
-    A: A constitutional right
-    B: A privilege
-    C: A requirement for all adults
-    D: An optional hobby
-  answer: B
-  explanation: The Secretary's Message states, "Remember that driving or riding is
-    a privilege, and above all, safety must be the priority."
-- id: 44
-  category: safe_driving_rules
-  question: What does the Secretary of the California State Transportation Agency
-    advise regarding cell phone use while driving?
-  choices:
-    A: Only use it for navigation
-    B: Put it down when behind the wheel or handlebars
-    C: Use hands-free devices only
-    D: It is acceptable during daylight hours
-  answer: B
-  explanation: The Secretary's Message explicitly advises to "put down that cell phone
-    when behind the wheel or handlebars. Do not operate a vehicle, motorcycle or bicycle
-    while distracted or impaired."
-- id: 45
-  category: license_system
-  question: Where can a Californian start their driver's license application from
-    the comfort of their home?
-  choices:
-    A: By calling the DMV hotline
-    B: By visiting the DMV website at dmv.ca.gov
-    C: Through the Google Translate toolbar
-    D: By emailing the Secretary of Transportation
-  answer: B
-  explanation: The text states, "The driver’s license application can be started from
-    the comfort of home by visiting the DMV website at dmv.ca.gov."
-- id: 46
-  category: driver_testing
-  question: In how many languages is the California Driver's Handbook available?
-  choices:
-    A: '3'
-    B: '5'
-    C: '9'
-    D: '12'
+    A: When the child prefers to sit in the front seat.
+    B: When the driver is the child's parent or legal guardian.
+    C: When all rear seats are already occupied by children 7 years old or younger.
+    D: When the vehicle is traveling at speeds below 30 mph.
   answer: C
-  explanation: The Secretary's Message notes that "The California Driver’s Handbook
-    is available in nine languages..."
-- id: 47
+  explanation: A child under 8 may ride in the front seat in specific cases outlined
+    in the manual, such as when all rear seats are already occupied by children 7
+    years old or younger.
+- id: 160
+  category: safe_driving_rules
+  question: Why can the pavement be very slippery when it first starts to rain after
+    a period of dry and hot weather?
+  choices:
+    A: The heat causes the asphalt to melt and become slick.
+    B: Oil and dust on the road's surface have not yet been washed away.
+    C: The rain mixes with vehicle exhaust to create a slippery film.
+    D: Tire rubber hardens in hot weather, reducing traction.
+  answer: B
+  explanation: The manual notes that pavement can be very slippery at the first sign
+    of rain, especially after dry and hot weather, because oil and dust on the road's
+    surface have not been washed away.
+- id: 161
+  category: defensive_driving
+  question: What should you do immediately after driving through a flooded road?
+  choices:
+    A: Pull over and check your tire pressure.
+    B: Test your brakes to make sure they work correctly.
+    C: Turn on your high-beam headlights to check for debris.
+    D: Shift into neutral and rev the engine to dry it out.
+  answer: B
+  explanation: The manual states that if you have no other option but to drive through
+    a flooded road, you should drive slowly and, after making it through the water,
+    test your brakes to make sure they work correctly.
+- id: 162
+  category: safe_driving_rules
+  question: When is a child permitted to use a properly secured safety belt instead
+    of a child passenger restraint system?
+  choices:
+    A: When they are 6 years old or at least 4 feet tall.
+    B: When they are 7 years old or at least 4 feet 5 inches tall.
+    C: When they are 8 years old or older, or at least 4 feet 9 inches tall.
+    D: When they are 9 years old or at least 5 feet tall.
+  answer: C
+  explanation: According to the manual, children who are 8 years old or older, or
+    at least 4 feet 9 inches tall may use a properly secured safety belt that meets
+    federal standards.
+- id: 163
+  category: vehicle_information
+  question: To maintain safety while driving, how far should you sit from the airbag
+    cover?
+  choices:
+    A: At least 5 inches
+    B: At least 10 inches
+    C: At least 12 inches
+    D: At least 15 inches
+  answer: B
+  explanation: The manual states to ride at least 10 inches from the airbag cover,
+    measured from the center of the steering wheel to your breastbone, as long as
+    you can maintain full control of your vehicle.
+- id: 164
+  category: driver_responsibility
+  question: 'It is illegal to leave a child who is six years old or younger unattended
+    in a vehicle unless they are supervised by a person who is at least:'
+  choices:
+    A: 10 years old
+    B: 12 years old
+    C: 14 years old
+    D: 16 years old
+  answer: B
+  explanation: It is illegal to leave a child who is six years old or younger unattended
+    in a vehicle. However, a child may be left under the supervision of a person who
+    is at least 12 years old.
+- id: 165
+  category: safe_driving_rules
+  question: What does California's Basic Speed Law state?
+  choices:
+    A: You must always drive at the posted speed limit.
+    B: You may never drive faster than is safe for the current road conditions.
+    C: You must drive 5 mph below the speed limit in bad weather.
+    D: You may exceed the speed limit to pass another vehicle safely.
+  answer: B
+  explanation: In California, you may never drive faster than is safe for the current
+    road conditions. This is known as the Basic Speed Law.
+- id: 166
+  category: safe_driving_rules
+  question: Unless otherwise posted, what is the maximum speed limit on a two-lane
+    undivided highway in California?
+  choices:
+    A: 55 mph
+    B: 60 mph
+    C: 65 mph
+    D: 70 mph
+  answer: A
+  explanation: Unless otherwise posted, the ideal maximum speed limit is 55 mph on
+    a two-lane undivided highway and for vehicles towing trailers.
+- id: 167
+  category: defensive_driving
+  question: If you are on a two-lane road with an oncoming vehicle to the left and
+    a bicyclist ahead to your right, what is the safest action?
+  choices:
+    A: Speed up to pass the bicyclist before the vehicle reaches you.
+    B: Drive between the vehicle and the bicyclist.
+    C: Honk your horn so the bicyclist moves off the road.
+    D: Slow down and let the oncoming vehicle pass before moving left to pass the
+      bicyclist.
+  answer: D
+  explanation: Instead of driving between the vehicle and the bicyclist, take one
+    danger at a time. Slow down and let the oncoming vehicle pass, then move to the
+    left to allow plenty of space to pass the bicyclist.
+- id: 168
+  category: defensive_driving
+  question: What is a recommended step to take if you experience a tire blowout while
+    driving?
+  choices:
+    A: Brake suddenly to stop the vehicle as quickly as possible.
+    B: Abruptly remove your foot from the accelerator.
+    C: Hold the steering wheel with both hands and gradually release the accelerator.
+    D: Turn the steering wheel sharply toward the shoulder of the road.
+  answer: C
+  explanation: If you have a tire blowout, you should hold the steering wheel with
+    both hands, maintain your speed if possible, and gradually release the accelerator.
+    Suddenly braking or abruptly removing your foot from the accelerator can result
+    in a loss of control.
+- id: 169
+  category: defensive_driving
+  question: 'If your wheels drift off the pavement, you should do all of the following
+    EXCEPT:'
+  choices:
+    A: Grip the steering wheel firmly.
+    B: Brake gently.
+    C: Pull the steering wheel with force to get back on the road.
+    D: Remove your foot from the accelerator.
+  answer: C
+  explanation: If your wheels drift off the pavement, do not pull or turn your steering
+    wheel with too much force, as this may cause you to drive into oncoming traffic.
+    You should grip the wheel firmly, remove your foot from the accelerator, and brake
+    gently.
+- id: 170
+  category: safe_driving_rules
+  question: If your vehicle becomes disabled on the freeway and you must get out,
+    from which side should you exit?
+  choices:
+    A: The left side
+    B: The right side
+    C: The driver's side
+    D: Whichever side has a working door
+  answer: B
+  explanation: If your vehicle stops working on the freeway, you should safely pull
+    over to the right shoulder and exit on the right side so you are away from traffic.
+- id: 171
+  category: vehicle_information
+  question: Which of the following services will the California Highway Patrol Freeway
+    Service Patrol (FSP) NOT provide?
+  choices:
+    A: Provide a gallon of gas if you run out.
+    B: Jump start your vehicle if the battery is dead.
+    C: Tow your vehicle to a private repair service.
+    D: Change a flat tire.
+  answer: C
+  explanation: The FSP will provide gas, jump starts, and change flat tires, but they
+    will not tow your vehicle to a private repair service or residence.
+- id: 172
+  category: safe_driving_rules
+  question: If your vehicle stalls on a railroad track and a train is approaching
+    with warning lights flashing, what should you do immediately?
+  choices:
+    A: Stay in your vehicle and call 911.
+    B: Exit your vehicle and run diagonally away from the tracks in the direction
+      the train is coming from.
+    C: Exit your vehicle and run in the same direction the train is traveling.
+    D: Try to restart the engine while honking your horn.
+  answer: B
+  explanation: If your vehicle stalls with a train approaching and warning lights
+    flashing, immediately exit your vehicle and run away from the tracks diagonally
+    in the direction the train is coming from, then call 911.
+- id: 173
+  category: safe_driving_rules
+  question: How must an adult driver use a cell phone while driving?
+  choices:
+    A: They may hold the phone if they are only talking, not texting.
+    B: They must only use the cell phone in hands-free mode.
+    C: They can use a handheld phone if they are driving under 30 mph.
+    D: They are completely prohibited from using any cell phone, even hands-free.
+  answer: B
+  explanation: Driving while using a handheld cell phone is unsafe and illegal. Adult
+    drivers should only use a cell phone in hands-free mode when necessary.
+- id: 174
+  category: safe_driving_rules
+  question: Under what circumstance is a minor legally permitted to use a cell phone
+    while driving?
+  choices:
+    A: When talking to a parent or guardian.
+    B: When using a hands-free device.
+    C: To make a call for emergency assistance.
+    D: When stopped at a red light.
+  answer: C
+  explanation: It is against the law for a minor to use a cell phone while driving,
+    with the exception that minors may use a cell phone to make a call for emergency
+    assistance.
+- id: 175
+  category: vehicle_information
+  question: Which of the following is a symptom of carbon monoxide poisoning?
+  choices:
+    A: Ringing in the ears
+    B: Excessive thirst
+    C: Blurred vision
+    D: Muscle cramps
+  answer: A
+  explanation: Symptoms of carbon monoxide poisoning include tiredness, yawning, dizziness,
+    nausea, headache, and ringing in the ears.
+- id: 176
+  category: vehicle_information
+  question: What should you do if you are driving in extreme heat to prevent or handle
+    overheating?
+  choices:
+    A: Turn on the air conditioner to its maximum setting.
+    B: Drive at high speeds to increase airflow to the engine.
+    C: Turn off the air conditioner.
+    D: Slightly open your windows and use the defroster.
+  answer: C
+  explanation: In extreme heat, you should watch the temperature gauge, avoid driving
+    at high speeds for long periods, and turn off the air conditioner.
+- id: 177
   category: alcohol_drugs_health
-  question: 'According to the handbook''s introduction, operating a vehicle, motorcycle,
-    or bicycle while distracted or impaired could mean:'
+  question: What is the penalty if you refuse to take a blood or urine test when a
+    law enforcement officer suspects you of a DUI?
   choices:
-    A: A minor traffic citation
-    B: The difference between life and death
-    C: An automatic license suspension
-    D: Increased insurance premiums
+    A: You will receive a warning ticket.
+    B: DMV will suspend or revoke your driving privilege for one year.
+    C: You will be fined $1,000 immediately.
+    D: Your vehicle will be impounded for 6 months.
   answer: B
-  explanation: The Secretary's Message warns, "Do not operate a vehicle, motorcycle
-    or bicycle while distracted or impaired—it could mean the difference between life
-    and death."
-- id: 48
-  category: defensive_driving
-  question: Which of the following is listed as a safety priority for drivers in the
-    Secretary's Message?
-  choices:
-    A: Always driving below the speed limit
-    B: Yielding to commercial vehicles only
-    C: Always buckling up and paying attention to others
-    D: Upgrading to a newer vehicle
-  answer: C
-  explanation: The text advises to "Always buckle up, follow traffic laws, pay attention
-    to other drivers, bicyclists and pedestrians..."
-- id: 49
-  category: license_system
-  question: Which version of the DMV website is considered the official and accurate
-    source for program information and services?
-  choices:
-    A: The Spanish version
-    B: The Google Translated version
-    C: The English version
-    D: The American Sign Language version
-  answer: C
-  explanation: The Google Translate Disclaimer states, "The web pages currently in
-    English on the DMV website are the official and accurate source for the program
-    information and services the DMV provides."
-- id: 50
-  category: license_system
-  question: According to the DMV website disclaimer, which of the following pages
-    CANNOT be translated using Google Translate?
-  choices:
-    A: The Secretary's Message
-    B: The Glossary
-    C: Online Applications
-    D: The Safe Driving section
-  answer: C
-  explanation: The disclaimer lists "Forms, Publications, Field Office Locations,
-    Online Applications" as pages that cannot be translated using Google Translate.
-- id: 51
-  category: vehicle_information
-  question: Due to the DMV's expanding online services, which of the following transactions
-    can be completed on the DMV website?
-  choices:
-    A: Smog checks
-    B: Vehicle registration and driver's license renewal
-    C: Behind-the-wheel driving tests
-    D: Vision exams
-  answer: B
-  explanation: The Secretary's Message states, "Some of these transactions include
-    driver’s license renewal, vehicle registration and others."
-- id: 52
-  category: driver_responsibility
-  question: What does the DMV advise if you choose to save your chat transcript with
-    the Virtual Assistant on a public computer?
-  choices:
-    A: Use caution
-    B: Print it immediately
-    C: Email it to the DMV
-    D: Share it with the site administrator
-  answer: A
-  explanation: The chatbot disclaimer warns, "When your chat is over, you can save
-    the transcript. Use caution when using a public computer or device."
-- id: 53
-  category: license_system
-  question: If discrepancies arise in the translation of the DMV website, what is
-    the legal effect for compliance or enforcement purposes?
-  choices:
-    A: The translated text supersedes the English text
-    B: The discrepancies are not binding and have no legal effect
-    C: The user is exempt from the rule
-    D: The DMV must provide a certified translator
-  answer: B
-  explanation: The disclaimer states, "Any discrepancies or differences created in
-    the translation are not binding and have no legal effect for compliance or enforcement
-    purposes."
-- id: 54
-  category: sharing_the_road
-  question: According to the Secretary's Message, who must drivers pay attention to
-    in order to share the road safely?
-  choices:
-    A: Only other drivers
-    B: Only pedestrians in crosswalks
-    C: Other drivers, bicyclists, and pedestrians
-    D: Only commercial truck drivers
-  answer: C
-  explanation: The Secretary's Message reminds Californians to "pay attention to other
-    drivers, bicyclists and pedestrians..."
-- id: 55
-  category: license_system
-  question: For what purpose does the DMV provide machine translation services on
-    its website and chatbot?
-  choices:
-    A: For official legal documentation
-    B: For purposes of information and convenience only
-    C: To replace English as the official language
-    D: To guarantee perfect accuracy for non-English speakers
-  answer: B
-  explanation: The disclaimers state that "Machine translation is provided for purposes
-    of information and convenience only."
-- id: 56
-  category: vehicle_information
-  question: According to the handbook's table of contents, which section covers Financial
-    Responsibility, Insurance Requirements, and Collisions?
-  choices:
-    A: Section 7
-    B: Section 8
-    C: Section 9
-    D: Section 10
-  answer: D
-  explanation: 'The provided table of contents lists "Section 10: Financial Responsibility,
-    Insurance Requirements, and Collisions."'
-- id: 57
-  category: safe_driving_rules
-  question: Who has the right-of-way at a crosswalk with no pedestrian signals?
-  choices:
-    A: Vehicles, if they are traveling at the speed limit.
-    B: Pedestrians always have the right-of-way in crosswalks.
-    C: Vehicles, if the pedestrian is not in a marked crosswalk.
-    D: Pedestrians, but only if they make eye contact with the driver.
-  answer: B
-  explanation: Pedestrians have the right-of-way in marked or unmarked crosswalks.
-    Drivers must yield and reduce speed or stop if necessary to ensure the pedestrian's
-    safety.
-- id: 58
-  category: defensive_driving
-  question: To avoid tailgating, how much space should you leave between your vehicle
-    and the vehicle in front of you under normal conditions?
-  choices:
-    A: 2 seconds
-    B: 3 seconds
-    C: 4 seconds
-    D: 5 seconds
-  answer: B
-  explanation: 'To avoid tailgating, the California Driver Handbook recommends using
-    the ''3-second rule'': when the vehicle ahead of you passes a certain point, count
-    three seconds to ensure safe following distance.'
-- id: 59
-  category: vehicle_information
-  question: You must turn on your headlights ___ after sunset and leave them on until
-    ___ before sunrise.
-  choices:
-    A: 30 minutes; 30 minutes
-    B: 1 hour; 1 hour
-    C: 15 minutes; 15 minutes
-    D: Immediately; immediately
-  answer: A
-  explanation: California law requires you to turn on your headlights 30 minutes after
-    sunset and leave them on until 30 minutes before sunrise.
-- id: 60
-  category: defensive_driving
-  question: What is the best way to check your blind spots before changing lanes?
-  choices:
-    A: Look in your rearview mirror.
-    B: Look in your side mirrors.
-    C: Turn your head and look over your shoulder.
-    D: Honk your horn to warn other drivers.
-  answer: C
-  explanation: To check your blind spots, you must turn your head and look over your
-    shoulder in the direction you plan to move to see vehicles that are not visible
-    in your mirrors.
-- id: 61
+  explanation: The manual states that if you refuse to take a blood or urine test,
+    the DMV will suspend or revoke your driving privilege for one year.
+- id: 178
   category: penalties_and_points
-  question: If you are convicted of fleeing a peace officer on duty without causing
-    bodily injury, you may face which of the following penalties?
+  question: If you are 13 to 20 years old and convicted of operating a bicycle while
+    under the influence of alcohol or drugs, what may happen?
   choices:
-    A: Up to 1 year in a county jail.
-    B: A warning and a fine.
-    C: Mandatory community service.
-    D: Permanent revocation of your license.
-  answer: A
-  explanation: Any person convicted of causing a pursuit and fleeing a peace officer
-    is punishable by imprisonment in a county jail for not more than one year.
-- id: 62
-  category: signs_and_signals
-  question: 'A three-sided, red and white sign indicates that you must:'
-  choices:
-    A: Stop completely before entering the intersection.
-    B: Yield the right-of-way to other traffic and pedestrians.
-    C: Maintain your speed and merge.
-    D: Ignore the sign if no other vehicles are visible.
-  answer: B
-  explanation: A three-sided red YIELD sign indicates that you must slow down and
-    be ready to stop, if necessary, to let any vehicle, bicyclist, or pedestrian pass
-    before you proceed.
-- id: 63
-  category: sharing_the_road
-  question: 'When passing a bicyclist in a travel lane, you must ensure there is enough
-    width for the cyclist and maintain a minimum clearance of:'
-  choices:
-    A: 1 foot
-    B: 2 feet
-    C: 3 feet
-    D: 4 feet
+    A: You will be required to pay a $500 fine.
+    B: You must complete 100 hours of community service.
+    C: Your driving privilege may be suspended or delayed for one year once you are
+      eligible to drive.
+    D: Your bicycle will be permanently confiscated by the state.
   answer: C
-  explanation: California law requires drivers to leave a distance of at least three
-    feet when passing a bicyclist to ensure their safety.
-- id: 64
-  category: safe_driving_rules
-  question: In which of the following situations is it legal to make a U-turn?
-  choices:
-    A: On a divided highway by crossing a dividing section, curb, or strip of land.
-    B: Across a double yellow line when it is safe and legal.
-    C: At a railroad crossing.
-    D: On a one-way street.
-  answer: B
-  explanation: You may make a U-turn across a double yellow line when it is safe and
-    legal. It is illegal to make a U-turn on a one-way street, at a railroad crossing,
-    or across a divided highway barrier.
-- id: 65
+  explanation: If you are 13 to 20 years old and convicted of operating a bicycle
+    under the influence, your driving privilege may be suspended or delayed for one
+    year once you are eligible to drive.
+- id: 179
   category: alcohol_drugs_health
-  question: 'If you are under 21 years of age, California''s ''Zero Tolerance'' law
-    states it is illegal to drive with a BAC of:'
+  question: Where must you keep an opened container of alcohol in your vehicle?
+  choices:
+    A: In the glove box.
+    B: Under the driver's seat.
+    C: In the trunk or a place where passengers do not sit.
+    D: In the center console.
+  answer: C
+  explanation: If an alcohol container is open, you must keep it in the trunk or a
+    place where passengers do not sit. It is illegal to keep an open container in
+    your glove box.
+- id: 180
+  category: alcohol_drugs_health
+  question: 'It is illegal for a person 21 years of age or older to drive with a Blood
+    Alcohol Concentration (BAC) of:'
+  choices:
+    A: 0.04% or higher
+    B: 0.05% or higher
+    C: 0.08% or higher
+    D: 0.10% or higher
+  answer: C
+  explanation: It is illegal for you to drive if you have a BAC of 0.08% or higher
+    if you are over 21 years old.
+- id: 181
+  category: alcohol_drugs_health
+  question: What is the legal BAC limit for someone driving a vehicle that requires
+    a commercial driver's license?
   choices:
     A: 0.01% or higher
-    B: 0.04% or higher
-    C: 0.05% or higher
+    B: 0.02% or higher
+    C: 0.04% or higher
     D: 0.08% or higher
-  answer: A
-  explanation: California's Zero Tolerance law makes it illegal for anyone under 21
-    to drive with a BAC of 0.01% or higher.
-- id: 66
-  category: driver_responsibility
-  question: 'If you are involved in a collision resulting in an injury or death, you
-    must report it to the DMV within:'
-  choices:
-    A: 24 hours
-    B: 5 days
-    C: 10 days
-    D: 30 days
   answer: C
-  explanation: You (or your insurance agent, broker, or legal representative) must
-    report the collision to the DMV within 10 days if someone is injured or killed,
-    or if property damage exceeds $1,000.
+  explanation: It is illegal to drive with a BAC of 0.04% or higher if you drive a
+    vehicle that requires a commercial driver's license.
+- id: 182
+  category: penalties_and_points
+  question: If you are arrested for a DUI, how many days do you have to request a
+    DMV administrative hearing?
+  choices:
+    A: 5 days
+    B: 10 days
+    C: 14 days
+    D: 30 days
+  answer: B
+  explanation: If you are arrested for DUI, you may request a DMV administrative hearing
+    within 10 days from the date of your arrest.
+- id: 183
+  category: penalties_and_points
+  question: How long does a DUI conviction remain on your driver's record?
+  choices:
+    A: 3 years
+    B: 5 years
+    C: 7 years
+    D: 10 years
+  answer: D
+  explanation: All DUI convictions remain on your driver's record for 10 years.
+- id: 184
+  category: alcohol_drugs_health
+  question: 'If you are under 21 years old, you may carry an alcoholic beverage inside
+    a vehicle ONLY if:'
+  choices:
+    A: It is stored in the glove box.
+    B: An individual who is 21 years old or older is with you.
+    C: You are driving to a private party.
+    D: The container is empty.
+  answer: B
+  explanation: If you are under 21, you may not carry any alcohol beverage inside
+    a vehicle unless an individual who is 21 years old or older is with you, and the
+    container must be full, sealed, and unopened.
+- id: 185
+  category: penalties_and_points
+  question: If you are under 21 and caught with alcohol in your vehicle, how long
+    can law enforcement impound your vehicle?
+  choices:
+    A: Up to 10 days
+    B: Up to 30 days
+    C: Up to 60 days
+    D: Up to 90 days
+  answer: B
+  explanation: If you are under 21 and caught with alcohol in your vehicle, law enforcement
+    can impound your vehicle for up to 30 days.
+- id: 186
+  category: safe_driving_rules
+  question: What is the minimum insurance coverage required for property damage in
+    California?
+  choices:
+    A: $5,000
+    B: $10,000
+    C: $15,000
+    D: $30,000
+  answer: C
+  explanation: Your insurance must cover at least $15,000 for property damage.
+- id: 187
+  category: penalties_and_points
+  question: What is the penalty for being in a collision without proper insurance
+    coverage?
+  choices:
+    A: A $500 fine.
+    B: Your driving privilege will be suspended for up to four years.
+    C: Mandatory jail time of 30 days.
+    D: Your vehicle will be impounded for one year.
+  answer: B
+  explanation: Your driving privilege will be suspended for up to four years if you
+    are in a collision and do not have proper insurance coverage, regardless of who
+    was at fault.
+- id: 188
+  category: alcohol_drugs_health
+  question: How does California law view driving under the influence of prescription
+    medications compared to illegal drugs?
+  choices:
+    A: Prescription medications are exempt from DUI laws.
+    B: The law does not see a difference between illegal drugs and medications you
+      get from a doctor or pharmacy.
+    C: Prescription medications only result in a warning.
+    D: Over-the-counter medications are legal to use while driving regardless of side
+      effects.
+  answer: B
+  explanation: The law does not see a difference between illegal drugs and medications
+    you get from a doctor or pharmacy. They can all affect your ability to drive safely.
+- id: 189
+  category: penalties_and_points
+  question: Which of the following is a requirement if you are convicted of a DUI?
+  choices:
+    A: You must sell your vehicle.
+    B: You must surrender your passport.
+    C: You must file a California Insurance Proof Certificate (SR 22/SR 1P).
+    D: You must retake the written driving test immediately.
+  answer: C
+  explanation: If you are convicted of a DUI, you must complete a DUI program, file
+    a California Insurance Proof Certificate (SR 22/SR 1P), pay fees, and you may
+    be required to install an ignition interlock device.
+- id: 190
+  category: vehicle_information
+  question: When you buy a vehicle, how many days do you have to transfer ownership
+    to your name?
+  choices:
+    A: 5 days
+    B: 10 days
+    C: 15 days
+    D: 20 days
+  answer: B
+  explanation: According to the manual, when you buy a vehicle, you have 10 days to
+    transfer ownership to your name.
+- id: 191
+  category: vehicle_information
+  question: When you sell a vehicle, within how many days must you notify the DMV?
+  choices:
+    A: 5 days
+    B: 10 days
+    C: 15 days
+    D: 30 days
+  answer: A
+  explanation: When you sell a vehicle, you must notify DMV within five days by completing
+    a Notice of Transfer and Release of Liability.
+- id: 192
+  category: vehicle_information
+  question: After you become a resident or get a job in California, how long do you
+    have to register your out-of-state vehicle?
+  choices:
+    A: 10 days
+    B: 20 days
+    C: 30 days
+    D: 60 days
+  answer: B
+  explanation: You have 20 days to register your vehicle after you become a resident
+    or get a job in California.
+- id: 193
+  category: driver_responsibility
+  question: 'You must report a collision to the DMV within 10 days if:'
+  choices:
+    A: The collision caused more than $500 in property damage.
+    B: The collision caused more than $1,000 in property damage or anyone was injured.
+    C: You were at fault for the collision.
+    D: The collision happened on a public highway and caused traffic delays.
+  answer: B
+  explanation: If you are in a collision, you must report it to DMV within 10 days
+    if the collision caused more than $1,000 in damage to property, or anyone was
+    injured or killed.
+- id: 194
+  category: penalties_and_points
+  question: 'Failing to stop or leaving the scene of a collision you are involved
+    in is known as:'
+  choices:
+    A: A priority reexamination.
+    B: A hit-and-run.
+    C: A right-of-way violation.
+    D: An SR-1 violation.
+  answer: B
+  explanation: Failing to stop or leaving the scene of an accident is called a hit-and-run,
+    and the punishment is severe if you are convicted.
+- id: 195
+  category: driver_responsibility
+  question: If your vehicle hits a parked car and you cannot find the owner, what
+    must you do?
+  choices:
+    A: Wait by the vehicle until the owner returns.
+    B: Leave a note with your name, phone number, and address, and report the collision
+      to law enforcement.
+    C: Call your insurance company and leave the scene.
+    D: Move the parked car out of the way and leave a note on the windshield.
+  answer: B
+  explanation: If you cannot find the owner, leave a note with your name, phone number,
+    and address securely attached to the vehicle or property, and report the collision
+    to law enforcement.
+- id: 196
+  category: safe_driving_rules
+  question: What should you do if you accidentally injure an animal while driving?
+  choices:
+    A: Move the injured animal to the side of the road.
+    B: Call the nearest humane society or law enforcement.
+    C: Put the animal in your car and drive it to a vet.
+    D: Leave the scene immediately to avoid traffic.
+  answer: B
+  explanation: If you kill or injure an animal, call the nearest humane society or
+    law enforcement. Do not try to move an injured animal.
+- id: 197
+  category: driver_responsibility
+  question: 'If anyone is injured or killed in a collision, you must make a report
+    to law enforcement within:'
+  choices:
+    A: 24 hours.
+    B: 48 hours.
+    C: 5 days.
+    D: 10 days.
+  answer: A
+  explanation: You must make a report to law enforcement within 24 hours of the collision
+    if anyone is injured or killed.
+- id: 198
+  category: driver_testing
+  question: If you receive a Notice of Priority Reexamination of Driver, how many
+    working days do you have to contact the DMV before your driving privilege is automatically
+    suspended?
+  choices:
+    A: 3 working days.
+    B: 5 working days.
+    C: 10 working days.
+    D: 14 working days.
+  answer: B
+  explanation: You have five working days to contact DMV to initiate the process or
+    your driving privilege will be automatically suspended.
+- id: 199
+  category: driver_testing
+  question: Which of the following CANNOT be used as the basis for a DMV driver reexamination?
+  choices:
+    A: A physical condition.
+    B: A mental condition.
+    C: A poor driver's record.
+    D: A driver's age.
+  answer: D
+  explanation: A physical or mental condition or poor driver's record can be the basis
+    for a reexamination, not a driver's age.
+- id: 200
+  category: driver_responsibility
+  question: Who is required to file a Report of Traffic Accident Occurring in California
+    (SR 1) with the DMV if a collision meets the reporting requirements?
+  choices:
+    A: Only the driver who caused the collision.
+    B: Only the driver who was not at fault.
+    C: Each driver involved, regardless of who caused the collision.
+    D: Law enforcement officers only.
+  answer: C
+  explanation: Each driver must file a Report of Traffic Accident Occurring in California
+    (SR 1) with DMV. You must file a report whether or not you caused the collision.
+- id: 201
+  category: safe_driving_rules
+  question: If you are in a collision and no one is hurt, what should you do first?
+  choices:
+    A: Call 911 immediately while leaving your vehicle in the lane.
+    B: Move your vehicle out of traffic, then call 911.
+    C: File an SR 1 form with the DMV.
+    D: Wait for law enforcement to arrive before moving your vehicle.
+  answer: B
+  explanation: If you are in a collision, move your vehicle out of traffic if no one
+    is hurt. Then call 911.
+- id: 202
+  category: defensive_driving
+  question: According to the manual, which of the following is a common cause of collisions?
+  choices:
+    A: Driving a vehicle with a manual transmission.
+    B: A vehicle traveling faster or slower than the flow of traffic.
+    C: Using hands-free devices.
+    D: Driving during daylight hours.
+  answer: B
+  explanation: The most common causes of collisions include a vehicle traveling faster
+    or slower than the flow of traffic.
+- id: 203
+  category: driver_responsibility
+  question: If you are involved in a collision resulting in $1,000 in damage, how
+    will it affect your driver's record?
+  choices:
+    A: It will only be added to your record if you caused the collision.
+    B: It will be added to your driver's record regardless of who caused the collision.
+    C: It will not be added to your record if it happened on private property.
+    D: It will only be added if law enforcement files the report for you.
+  answer: B
+  explanation: If you are involved in a collision resulting in $1,000 in damage...
+    DMV will add it to your driver's record. It does not matter who caused the collision.
+- id: 204
+  category: license_system
+  question: Which of the following is true regarding driver's license restrictions
+    for senior drivers?
+  choices:
+    A: Seniors over 70 are restricted from freeway driving.
+    B: There are no specific restrictions based on age, only on conditions.
+    C: Seniors must wear corrective lenses after age 65.
+    D: Seniors are automatically restricted from driving at night.
+  answer: B
+  explanation: According to the manual, there are no specific restrictions for seniors.
+    All restrictions placed on a driver's license are based on conditions, not age.
+- id: 205
+  category: safe_driving_rules
+  question: Which of the following is considered a warning sign of an unsafe driver?
+  choices:
+    A: Driving during light traffic hours.
+    B: Getting lost in familiar places.
+    C: Choosing a well-lit route at night.
+    D: Installing an additional right-side mirror.
+  answer: B
+  explanation: The manual lists getting lost in familiar places, dents and scrapes
+    on the car or property, and frequent close calls or collisions as warning signs
+    of an unsafe driver.
+- id: 206
+  category: license_system
+  question: 'If you are 70 years old or older when your driver''s license expires,
+    you are required to:'
+  choices:
+    A: Retake the behind-the-wheel drive test.
+    B: Renew your license in person and pass a vision test.
+    C: Surrender your license for a Senior ID card.
+    D: Complete an eight-hour Mature Driver Program.
+  answer: B
+  explanation: If you are 70 years old or older at the time your driver's license
+    expires, you are required to renew your driver's license in person and pass a
+    vision test.
+- id: 207
+  category: license_system
+  question: Approximately how many days before your driver's license expires does
+    the DMV send a renewal notice to your address of record?
+  choices:
+    A: 30 days
+    B: 60 days
+    C: 90 days
+    D: 120 days
+  answer: C
+  explanation: The DMV sends a renewal notice to your address of record about 90 days
+    before your driver's license expires.
+- id: 208
+  category: driver_responsibility
+  question: What is one limitation of the DMV's Community Liaison?
+  choices:
+    A: They cannot represent you in a DMV hearing or reexamination.
+    B: They cannot provide you with useful tools and information.
+    C: They cannot assist teens or senior drivers.
+    D: They cannot ensure drivers are treated fairly.
+  answer: A
+  explanation: While the Community Liaison can assist as a go-between to ensure fair
+    treatment, they cannot represent you in a DMV hearing or reexamination.
+- id: 209
+  category: safe_driving_rules
+  question: 'The Mature Driver Improvement Program is an eight-hour course designed
+    for drivers who are at least:'
+  choices:
+    A: 50 years old
+    B: 55 years old
+    C: 62 years old
+    D: 70 years old
+  answer: B
+  explanation: The Mature Driver Improvement Program is an eight-hour course for drivers
+    55 years old and older.
+- id: 210
+  category: license_system
+  question: How long is the completion certificate for the Mature Driver Improvement
+    Program valid?
+  choices:
+    A: One year
+    B: Two years
+    C: Three years
+    D: Five years
+  answer: C
+  explanation: Your certificate for completing the Mature Driver Improvement Program
+    is valid for three years and can be renewed by completing another four-hour course.
+- id: 211
+  category: license_system
+  question: At what age are you eligible for a no-fee Senior ID card?
+  choices:
+    A: 55 years old
+    B: 60 years old
+    C: 62 years old
+    D: 65 years old
+  answer: C
+  explanation: If you are 62 years old or older, you are eligible for a no-fee Senior
+    ID card.
+- id: 212
+  category: license_system
+  question: 'Drivers of any age who are unable to continue driving safely due to a
+    physical or mental condition may be eligible to:'
+  choices:
+    A: Receive a permanent exemption from renewal fees.
+    B: Exchange their driver's license for a no-fee ID card.
+    C: Drive only during daylight hours without restrictions.
+    D: Keep their license if they complete an eight-hour course.
+  answer: B
+  explanation: Drivers of any age who are unable to continue driving safely due to
+    a physical or mental condition may be eligible to exchange their driver's license
+    for a no-fee ID card.
+- id: 213
+  category: alcohol_drugs_health
+  question: What does a Blood Alcohol Concentration (BAC) of 0.10% mean?
+  choices:
+    A: You have 0.10 grams of alcohol in 100 milliliters of blood.
+    B: You have 0.10 ounces of alcohol in 100 ounces of blood.
+    C: You have 1.0 grams of alcohol in 10 milliliters of blood.
+    D: You have 10 grams of alcohol in 100 milliliters of blood.
+  answer: A
+  explanation: According to the glossary, a BAC of 0.10% means that you have 0.10
+    grams of alcohol in 100 milliliters of blood.
+- id: 214
+  category: sharing_the_road
+  question: According to the DMV glossary, which of the following is considered a
+    pedestrian?
+  choices:
+    A: A person riding a motorized scooter on the highway.
+    B: A person with a disability using a wheelchair for transportation.
+    C: A person riding a bicycle in a designated bike lane.
+    D: A person operating a street sweeper.
+  answer: B
+  explanation: A pedestrian is a person walking and can also be a person with a disability
+    using a tricycle, quadricycle, or wheelchair for transportation.
+- id: 215
+  category: defensive_driving
+  question: 'The ''three-second rule'' is a driving rule that helps you estimate:'
+  choices:
+    A: How long to stop at a stop sign.
+    B: How closely you should follow other vehicles.
+    C: When to yield the right-of-way at an intersection.
+    D: How long to look in your mirrors before changing lanes.
+  answer: B
+  explanation: The three-second rule is a driving rule that helps you estimate how
+    closely you should follow other vehicles.
+- id: 216
+  category: sharing_the_road
+  question: What does the term 'Vulnerable Road Users' (VRU) refer to?
+  choices:
+    A: Drivers of commercial vehicles carrying hazardous materials.
+    B: Non-motorized road users, such as cyclists and pedestrians.
+    C: Drivers who have recently received a traffic citation.
+    D: Senior drivers over the age of 70.
+  answer: B
+  explanation: VRUs are non-motorized road users, such as cyclists, pedestrians, and
+    persons with disabilities or reduced mobility using a wheelchair, tricycle, or
+    quadricycle.
+- id: 217
+  category: signs_and_signals
+  question: What does it mean to 'yield' on the road?
+  choices:
+    A: To speed up to merge smoothly into traffic.
+    B: To wait for, slow down, and be ready to stop to allow others with the right-of-way
+      to proceed.
+    C: To come to a complete stop for at least three seconds.
+    D: To claim the right-of-way over pedestrians and cyclists.
+  answer: B
+  explanation: Yield means to wait for, slow down, and be ready to stop (if necessary)
+    to allow other vehicles or pedestrians who have the right-of-way to proceed.
+- id: 218
+  category: driver_responsibility
+  question: When a senior suffers from progressive dementia and loses their ability
+    to drive safely, who is often responsible for stopping them from driving and arranging
+    alternative transportation?
+  choices:
+    A: The DMV Community Liaison.
+    B: Caregivers, physicians, and law enforcement.
+    C: The Mature Driver Improvement Program instructors.
+    D: The senior driver's insurance company.
+  answer: B
+  explanation: The manual states that it is often up to caregivers, physicians, and
+    law enforcement to stop seniors with progressive dementia from driving and arrange
+    alternative transportation.
 - image: stop.png
   category: signs_and_signals
   question: What does this sign mean?
@@ -823,7 +2678,7 @@ questions:
   explanation: A red octagonal STOP sign means you must come to a complete stop at
     the stop line, crosswalk, or before entering the intersection. Check for traffic
     and pedestrians before proceeding.
-  id: 67
+  id: 219
 - image: yield.png
   category: signs_and_signals
   question: What does this sign require you to do?
@@ -836,7 +2691,20 @@ questions:
   explanation: A red and white triangular YIELD sign means you must slow down and
     yield the right-of-way to traffic and pedestrians. You must stop if necessary
     to let others pass safely.
-  id: 68
+  id: 220
+- image: do_not_enter.png
+  category: signs_and_signals
+  question: What does this sign mean?
+  choices:
+    A: Road closed ahead
+    B: No parking allowed
+    C: Do not enter this roadway
+    D: Dead end ahead
+  answer: C
+  explanation: A red and white DO NOT ENTER sign means you must not enter the road
+    or ramp where this sign is posted. It is usually seen at freeway off-ramps or
+    one-way streets where entering would put you in the path of oncoming traffic.
+  id: 221
 - image: wrong_way.png
   category: signs_and_signals
   question: If you see this sign, what should you do?
@@ -849,7 +2717,31 @@ questions:
   explanation: A red and white WRONG WAY sign means you are traveling against traffic
     on a one-way road or highway ramp. Stop immediately and safely turn around or
     back up.
-  id: 69
+  id: 222
+- image: one_way_left.png
+  category: signs_and_signals
+  question: What does this sign indicate?
+  choices:
+    A: Left turn only
+    B: Traffic flows in one direction — to the left
+    C: Keep left of the median
+    D: Highway exit to the left
+  answer: B
+  explanation: A black and white ONE WAY sign with an arrow indicates that traffic
+    on this street moves in only one direction — the direction the arrow points.
+  id: 223
+- image: no_u_turn.png
+  category: signs_and_signals
+  question: What does this sign prohibit?
+  choices:
+    A: Right turns
+    B: Left turns
+    C: U-turns
+    D: Passing other vehicles
+  answer: C
+  explanation: A white regulatory sign with a U-turn arrow crossed out means U-turns
+    are prohibited at this location.
+  id: 224
 - image: no_left_turn.png
   category: signs_and_signals
   question: What action is prohibited by this sign?
@@ -861,7 +2753,44 @@ questions:
   answer: B
   explanation: A white regulatory sign showing a left turn arrow crossed out means
     left turns are not allowed at this intersection.
-  id: 70
+  id: 225
+- image: no_right_turn.png
+  category: signs_and_signals
+  question: What does this sign mean?
+  choices:
+    A: No U-turn allowed
+    B: No left turn allowed
+    C: No right turn allowed
+    D: No passing allowed
+  answer: C
+  explanation: A white regulatory sign showing a right turn arrow crossed out means
+    right turns are prohibited at this location.
+  id: 226
+- image: no_passing.png
+  category: signs_and_signals
+  question: What does this sign indicate?
+  choices:
+    A: Road narrows ahead
+    B: Do not pass other vehicles in this zone
+    C: Two-way traffic ahead
+    D: Keep right
+  answer: B
+  explanation: A black and white NO PASSING ZONE pennant-shaped sign means you are
+    not allowed to pass other vehicles in this area. It marks the beginning of a no-passing
+    zone.
+  id: 227
+- image: keep_right.png
+  category: signs_and_signals
+  question: What does this sign instruct drivers to do?
+  choices:
+    A: Merge right
+    B: Turn right only
+    C: Keep to the right of a divider or obstruction
+    D: Right lane ends ahead
+  answer: C
+  explanation: A white regulatory KEEP RIGHT sign with an arrow means you must keep
+    to the right side of a traffic island, median, or obstruction.
+  id: 228
 - image: speed_limit_25.png
   category: signs_and_signals
   question: What type of sign is this, based on its shape and color?
@@ -873,7 +2802,7 @@ questions:
   answer: C
   explanation: White rectangular signs with black lettering are regulatory signs.
     Speed limit signs tell you the maximum legal speed for the area under ideal conditions.
-  id: 71
+  id: 229
 - image: deer_crossing.png
   category: signs_and_signals
   question: What does this yellow diamond-shaped sign warn you about?
@@ -886,7 +2815,19 @@ questions:
   explanation: A yellow diamond-shaped sign with a deer silhouette warns that deer
     frequently cross the road in this area. Slow down and watch for animals, especially
     at dawn and dusk.
-  id: 72
+  id: 230
+- image: pedestrian_crossing.png
+  category: signs_and_signals
+  question: What does this sign warn you about?
+  choices:
+    A: School zone ahead
+    B: Pedestrian crossing ahead
+    C: Hiking trail nearby
+    D: Bus stop ahead
+  answer: B
+  explanation: A yellow diamond-shaped sign with a pedestrian figure warns of a pedestrian
+    crossing ahead. Be prepared to stop for pedestrians crossing the road.
+  id: 231
 - image: school_zone.png
   category: signs_and_signals
   question: What does the shape of this sign indicate?
@@ -898,7 +2839,19 @@ questions:
   answer: C
   explanation: A pentagon-shaped (5-sided) fluorescent yellow-green sign indicates
     a school zone or school crossing. Slow down and watch for children.
-  id: 73
+  id: 232
+- image: railroad_crossing.png
+  category: signs_and_signals
+  question: What does this circular yellow sign warn you about?
+  choices:
+    A: A roundabout ahead
+    B: A hospital zone
+    C: A railroad crossing ahead
+    D: A no-passing zone
+  answer: C
+  explanation: A circular yellow sign with a black X and two R's is the advance warning
+    sign for a railroad crossing ahead. Slow down, look, and listen for trains.
+  id: 233
 - image: railroad_crossbuck.png
   category: signs_and_signals
   question: Where would you typically see this sign?
@@ -910,7 +2863,19 @@ questions:
   answer: B
   explanation: The white X-shaped railroad crossbuck sign is placed at railroad crossings.
     It means you must yield to trains. If a train is approaching, you must stop.
-  id: 74
+  id: 234
+- image: curve_right.png
+  category: signs_and_signals
+  question: What does this yellow diamond-shaped sign indicate?
+  choices:
+    A: Road ends ahead
+    B: Right turn required
+    C: A curve to the right ahead
+    D: Detour ahead
+  answer: C
+  explanation: A yellow diamond-shaped sign with a curved arrow warns of a curve in
+    the road ahead. Slow down before entering the curve.
+  id: 235
 - image: sharp_turn_right.png
   category: signs_and_signals
   question: How does this sign differ from a curve sign?
@@ -923,7 +2888,55 @@ questions:
   explanation: A sharp turn sign (with a more angled arrow) indicates a sharper turn
     than a curve sign. You need to reduce your speed more significantly before this
     turn.
-  id: 75
+  id: 236
+- image: reverse_curve.png
+  category: signs_and_signals
+  question: What road condition does this sign warn about?
+  choices:
+    A: A winding road
+    B: A single curve ahead
+    C: A series of two curves in opposite directions
+    D: A roundabout ahead
+  answer: C
+  explanation: A reverse curve sign warns of two curves in opposite directions ahead.
+    Slow down and be prepared for the road to curve first one way, then the other.
+  id: 237
+- image: winding_road.png
+  category: signs_and_signals
+  question: What does this sign warn you to expect?
+  choices:
+    A: A single sharp curve
+    B: A slippery road surface
+    C: A series of curves or turns ahead
+    D: A hill ahead
+  answer: C
+  explanation: A winding road sign warns of a series of curves or turns ahead. Reduce
+    your speed and be alert for changing road conditions.
+  id: 238
+- image: merge.png
+  category: signs_and_signals
+  question: What does this sign tell you to prepare for?
+  choices:
+    A: A lane ending
+    B: Traffic merging from another road
+    C: A divided highway beginning
+    D: A road narrowing to one lane
+  answer: B
+  explanation: A yellow diamond-shaped merge sign warns that traffic from another
+    road will be merging into your lane. Be prepared to adjust your speed and position.
+  id: 239
+- image: road_narrows.png
+  category: signs_and_signals
+  question: What does this sign warn about?
+  choices:
+    A: Bridge ahead
+    B: Road narrows ahead
+    C: Lane ends
+    D: Divided highway ends
+  answer: B
+  explanation: This warning sign indicates the road ahead becomes narrower. Be prepared
+    for reduced road width and adjust your lane position.
+  id: 240
 - image: divided_highway.png
   category: signs_and_signals
   question: What does this sign indicate is ahead?
@@ -935,7 +2948,130 @@ questions:
   answer: C
   explanation: This sign warns that the road ahead becomes a divided highway with
     a median or barrier separating opposing traffic. Keep to the right.
-  id: 76
+  id: 241
+- image: divided_highway_ends.png
+  category: signs_and_signals
+  question: What does this sign warn you about?
+  choices:
+    A: A divided highway begins
+    B: The divided highway ends and two-way traffic resumes
+    C: A merge area ahead
+    D: Road construction ahead
+  answer: B
+  explanation: This sign warns that the divided highway is ending. Opposing traffic
+    will no longer be separated by a median. Be prepared for two-way traffic.
+  id: 242
+- image: two_way_traffic.png
+  category: signs_and_signals
+  question: What does this sign warn you about?
+  choices:
+    A: A divided highway begins
+    B: A passing zone ahead
+    C: Two-way traffic ahead — traffic moves in both directions
+    D: A lane shift ahead
+  answer: C
+  explanation: This sign warns of two-way traffic ahead. You may be leaving a one-way
+    road or divided highway and will encounter vehicles traveling in the opposite
+    direction.
+  id: 243
+- image: slippery_when_wet.png
+  category: signs_and_signals
+  question: What road condition does this sign warn about?
+  choices:
+    A: Icy road conditions
+    B: The road may be slippery when wet
+    C: Winding road ahead
+    D: Uneven pavement
+  answer: B
+  explanation: A slippery when wet sign warns that the road surface may become very
+    slippery during rain or wet conditions. Reduce your speed and avoid sudden braking
+    or turning.
+  id: 244
+- image: hill.png
+  category: signs_and_signals
+  question: What does this sign warn you about?
+  choices:
+    A: A bump in the road
+    B: An uneven road surface
+    C: A steep hill or grade ahead
+    D: Road construction
+  answer: C
+  explanation: This sign warns of a steep hill or grade ahead. You may need to adjust
+    your speed and shift to a lower gear, especially in trucks or when towing.
+  id: 245
+- image: signal_ahead.png
+  category: signs_and_signals
+  question: What does this sign warn you to prepare for?
+  choices:
+    A: A stop sign ahead
+    B: A traffic signal ahead
+    C: A school crossing
+    D: A police checkpoint
+  answer: B
+  explanation: This sign warns of a traffic signal ahead. Be prepared to stop if the
+    light is red or yellow. This sign is often placed where the signal may not be
+    visible from a distance.
+  id: 246
+- image: stop_ahead.png
+  category: signs_and_signals
+  question: What does this sign tell you to expect ahead?
+  choices:
+    A: A yield sign
+    B: A traffic signal
+    C: A stop sign where you must stop
+    D: A speed bump
+  answer: C
+  explanation: This sign warns that there is a stop sign ahead. Begin slowing down
+    and prepare to come to a complete stop at the stop sign.
+  id: 247
+- image: cross_road.png
+  category: signs_and_signals
+  question: What does this sign warn about?
+  choices:
+    A: A railroad crossing ahead
+    B: A crossroad or intersection ahead
+    C: A hospital ahead
+    D: A pedestrian crossing
+  answer: B
+  explanation: This sign warns that a crossroad or 4-way intersection is ahead. Watch
+    for traffic entering from side roads.
+  id: 248
+- image: side_road.png
+  category: signs_and_signals
+  question: What does this sign warn you about?
+  choices:
+    A: A T-intersection ahead
+    B: A side road entering from the right
+    C: A curve in the road
+    D: A dead end
+  answer: B
+  explanation: This sign warns of a side road entering from the right. Watch for vehicles
+    entering the highway from the side road.
+  id: 249
+- image: added_lane.png
+  category: signs_and_signals
+  question: What does this sign mean?
+  choices:
+    A: Lanes are merging
+    B: A lane is ending
+    C: A new lane is being added — no merging needed
+    D: Right turn required
+  answer: C
+  explanation: An added lane sign means a new lane is joining the highway without
+    requiring merging. Traffic entering from the ramp has its own new lane.
+  id: 250
+- image: no_parking.png
+  category: signs_and_signals
+  question: What does this sign prohibit?
+  choices:
+    A: Stopping at any time
+    B: Parking in this area
+    C: Standing or idling
+    D: Loading or unloading
+  answer: B
+  explanation: A red and white NO PARKING sign means you cannot park your vehicle
+    in this area. You may briefly stop to load or unload passengers.
+  id: 251
 - image: handicap_parking.png
   category: signs_and_signals
   question: Who is allowed to park in a space marked with this sign?
@@ -948,2512 +3084,4 @@ questions:
   explanation: A blue sign with the wheelchair symbol marks parking reserved for persons
     with disabilities. Only vehicles displaying a valid disability parking placard
     or license plate may park in these spaces. Violations carry heavy fines.
-  id: 77
-- id: 78
-  category: safe_driving_rules
-  question: When parking next to a curb, how far away from the curb must your wheels
-    be?
-  choices:
-    A: No more than 6 inches
-    B: No more than 12 inches
-    C: No more than 18 inches
-    D: No more than 24 inches
-  answer: C
-  explanation: When you park alongside a curb on a level street, the front and back
-    wheels must be parallel and within 18 inches of the curb.
-- id: 79
-  category: sharing_the_road
-  question: You are driving on a road with a lane marked for high-occupancy vehicles
-    (HOV). What is the primary purpose of this lane?
-  choices:
-    A: To allow drivers to pass slower traffic
-    B: To provide a dedicated lane for emergency vehicles
-    C: To encourage carpooling and reduce traffic congestion
-    D: To serve as an extra lane during rush hour for all vehicles
-  answer: C
-  explanation: The purpose of HOV lanes is to promote carpooling and ridesharing to
-    move more people with fewer vehicles, thereby reducing traffic congestion.
-- id: 80
-  category: safe_driving_rules
-  question: It is illegal to park your vehicle within how many feet of a fire hydrant?
-  choices:
-    A: 10 feet
-    B: 15 feet
-    C: 20 feet
-    D: 25 feet
-  answer: B
-  explanation: Never park within 15 feet of a fire hydrant. This ensures emergency
-    vehicles have adequate access.
-- id: 81
-  category: safe_driving_rules
-  question: What is the proper procedure to use a center left-turn lane?
-  choices:
-    A: Enter the lane as early as possible to wait for a gap in traffic
-    B: Use the lane to pass slower vehicles before making your turn
-    C: Drive in the lane for no more than 200 feet before making your turn
-    D: Only enter the lane after coming to a complete stop in the regular travel lane
-  answer: C
-  explanation: The center left-turn lane should not be used for travel. You may only
-    drive for 200 feet in the center left-turn lane before making your turn.
-- id: 82
-  category: license_system
-  question: A driver with a provisional license (under 18) has what restriction regarding
-    passengers during the first 12 months?
-  choices:
-    A: They cannot transport any passengers
-    B: They cannot transport passengers under 20 years old, unless a licensed parent
-      or guardian is also in the vehicle
-    C: They can only transport immediate family members
-    D: They can transport anyone as long as it is during daylight hours
-  answer: B
-  explanation: For the first 12 months, a provisional driver cannot transport passengers
-    under 20 years old, unless they are accompanied by a licensed parent, guardian,
-    or other specified adult.
-- id: 83
-  category: safe_driving_rules
-  question: What does a curb painted blue indicate?
-  choices:
-    A: Loading zone for commercial vehicles only
-    B: Parking for a limited time, as indicated by a sign
-    C: Parking for persons with a disabled placard or license plates
-    D: No stopping, standing, or parking
-  answer: C
-  explanation: Blue curbs indicate parking is permitted only for a disabled person
-    who displays a placard or special license plates for disabled persons.
-- id: 84
-  category: safe_driving_rules
-  question: At a 'T' intersection without signs or signals, which vehicle has the
-    right-of-way?
-  choices:
-    A: The vehicle on the terminating road must yield to vehicles on the through road
-    B: The vehicle on the through road must yield to vehicles on the terminating road
-    C: The vehicle that arrived first has the right-of-way
-    D: The vehicle turning left has the right-of-way
-  answer: A
-  explanation: At a 'T' intersection where one road ends, traffic on the terminating
-    road must yield the right-of-way to all traffic on the through road.
-- id: 85
-  category: safe_driving_rules
-  question: 'When driving in heavy fog, you should use your:'
-  choices:
-    A: High-beam headlights
-    B: Low-beam headlights
-    C: Parking lights only
-    D: Emergency flashers
-  answer: B
-  explanation: In heavy fog, use your low-beam headlights. High beams will reflect
-    off the fog and cause glare, making it more difficult to see.
-- id: 86
-  category: penalties_and_points
-  question: For how long do most traffic violation points typically stay on your driving
-    record?
-  choices:
-    A: 12 months
-    B: 24 months
-    C: 39 months
-    D: 60 months
-  answer: C
-  explanation: A traffic conviction for a minor violation will generally stay on your
-    record for 39 months (3 years and 3 months).
-- id: 87
-  category: safe_driving_rules
-  question: When two vehicles meet on a steep, narrow mountain road where neither
-    can pass, who has the right-of-way?
-  choices:
-    A: The vehicle going uphill
-    B: The vehicle going downhill
-    C: The vehicle that is larger
-    D: The vehicle that reached the narrow spot first
-  answer: A
-  explanation: The vehicle facing downhill must yield the right-of-way by backing
-    up until the vehicle going uphill can pass. The vehicle facing downhill has greater
-    control when backing up.
-- id: 88
-  category: defensive_driving
-  question: 'To maintain a safe space cushion and see farther down the road, you should
-    scan your surroundings by looking ahead:'
-  choices:
-    A: 1-2 seconds
-    B: 3-5 seconds
-    C: 5-8 seconds
-    D: 10-15 seconds
-  answer: D
-  explanation: To avoid last-minute moves, you should scan the road 10-15 seconds
-    ahead of your vehicle so you can see hazards before you reach them.
-- id: 89
-  category: sharing_the_road
-  question: When you see a 'safety zone' marked by raised buttons or markers on a
-    roadway, what should you do?
-  choices:
-    A: You may drive through it if no pedestrians are present
-    B: You must not drive through the safety zone at any time
-    C: You may use it to make a left turn
-    D: You may drive through it at a speed no greater than 10 mph
-  answer: B
-  explanation: A safety zone is an area set aside for pedestrians. It is illegal to
-    drive through a safety zone at any time or for any reason.
-- id: 90
-  category: license_system
-  question: A minor (under 18) with a provisional license is not permitted to drive
-    between what hours, with some exceptions?
-  choices:
-    A: 10 p.m. and 6 a.m.
-    B: 11 p.m. and 5 a.m.
-    C: Midnight and 6 a.m.
-    D: 9 p.m. and 5 a.m.
-  answer: B
-  explanation: During the first 12 months of having a provisional license, a minor
-    cannot drive between 11 p.m. and 5 a.m., unless accompanied by a specified adult
-    or for valid exceptions.
-- id: 91
-  category: safe_driving_rules
-  question: What is the meaning of a curb painted green?
-  choices:
-    A: No stopping or parking
-    B: Parking for a limited time
-    C: Loading and unloading of passengers or freight
-    D: Parking for disabled persons only
-  answer: B
-  explanation: A green curb indicates that parking is allowed for a limited time.
-    The time limit may be posted on a sign or painted on the curb.
-- id: 92
-  category: defensive_driving
-  question: 'If your vehicle starts to hydroplane on a wet road, you should:'
-  choices:
-    A: Brake firmly to regain traction
-    B: Accelerate to get through the water quickly
-    C: Slow down gradually by easing your foot off the gas pedal
-    D: Turn the steering wheel sharply in the opposite direction of the skid
-  answer: C
-  explanation: If your vehicle begins to hydroplane, do not brake or turn suddenly.
-    Ease your foot off the gas pedal until the vehicle slows and you can feel the
-    road again.
-- id: 93
-  category: vehicle_information
-  question: 'It is legal to use your vehicle''s horn to:'
-  choices:
-    A: Urge a slow-moving driver to speed up
-    B: Alert other drivers that they made a mistake
-    C: Help avoid a collision
-    D: Greet a friend you see on the sidewalk
-  answer: C
-  explanation: The horn should only be used to ensure safe driving, such as to avoid
-    collisions, alert another driver of a hazard, or alert oncoming traffic on narrow
-    mountain roads.
-- id: 94
-  category: safe_driving_rules
-  question: 'If you arrive at an intersection where the traffic signals are not working,
-    you should:'
-  choices:
-    A: Slow down and proceed with caution
-    B: Stop, then proceed when it is safe
-    C: Treat the intersection as an uncontrolled intersection and yield to the right
-    D: Treat the intersection as a four-way stop
-  answer: D
-  explanation: If traffic signals are not working, you must treat the intersection
-    as if it were a four-way stop. Stop, yield to vehicles and pedestrians already
-    in the intersection, and then proceed when it is your turn.
-- id: 95
-  category: penalties_and_points
-  question: What is the penalty for abandoning an animal on a highway?
-  choices:
-    A: A warning from a peace officer
-    B: A small fine of up to $100
-    C: A fine of up to $1,000 and/or six months in jail
-    D: Community service only
-  answer: C
-  explanation: Abandoning an animal on a highway is a misdemeanor punishable by a
-    fine of up to $1,000, up to six months in jail, or both.
-- id: 96
-  category: safe_driving_rules
-  question: 'When making a left turn from a two-way street onto a one-way street,
-    you should start your turn from:'
-  choices:
-    A: The far right lane
-    B: Any lane, as long as you signal
-    C: The lane closest to the center line
-    D: The right-hand turn lane
-  answer: C
-  explanation: Begin the turn from the lane closest to the middle of the street (the
-    center line). Turn into any lane on the one-way street that is safely open.
-- id: 97
-  category: sharing_the_road
-  question: 'When sharing the road with a light-rail vehicle or streetcar, you should
-    be aware that:'
-  choices:
-    A: They can stop more quickly than a standard vehicle
-    B: They always have the right-of-way
-    C: You can pass them on the left or right side
-    D: They can interrupt traffic signals
-  answer: D
-  explanation: Be aware that light-rail vehicles can interrupt traffic signals to
-    ensure they can proceed through intersections without stopping.
-- id: 98
-  category: defensive_driving
-  question: If your accelerator becomes stuck and your vehicle keeps accelerating,
-    what is one of the first things you should do?
-  choices:
-    A: Turn off the ignition immediately
-    B: Shift to neutral and apply the brakes
-    C: Pump the gas pedal several times
-    D: Attempt to unstick the pedal with your hand
-  answer: B
-  explanation: If your accelerator gets stuck, you should shift your vehicle to neutral
-    and apply the brakes. This will disengage the engine from the wheels, allowing
-    you to slow down and stop safely.
-- id: 99
-  category: safe_driving_rules
-  question: What does 'double parking' mean, and is it legal?
-  choices:
-    A: Parking in a space for two cars; it is legal
-    B: Parking on the wrong side of the street; it is illegal
-    C: Parking in the street alongside a car that is already parked at the curb; it
-      is illegal
-    D: Parking for twice the posted time limit; it is illegal
-  answer: C
-  explanation: Double parking is when you park in the street on the side of another
-    vehicle that is stopped or parked at the curb. It is illegal and blocks the normal
-    flow of traffic.
-- id: 100
-  category: vehicle_information
-  question: What is the minimum legal tread depth for tires on a passenger vehicle
-    in California?
-  choices:
-    A: 1/32 of an inch
-    B: 1/16 of an inch
-    C: 3/32 of an inch
-    D: 4/32 of an inch
-  answer: A
-  explanation: The law requires that your tires have a minimum tread depth of 1/32
-    of an inch in any two adjacent grooves. Insufficient tread depth is unsafe.
-- id: 101
-  category: alcohol_drugs_health
-  question: 'If you are convicted of a first DUI, a court may sentence you to serve
-    up to:'
-  choices:
-    A: 48 hours in jail
-    B: 30 days in jail
-    C: 6 months in jail
-    D: 1 year in jail
-  answer: C
-  explanation: Penalties for a first DUI conviction can include up to 6 months in
-    jail, along with fines, fees, and a mandatory driver license suspension.
-- id: 102
-  category: signs_and_signals
-  question: What does a round yellow sign with a black 'X' and 'RR' letters indicate?
-  choices:
-    A: A crossroad ahead
-    B: A hospital zone ahead
-    C: You are approaching a railroad crossing
-    D: A road closure ahead
-  answer: C
-  explanation: A round yellow sign with a black 'X' and 'RR' is an advance warning
-    sign that you are approaching a railroad crossing. You should slow down, look,
-    and listen for a train.
-- id: 103
-  category: sharing_the_road
-  question: What is a key safety rule when sharing the road with light-rail vehicles?
-  choices:
-    A: You may turn in front of an approaching light-rail vehicle if you have a green
-      light.
-    B: Never turn in front of an approaching light-rail vehicle.
-    C: It is safe to drive on the light-rail tracks if there is no train in sight.
-    D: Light-rail vehicles must yield the right-of-way to cars at intersections.
-  answer: B
-  explanation: The manual emphasizes to never turn in front of an approaching light-rail
-    vehicle, as they move more quickly than freight trains and cannot stop quickly.
-- id: 104
-  category: license_system
-  question: 'For the first 12 months of having a provisional driver''s license, a
-    minor may not drive between 11 p.m. and 5 a.m. or transport passengers under 20
-    years of age unless:'
-  choices:
-    A: They are driving to a school-sponsored event.
-    B: They have a signed note from a parent or guardian.
-    C: They are accompanied by a licensed California parent, guardian, or other specified
-      adult 25 years of age or older.
-    D: They have completed an additional 10 hours of driving practice.
-  answer: C
-  explanation: A minor with a provisional license has strict time and passenger restrictions
-    for the first year, which are waived if they are accompanied by a licensed parent,
-    guardian, or other specified adult 25 years of age or older.
-- id: 105
-  category: signs_and_signals
-  question: 'A curb painted blue indicates a parking space reserved for:'
-  choices:
-    A: Loading and unloading of passengers or mail only.
-    B: Short-term parking, with the time limit posted on a sign.
-    C: Loading and unloading of freight only.
-    D: Persons with a disabled person placard or license plates.
-  answer: D
-  explanation: A blue curb indicates parking is reserved for persons with disabilities
-    who have a valid placard or special license plates.
-- id: 106
-  category: alcohol_drugs_health
-  question: If you are taking prescription or over-the-counter medication, what is
-    your responsibility before driving?
-  choices:
-    A: Assume it is safe to drive unless the label explicitly says 'Do not operate
-      heavy machinery.'
-    B: Read the warning labels and be aware of any potential side effects that could
-      impair your driving.
-    C: Only take half the prescribed dose if you plan to drive.
-    D: It is always legal to drive after taking any prescribed medication.
-  answer: B
-  explanation: It is your responsibility to know the effects of any medication you
-    take. Many prescription and over-the-counter drugs can cause drowsiness or dizziness,
-    making it unsafe to drive.
-- id: 107
-  category: sharing_the_road
-  question: When are you legally allowed to drive in a bicycle lane?
-  choices:
-    A: When you are within 200 feet of a turn you need to make.
-    B: When the main traffic lanes are blocked or congested.
-    C: To pass a slower vehicle ahead of you.
-    D: Never, it is for bicycles only.
-  answer: A
-  explanation: You may enter a bicycle lane to park (where permitted), to enter or
-    leave the roadway, or to prepare for a turn within 200 feet of the intersection.
-- id: 108
-  category: penalties_and_points
-  question: Under the Negligent Operator Treatment System (NOTS), you may be considered
-    a negligent operator if you get how many points on your driving record in 12 months?
-  choices:
-    A: 2 points
-    B: 4 points
-    C: 6 points
-    D: 8 points
-  answer: B
-  explanation: The DMV may consider you a negligent operator if you accumulate 4 points
-    in 12 months, 6 points in 24 months, or 8 points in 36 months, which can lead
-    to license probation or suspension.
-- id: 109
-  category: safe_driving_rules
-  question: In which of the following situations should you use your horn?
-  choices:
-    A: To express anger or frustration at another driver.
-    B: To get a slow driver to speed up.
-    C: To help avoid a collision by alerting another driver of your presence.
-    D: To greet a friend you see on the sidewalk.
-  answer: C
-  explanation: Your horn should only be used as a safety warning to help avoid collisions.
-    For example, use your horn to alert another driver who is in danger of hitting
-    you, or on narrow mountain roads where you cannot see at least 200 feet ahead.
-- id: 110
-  category: sharing_the_road
-  question: Regarding motorcyclists 'lane splitting' (riding between lanes of traffic),
-    which statement is true in California?
-  choices:
-    A: It is always illegal and highly dangerous.
-    B: It is legal, but motorcyclists should do so in a safe and prudent manner.
-    C: It is only legal on freeways with more than four lanes.
-    D: It is only legal when traffic is moving faster than 30 mph.
-  answer: B
-  explanation: California law allows for motorcycle lane splitting or filtering, provided
-    it is done in a safe and prudent manner. Drivers of other vehicles should be aware
-    of this and check their blind spots for motorcycles.
-- id: 111
-  category: signs_and_signals
-  question: 'When entering a roundabout, you must yield to:'
-  choices:
-    A: Vehicles on your right.
-    B: All vehicles, pedestrians, and bicyclists already in the roundabout.
-    C: All vehicles waiting to enter the roundabout.
-    D: Vehicles on your left that are signaling to exit.
-  answer: B
-  explanation: When approaching a roundabout, you must slow down and yield to all
-    traffic, including pedestrians and bicyclists, that is already circulating within
-    the roundabout.
-- id: 112
-  category: safe_driving_rules
-  question: To maintain the best control of your vehicle, especially one equipped
-    with airbags, where should you place your hands on the steering wheel?
-  choices:
-    A: At the 10 and 2 o'clock positions.
-    B: At the 8 and 4 o'clock positions.
-    C: Both hands at the top of the wheel.
-    D: One hand at the 12 o'clock position.
-  answer: B
-  explanation: The recommended hand positions are 9 and 3 o'clock or, to reduce the
-    risk of hand and arm injury from an airbag, a lower position such as 8 and 4 o'clock.
-    This provides better stability and safety.
-- id: 113
-  category: signs_and_signals
-  question: 'A curb painted green means you may park for:'
-  choices:
-    A: A limited time, as indicated by a posted sign or marking.
-    B: As long as you wish, provided you remain in your vehicle.
-    C: Loading or unloading passengers or mail only.
-    D: Emergency stopping only.
-  answer: A
-  explanation: A green curb indicates that parking is permitted for a limited time.
-    The time limit is usually shown on a nearby sign or painted on the curb itself.
-- id: 114
-  category: driver_responsibility
-  question: 'If you move, you must notify the DMV of your new address within:'
-  choices:
-    A: 5 days.
-    B: 10 days.
-    C: 30 days.
-    D: 60 days.
-  answer: B
-  explanation: California law requires you to notify the DMV of a change of address
-    within 10 days of moving. This can be done online, by mail, or in person.
-- id: 115
-  category: safe_driving_rules
-  question: You should signal your intention to turn at least how many feet before
-    making the turn?
-  choices:
-    A: 50 feet
-    B: 100 feet
-    C: 200 feet
-    D: 300 feet
-  answer: B
-  explanation: To alert other drivers, you should signal during the last 100 feet
-    before turning. Signaling earlier or later can confuse other drivers.
-- id: 116
-  category: sharing_the_road
-  question: When encountering a funeral procession, what is the proper and respectful
-    action to take?
-  choices:
-    A: You should yield the right-of-way to all vehicles in the procession.
-    B: You may interrupt or cut through the procession if you have a green light.
-    C: You should honk to show respect.
-    D: You can join the end of the procession to get through traffic faster.
-  answer: A
-  explanation: Out of respect, and for safety, drivers should yield the right-of-way
-    to all vehicles in a funeral procession. Do not cut through, join, or otherwise
-    interfere with the procession.
-- id: 117
-  category: signs_and_signals
-  question: 'A flashing yellow arrow traffic signal means:'
-  choices:
-    A: Stop and wait for a green arrow.
-    B: The protected turning time period is about to end.
-    C: You may turn in the direction of the arrow, but you must first yield to oncoming
-      traffic and pedestrians.
-    D: The traffic signal is broken; treat it as a stop sign.
-  answer: C
-  explanation: A flashing yellow arrow indicates that turns are permitted (unprotected),
-    but you must first yield to oncoming traffic and pedestrians before proceeding.
-- id: 118
-  category: alcohol_drugs_health
-  question: 'California''s ''Implied Consent'' law means that by driving a motor vehicle,
-    you have agreed to:'
-  choices:
-    A: Always have your driver's license with you.
-    B: Take a chemical test (breath, blood, or urine) for alcohol or drugs if requested
-      by a peace officer.
-    C: Consent to a search of your vehicle at any time.
-    D: Automatically be at fault in any collision you are involved in.
-  answer: B
-  explanation: The Implied Consent law states that if you are lawfully arrested for
-    a DUI, you have consented to take a chemical test to determine your blood alcohol
-    concentration (BAC) or the presence of drugs. Refusing this test has separate,
-    serious consequences.
-- id: 119
-  category: driver_testing
-  question: During your behind-the-wheel driving test, you will be asked to locate
-    and demonstrate the use of certain vehicle controls. Which of the following is
-    NOT a required item on this pre-drive checklist?
-  choices:
-    A: Windshield wipers
-    B: Defroster
-    C: Emergency flashers
-    D: Radio or audio system
-  answer: D
-  explanation: Before the driving test begins, the examiner will ask you to demonstrate
-    the operation of safety-critical equipment like headlights, wipers, defroster,
-    horn, and emergency flashers. The radio/audio system is not a required safety
-    item.
-- id: 120
-  category: sharing_the_road
-  question: What is a key characteristic of Neighborhood Electric Vehicles (NEVs)
-    that other drivers should be aware of?
-  choices:
-    A: They are allowed on all California freeways.
-    B: They reach a top speed of only 25 mph.
-    C: They are heavier and stop more slowly than standard cars.
-    D: They are only allowed to drive during daylight hours.
-  answer: B
-  explanation: NEVs are restricted to roads with a speed limit of 35 mph or less and
-    can only reach a maximum speed of 25 mph. Other drivers should be aware of their
-    lower speed and the potential for them to cause backups in faster-moving traffic.
-- id: 121
-  category: driver_testing
-  question: According to the website's CSS code, what is the pixel value assigned
-    to the 'huge' font size preset?
-  choices:
-    A: 32px
-    B: 40px
-    C: 42px
-    D: 50px
-  answer: B
-  explanation: 'The provided CSS defines the variable as `--wp--preset--font-size--huge:
-    40px;`.'
-- id: 122
-  category: driver_responsibility
-  question: The website's code includes a script to load a specific font from Google.
-    What is this font family called?
-  choices:
-    A: Arial
-    B: Times New Roman
-    C: Playfair Display
-    D: Courier New
-  answer: C
-  explanation: 'The JavaScript snippet contains `WebFontConfig = { google: { families:
-    [ ''Playfair+Display:400,700'' ] } };`, indicating the ''Playfair Display'' font
-    is being loaded.'
-- id: 123
-  category: signs_and_signals
-  question: In the website's CSS, what is the name of the preset gradient that transitions
-    from `rgb(2,3,129)` to `rgb(40,116,252)`?
-  choices:
-    A: Pale Ocean
-    B: Luminous Dusk
-    C: Midnight
-    D: Cool to Warm Spectrum
-  answer: C
-  explanation: 'The CSS code defines `--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)
-    0%,rgb(40,116,252) 100%);`.'
-- id: 124
-  category: driver_responsibility
-  question: What is the `id` attribute of the HTML button element designed to show
-    the website's chatbot?
-  choices:
-    A: chatbot__show-btn
-    B: js-chatbot-dialog
-    C: js-chatbot-show
-    D: GTM-KHCVGH4
-  answer: C
-  explanation: The provided HTML for the button is `<button id="js-chatbot-show" ...>`.
-- id: 125
-  category: vehicle_information
-  question: The website's code includes an iframe for Google Tag Manager. What is
-    the ID specified for this service?
-  choices:
-    A: GTM-KHCVGH4
-    B: GTM-1234567
-    C: UA-XXXXX-Y
-    D: G-ABCDEFG
-  answer: A
-  explanation: The iframe's `src` attribute is 'https://www.googletagmanager.com/ns.html?id=GTM-KHCVGH4'.
-- id: 126
-  category: driver_testing
-  question: What is the defined value for the CSS preset spacing variable `--wp--preset--spacing--50`?
-  choices:
-    A: 1rem
-    B: 1.5rem
-    C: 2.25rem
-    D: 0.67rem
-  answer: B
-  explanation: 'The provided CSS code includes the definition: `--wp--preset--spacing--50:
-    1.5rem;`.'
-- id: 127
-  category: signs_and_signals
-  question: The CSS defines a preset color named 'luminous-vivid-amber'. What is its
-    corresponding hex color value?
-  choices:
-    A: '#f78da7'
-    B: '#ff6900'
-    C: '#fcb900'
-    D: '#00d084'
-  answer: C
-  explanation: 'The provided CSS defines the variable `--wp--preset--color--luminous-vivid-amber:
-    #fcb900;`.'
-- id: 128
-  category: signs_and_signals
-  question: According to the CSS styles, what is the name of the shadow preset defined
-    as `12px 12px 50px rgba(0, 0, 0, 0.4)`?
-  choices:
-    A: Natural
-    B: Sharp
-    C: Outlined
-    D: Deep
-  answer: D
-  explanation: The CSS variable `--wp--preset--shadow--deep` is defined as `12px 12px
-    50px rgba(0, 0, 0, 0.4);`.
-- id: 129
-  category: driver_testing
-  question: What is the pixel value for the CSS font size preset named 'normal'?
-  choices:
-    A: 18px
-    B: 21px
-    C: 28px
-    D: 32px
-  answer: B
-  explanation: 'The CSS code defines the preset font size as `--wp--preset--font-size--normal:
-    21px;`.'
-- id: 130
-  category: signs_and_signals
-  question: Which CSS preset gradient is defined as a transition from `rgb(202,248,128)`
-    to `rgb(113,206,126)`?
-  choices:
-    A: Electric Grass
-    B: Pale Ocean
-    C: Light Green Cyan to Vivid Green Cyan
-    D: Luminous Dusk
-  answer: A
-  explanation: 'The CSS defines `--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)
-    0%,rgb(113,206,126) 100%);`.'
-- id: 131
-  category: driver_responsibility
-  question: A JavaScript snippet in the code is designed to modify the `<html>` element
-    upon loading. What class name does it replace?
-  choices:
-    A: js
-    B: no-js
-    C: wf-active
-    D: is-layout-flex
-  answer: B
-  explanation: The script contains the line `document.documentElement.className =
-    document.documentElement.className.replace('no-js', " ");`, which removes the
-    'no-js' class.
-- id: 132
-  category: signs_and_signals
-  question: What is the hex color code for the preset color named 'vivid-red'?
-  choices:
-    A: '#cf2e2e'
-    B: '#ff6900'
-    C: '#fcb900'
-    D: '#72aee6'
-  answer: A
-  explanation: 'The provided CSS defines the variable `--wp--preset--color--vivid-red:
-    #cf2e2e;`.'
-- id: 133
-  category: driver_testing
-  question: The CSS code defines a preset for 'x-large' font size. What is its value
-    in pixels?
-  choices:
-    A: 28px
-    B: 32px
-    C: 40px
-    D: 42px
-  answer: D
-  explanation: 'The CSS variable is defined as `--wp--preset--font-size--x-large:
-    42px;`.'
-- id: 134
-  category: signs_and_signals
-  question: What is the definition of the 'crisp' shadow preset in the website's CSS?
-  choices:
-    A: 6px 6px 9px rgba(0, 0, 0, 0.2)
-    B: 12px 12px 50px rgba(0, 0, 0, 0.4)
-    C: 6px 6px 0px rgb(0, 0, 0)
-    D: 6px 6px 0px -3px rgb(255, 255, 255), 6px 6px rgb(0, 0, 0)
-  answer: C
-  explanation: 'The CSS defines the preset as `--wp--preset--shadow--crisp: 6px 6px
-    0px rgb(0, 0, 0);`.'
-- id: 135
-  category: driver_responsibility
-  question: The JavaScript code in the provided text loads a webfont script. From
-    what source protocol does it load the script?
-  choices:
-    A: Always 'https'
-    B: Always 'http'
-    C: Whichever protocol the page is currently using
-    D: FTP
-  answer: C
-  explanation: 'The script builds the source URL using `(''https:'' == document.location.protocol
-    ? ''https'' : ''http'') + ''://ajax.googleapis.com/...''`, which matches the current
-    page''s protocol.'
-- id: 136
-  category: signs_and_signals
-  question: Which preset gradient is defined by a linear gradient starting at `rgb(255,205,210)`
-    and ending at `rgb(198,40,40)`?
-  choices:
-    A: blush-light-purple
-    B: luminous-dusk
-    C: blush-bordeaux
-    D: luminous-vivid-orange-to-vivid-red
-  answer: C
-  explanation: 'The CSS code defines `--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(255,205,210)
-    0%,rgb(198,40,40) 100%);`.'
-- id: 137
-  category: driver_testing
-  question: What is the value of the smallest spacing preset, `--wp--preset--spacing--20`?
-  choices:
-    A: 0.44rem
-    B: 0.5em
-    C: 0.67rem
-    D: 1rem
-  answer: A
-  explanation: 'The CSS code defines the variable as `--wp--preset--spacing--20: 0.44rem;`.'
-- id: 138
-  category: driver_testing
-  question: What is the pixel value of the 'large' font size preset defined in the
-    website's CSS?
-  choices:
-    A: 21px
-    B: 28px
-    C: 32px
-    D: 40px
-  answer: C
-  explanation: 'The CSS defines the preset as `--wp--preset--font-size--large: 32px;`.'
-- id: 139
-  category: signs_and_signals
-  question: The CSS defines a shadow preset called 'outlined'. What is its specific
-    CSS definition?
-  choices:
-    A: 6px 6px 9px rgba(0, 0, 0, 0.2)
-    B: 12px 12px 50px rgba(0, 0, 0, 0.4)
-    C: 6px 6px 0px rgb(0, 0, 0)
-    D: 6px 6px 0px -3px rgb(255, 255, 255), 6px 6px rgb(0, 0, 0)
-  answer: D
-  explanation: 'The CSS variable is defined as `--wp--preset--shadow--outlined: 6px
-    6px 0px -3px rgb(255, 255, 255), 6px 6px rgb(0, 0, 0);`.'
-- id: 140
-  category: signs_and_signals
-  question: Which CSS color preset is assigned the hex code `#abb8c3`?
-  choices:
-    A: white
-    B: black
-    C: cyan-bluish-gray
-    D: pale-cyan-blue
-  answer: C
-  explanation: 'The CSS code includes the definition: `--wp--preset--color--cyan-bluish-gray:
-    #abb8c3;`.'
-- id: 141
-  category: driver_testing
-  question: The CSS code defines a preset spacing value of `5.06rem`. What is the
-    name of this spacing preset?
-  choices:
-    A: --wp--preset--spacing--60
-    B: --wp--preset--spacing--70
-    C: --wp--preset--spacing--80
-    D: --wp--preset--spacing--90
-  answer: C
-  explanation: 'The CSS defines `--wp--preset--spacing--80: 5.06rem;`.'
-- id: 142
-  category: signs_and_signals
-  question: The 'pale-ocean' gradient preset transitions between which two types of
-    colors?
-  choices:
-    A: A pale yellow to shades of blue-green
-    B: A light green to a darker green
-    C: A light purple to a dark blue
-    D: A light gray to a dark gray
-  answer: A
-  explanation: The CSS defines `--wp--preset--gradient--pale-ocean` with `rgb(255,245,203)`
-    (a pale yellow) and `rgb(182,227,212)` / `rgb(51,167,181)` (shades of blue-green).
-- id: 143
-  category: driver_responsibility
-  question: According to the JavaScript snippet, what does the code set the `async`
-    property of the new script element to?
-  choices:
-    A: 'false'
-    B: 'true'
-    C: '1'
-    D: It does not set the async property.
-  answer: B
-  explanation: The provided JavaScript contains the line `wf.async = 'true';`, which
-    sets the asynchronous property for the webfont loader script.
-- id: 144
-  category: driver_responsibility
-  question: According to the Secretary's Message, the California Driver's Handbook
-    is available in how many different languages to assist a diverse population of
-    drivers?
-  choices:
-    A: Three
-    B: Five
-    C: Seven
-    D: Nine
-  answer: D
-  explanation: The Secretary's Message in the handbook states, 'The California Driver’s
-    Handbook is available in nine languages and offers valuable information for Californians...'
-- id: 145
-  category: penalties_and_points
-  question: Which of the following specific payment types can be handled through the
-    DMV's online 'Make a Payment' portal?
-  choices:
-    A: Parking ticket fines
-    B: Dishonored check payments
-    C: Court-ordered restitution
-    D: Vehicle impound fees
-  answer: B
-  explanation: The text lists 'Dishonored Check Payment' as a specific option under
-    the 'Make a Payment' menu on the DMV website.
-- id: 146
-  category: license_system
-  question: The DMV website invites users to participate in a pilot program for what
-    new type of license under the 'Driver's Licenses & IDs' section?
-  choices:
-    A: A digital REAL ID
-    B: A mobile Driver's License (mDL)
-    C: An international driving permit
-    D: A temporary paper license
-  answer: B
-  explanation: Under the 'Driver's Licenses & IDs' menu, the option 'Join the mDL
-    Pilot' is listed, referring to the mobile Driver's License pilot program.
-- id: 147
-  category: driver_testing
-  question: Besides Driver Handbooks and Practice Tests, what other resource is offered
-    under the 'Testing' menu on the DMV website to help prepare drivers?
-  choices:
-    A: Live instructor Q&A sessions
-    B: A driving simulator
-    C: How-To Videos
-    D: A list of certified driving schools
-  answer: C
-  explanation: The 'Testing' menu on the DMV website lists 'How-To Videos' as a resource
-    for drivers, in addition to handbooks and practice tests.
-- id: 148
-  category: license_system
-  question: Which of the following is a specific case status you can check using the
-    DMV's online services?
-  choices:
-    A: Traffic school completion status
-    B: Vehicle smog check status
-    C: Driver Safety Case Status
-    D: Insurance claim status
-  answer: C
-  explanation: The 'Check Status' menu on the DMV website includes an option to check
-    'Driver Safety Case Status'.
-- id: 149
-  category: driver_responsibility
-  question: When using the DMV Virtual Assistant, what specific type of information
-    are you explicitly warned NOT to include in your chat?
-  choices:
-    A: Your driver's license number
-    B: Any personal information
-    C: Your vehicle's license plate number
-    D: Questions about traffic tickets
-  answer: B
-  explanation: The General Disclaimer for the DMV Virtual Assistant states, '...please
-    do not include any personal information.'
-- id: 150
-  category: vehicle_information
-  question: According to the DMV's online services menu, which of these tasks related
-    to vehicle registration can be completed online?
-  choices:
-    A: Submitting proof of insurance
-    B: Getting a vehicle safety inspection
-    C: Disputing a registration fee
-    D: Applying for a salvage title
-  answer: A
-  explanation: The 'Vehicle Registration' menu on the DMV website lists 'Submit Proof
-    of Insurance' as an available online service.
-- id: 151
-  category: sharing_the_road
-  question: Which section of the California Driver's Handbook specifically addresses
-    topics relevant to older drivers?
-  choices:
-    A: 'Section 8: Safe Driving'
-    B: 'Section 12: Driver Safety'
-    C: 'Section 13: Seniors and Driving'
-    D: 'Section 14: Glossary'
-  answer: C
-  explanation: 'The Table of Contents shows that ''Section 13: Seniors and Driving''
-    is dedicated to this topic.'
-- id: 152
-  category: penalties_and_points
-  question: Under the 'Make a Payment' section of the DMV website, which fee is specifically
-    listed as payable online?
-  choices:
-    A: A driver education course fee
-    B: A court traffic violation fine
-    C: A license reinstatement fee
-    D: A private parking citation
-  answer: C
-  explanation: The 'Make a Payment' menu on the DMV website explicitly lists 'Pay
-    Reinstatement Fee' as an online service.
-- id: 153
-  category: vehicle_information
-  question: If you need an official copy of your vehicle's history, which option should
-    you select from the DMV's online 'Vehicle Registration' menu?
-  choices:
-    A: New Registration
-    B: Request Vehicle Record
-    C: Renew Registration
-    D: Plates, Stickers, Placards
-  answer: B
-  explanation: The 'Vehicle Registration' menu includes the option 'Request Vehicle
-    Record' for obtaining a vehicle's history.
-- id: 154
-  category: driver_responsibility
-  question: The Secretary's Message states that a driver's license provides the opportunity
-    to travel to various places. Which of the following is NOT specifically mentioned
-    as a destination?
-  choices:
-    A: Essential services
-    B: A favorite vacation spot
-    C: International borders
-    D: Education
-  answer: C
-  explanation: The Secretary's Message mentions a license offers travel to 'essential
-    services, a favorite vacation spot, education, loved ones,' but does not mention
-    international borders.
-- id: 155
-  category: license_system
-  question: What is the title of Section 12 in the California Driver's Handbook?
-  choices:
-    A: Seniors and Driving
-    B: Vehicle Registration Requirements
-    C: Driver Safety
-    D: Alcohol and Drugs
-  answer: C
-  explanation: 'The Table of Contents lists ''Section 12: Driver Safety''.'
-- id: 156
-  category: driver_responsibility
-  question: What is the primary purpose of the machine translation services used for
-    the DMV chatbot, according to the disclaimer?
-  choices:
-    A: For legal compliance and enforcement
-    B: To provide a legally binding record of conversation
-    C: For information and convenience only
-    D: To guarantee the accuracy of all translated content
-  answer: C
-  explanation: The Third-Party Translation Disclaimer states, 'Machine translation
-    is provided for purposes of information and convenience only.'
-- id: 157
-  category: driver_testing
-  question: In addition to the Driver Handbooks, what other type of written material
-    is available under the 'Testing' menu on the DMV website?
-  choices:
-    A: DMV staff biographies
-    B: Specialty Driver Guides
-    C: Vehicle maintenance manuals
-    D: A list of traffic laws by county
-  answer: B
-  explanation: The 'Testing' menu on the DMV website lists 'Specialty Driver Guides'
-    as an available resource.
-- id: 158
-  category: license_system
-  question: According to the 'Check Status' menu, which of the following is NOT a
-    status you can check online?
-  choices:
-    A: Change of Address Status
-    B: DL/ID Renewal Status
-    C: Virtual Office Case Status
-    D: Driving School Accreditation Status
-  answer: D
-  explanation: The 'Check Status' menu lists Change of Address, DL/ID Renewal, and
-    Virtual Office Case statuses, but does not mention Driving School Accreditation.
-- id: 159
-  category: driver_responsibility
-  question: What warning does the DMV provide regarding saving a chat transcript from
-    the Virtual Assistant?
-  choices:
-    A: Transcripts are automatically deleted after 24 hours.
-    B: Transcripts are not legally admissible documents.
-    C: Use caution when using a public computer or device.
-    D: You must pay a fee to save the transcript.
-  answer: C
-  explanation: The General Disclaimer for the Virtual Assistant states, 'When your
-    chat is over, you can save the transcript. Use caution when using a public computer
-    or device.'
-- id: 160
-  category: license_system
-  question: If you need a copy of your own driving history, which option would you
-    choose from the 'Driver's Licenses & IDs' menu?
-  choices:
-    A: New DL/ID Card Application
-    B: Request Driver Record
-    C: Join the mDL Pilot
-    D: Renew DL/ID
-  answer: B
-  explanation: The 'Driver's Licenses & IDs' menu lists 'Request Driver Record' as
-    the service for obtaining a copy of your driving history.
-- id: 161
-  category: safe_driving_rules
-  question: The Secretary's Message emphasizes that all who use the roads must follow
-    the rules. Which of the following road users is NOT specifically mentioned in
-    this context?
-  choices:
-    A: Motorcycle riders
-    B: Pedestrians
-    C: Commercial vehicle drivers
-    D: Bicycle riders
-  answer: B
-  explanation: The Secretary's Message states, 'Whether driving a car, motorcycle,
-    commercial vehicle or riding a bicycle, it is critical we adhere to the rules...'
-    Pedestrians are not explicitly listed in this sentence.
-- id: 162
-  category: driver_responsibility
-  question: 'According to the handbook''s Table of Contents, which section immediately
-    follows ''Section 9: Alcohol and Drugs''?'
-  choices:
-    A: 'Section 8: Safe Driving (Continued)'
-    B: 'Section 11: Vehicle Registration Requirements'
-    C: 'Section 12: Driver Safety'
-    D: 'Section 10: Financial Responsibility, Insurance Requirements, and Collisions'
-  answer: D
-  explanation: The Table of Contents shows that Section 10, covering financial responsibility
-    and collisions, comes directly after Section 9 on alcohol and drugs.
-- id: 163
-  category: vehicle_information
-  question: Under which main menu on the DMV website would you find information about
-    replacing license plates, stickers, or placards?
-  choices:
-    A: Driver's Licenses & IDs
-    B: Make a Payment
-    C: Vehicle Registration
-    D: Check Status
-  answer: C
-  explanation: The 'Vehicle Registration' menu contains the sub-menu 'Plates, Stickers,
-    Placards'.
-- id: 164
-  category: penalties_and_points
-  question: What tool is provided under the 'Make a Payment' menu to help you determine
-    the cost of your vehicle registration?
-  choices:
-    A: Shopping Cart
-    B: Fee Calculator
-    C: Pay Late Registration Fee
-    D: Payments & Refunds
-  answer: B
-  explanation: The 'Make a Payment' menu lists a 'Fee Calculator' to help users determine
-    their fees.
-- id: 165
-  category: driver_responsibility
-  question: The introductory message in the California Driver's Handbook is from the
-    Secretary of which agency?
-  choices:
-    A: Department of Motor Vehicles
-    B: California Highway Patrol
-    C: California State Transportation Agency
-    D: Department of Justice
-  answer: C
-  explanation: The introductory message is signed by Toks Omishakin, Secretary of
-    the California State Transportation Agency.
-- id: 166
-  category: alcohol_drugs_health
-  question: The Secretary's message warns that operating a vehicle while distracted
-    or impaired could mean the difference between what?
-  choices:
-    A: A fine and a warning
-    B: Life and death
-    C: Keeping or losing your license
-    D: A misdemeanor and a felony
-  answer: B
-  explanation: The manual states, 'Do not operate a vehicle, motorcycle or bicycle
-    while distracted or impaired—it could mean the difference between life and death.'
-- id: 167
-  category: sharing_the_road
-  question: The warning to not operate while distracted or impaired applies to drivers
-    of vehicles, motorcycles, and what else?
-  choices:
-    A: Scooters
-    B: Skateboards
-    C: Commercial trucks
-    D: Bicycles
-  answer: D
-  explanation: 'The text explicitly states: ''Do not operate a vehicle, motorcycle
-    or bicycle while distracted or impaired...'''
-- id: 168
-  category: license_system
-  question: Why does the DMV recommend that you 'Try online first' for services like
-    renewals?
-  choices:
-    A: It is the only way to complete transactions
-    B: It can be a timesaver
-    C: It is required for all new drivers
-    D: It offers lower fees than in-person services
-  answer: B
-  explanation: The manual advises, 'Try online first, as it can be a timesaver.'
-- id: 169
-  category: driver_testing
-  question: In addition to various written languages, the California Driver's Handbook
-    is available as a video in which format?
-  choices:
-    A: Spanish with subtitles
-    B: Mandarin Chinese
-    C: American Sign Language
-    D: Audiobook format
-  answer: C
-  explanation: The manual provides an option for an 'American Sign Language Video'
-    available on YouTube.
-- id: 170
-  category: driver_testing
-  question: Which of the following is NOT one of the languages in which the PDF version
-    of the California Driver's Handbook is officially available?
-  choices:
-    A: Vietnamese
-    B: French
-    C: Russian
-    D: Punjabi
-  answer: B
-  explanation: The provided list of available languages for the PDF handbook includes
-    English, Spanish, Vietnamese, Russian, Armenian, Hindi, Punjabi, and Chinese,
-    but not French.
-- id: 171
-  category: driver_responsibility
-  question: According to the disclaimer, what is the DMV's position regarding the
-    accuracy of translations provided by Google™ Translate?
-  choices:
-    A: The DMV guarantees 95% accuracy
-    B: The DMV is unable to guarantee the accuracy
-    C: The DMV manually reviews all translations for accuracy
-    D: The DMV is liable for any minor inaccuracies
-  answer: B
-  explanation: The disclaimer states, 'The DMV is unable to guarantee the accuracy
-    of any translation provided by Google™ Translate and is therefore not liable for
-    any inaccurate information...'
-- id: 172
-  category: driver_responsibility
-  question: If any questions arise related to the information contained in a translated
-    version of the DMV website, what should you do?
-  choices:
-    A: Contact Google™ Translate support
-    B: Assume the translation is correct
-    C: File a formal complaint with the DMV
-    D: Refer to the English version
-  answer: D
-  explanation: The disclaimer advises, 'If any questions arise related to the information
-    contained in the translated website, please refer to the English version.'
-- id: 173
-  category: safe_driving_rules
-  question: What is the primary security instruction provided by the DMV when interacting
-    with its Virtual Assistant chatbot?
-  choices:
-    A: Speak clearly and slowly
-    B: Do not include any personal information
-    C: Only ask about vehicle registration
-    D: Have your driver's license number ready
-  answer: B
-  explanation: The disclaimer for the Virtual Assistant explicitly states, 'When interacting
-    with the Department of Motor Vehicles (DMV) Virtual Assistant, please do not include
-    any personal information.'
-- id: 174
-  category: license_system
-  question: The machine translation for the DMV chatbot and live chat services is
-    provided by whom?
-  choices:
-    A: DMV staff translators
-    B: Google™ Translate exclusively
-    C: Third-party vendors
-    D: An automated DMV system
-  answer: C
-  explanation: The disclaimer states, 'The DMV chatbot and live chat services use
-    third-party vendors to provide machine translation.'
-- id: 175
-  category: driver_responsibility
-  question: 'The Secretary''s message in the handbook emphasizes that driving or riding
-    is a:'
-  choices:
-    A: Constitutional right
-    B: Privilege
-    C: Mandatory skill
-    D: Lifelong requirement
-  answer: B
-  explanation: The text states, 'Remember that driving or riding is a privilege, and
-    above all, safety must be the priority.'
-- id: 176
-  category: safe_driving_rules
-  question: The Secretary's message advises drivers to put down their cell phone when
-    they are behind the wheel or what else?
-  choices:
-    A: In a parking lot
-    B: Stopped at a red light
-    C: Handlebars
-    D: In a school zone
-  answer: C
-  explanation: The message advises to 'put down that cell phone when behind the wheel
-    or handlebars,' referring to both cars and motorcycles/bicycles.
-- id: 177
-  category: driver_responsibility
-  question: The translation application tool on the DMV website is provided for what
-    stated purpose?
-  choices:
-    A: Legal compliance and enforcement
-    B: Official record-keeping
-    C: Replacing in-person translators
-    D: Information and convenience only
-  answer: D
-  explanation: The disclaimer states, 'This translation application tool is provided
-    for purposes of information and convenience only.'
-- id: 178
-  category: penalties_and_points
-  question: For compliance or enforcement purposes, what is considered the official
-    and accurate source for DMV program information?
-  choices:
-    A: The translated version of the website
-    B: The DMV Virtual Assistant
-    C: The web pages currently in English
-    D: A printed copy of the handbook
-  answer: C
-  explanation: The manual's disclaimer clarifies, 'The web pages currently in English
-    on the DMV website are the official and accurate source for the program information
-    and services the DMV provides.'
-- id: 179
-  category: license_system
-  question: According to the copyright information in the webpage footer, the State
-    of California holds the copyright for the content until which year?
-  choices:
-    A: '2024'
-    B: '2025'
-    C: '2026'
-    D: There is no copyright year listed
-  answer: C
-  explanation: The footer of the provided text includes the line 'Copyright &copy;
-    2026 State of California'.
-- id: 180
-  category: license_system
-  question: What is the stated goal of the DMV's efforts to modernize its interactions
-    with customers?
-  choices:
-    A: To eliminate all in-person appointments
-    B: To increase revenue from online fees
-    C: To make the digital experience easier, faster, and more convenient
-    D: To track driver behavior through online services
-  answer: C
-  explanation: The text states, 'The DMV has been modernizing interactions with its
-    customers, making Californians’ digital experience easier, faster and more convenient.'
-- id: 181
-  category: penalties_and_points
-  question: According to the disclaimer for the DMV's chatbot, what legal effect do
-    discrepancies created in a machine translation have?
-  choices:
-    A: They are legally binding if the user saves the transcript
-    B: They can be used for compliance but not enforcement
-    C: They are not binding and have no legal effect
-    D: They must be reported to the third-party vendor for correction
-  answer: C
-  explanation: The chatbot disclaimer states, 'Any discrepancies or differences created
-    in the translation are not binding and have no legal effect for compliance or
-    enforcement purposes.'
-- id: 182
-  category: safe_driving_rules
-  question: The Secretary of the California State Transportation Agency's message
-    states that above all else, what must be the priority when driving?
-  choices:
-    A: Speed
-    B: Convenience
-    C: Safety
-    D: Right-of-way
-  answer: C
-  explanation: The message clearly states, '...above all, safety must be the priority.'
-- id: 183
-  category: driver_responsibility
-  question: The DMV is not liable for inaccurate information or changes in page formatting
-    that result from using what?
-  choices:
-    A: The DMV Virtual Assistant
-    B: The Google™ Translate application tool
-    C: The online appointment system
-    D: The DMV's mobile application
-  answer: B
-  explanation: The disclaimer says the DMV 'is therefore not liable for any inaccurate
-    information or changes in the formatting of the pages resulting from the use of
-    the translation application tool.'
-- id: 184
-  category: license_system
-  question: The translation disclaimer specifies that Google™ Translate is a free
-    third-party service that is not ________ by the DMV.
-  choices:
-    A: Endorsed
-    B: Paid for
-    C: Controlled
-    D: Recommended
-  answer: C
-  explanation: The text states, 'Google™ Translate is a free third-party service,
-    which is not controlled by the DMV.'
-- id: 185
-  category: license_system
-  question: The DMV website provides links to its social media presence on several
-    platforms, including which of the following?
-  choices:
-    A: TikTok
-    B: Snapchat
-    C: Pinterest
-    D: LinkedIn
-  answer: D
-  explanation: The provided text shows icons for Facebook, X (Twitter), YouTube, Instagram,
-    and LinkedIn.
-- id: 186
-  category: sharing_the_road
-  question: According to the Secretary's message, a key safety action is to always
-    pay attention to other drivers, bicyclists, and who else?
-  choices:
-    A: Law enforcement officers
-    B: Road construction workers
-    C: Pedestrians
-    D: Emergency vehicles
-  answer: C
-  explanation: The message advises drivers to 'pay attention to other drivers, bicyclists
-    and pedestrians...'
-- id: 187
-  category: license_system
-  question: The DMV's modernization efforts, such as expanding online services, are
-    focused on improving the customer's ________ experience.
-  choices:
-    A: In-person
-    B: Telephone
-    C: Digital
-    D: Mail-in
-  answer: C
-  explanation: The text states that the DMV is 'making Californians’ digital experience
-    easier, faster and more convenient.'
-- id: 188
-  category: sharing_the_road
-  question: When driving near a large truck, where are its largest blind spots, also
-    known as 'No-Zones'?
-  choices:
-    A: Directly in front of the truck only
-    B: On the left (driver's) side only
-    C: On both sides, directly in front, and directly behind the truck
-    D: Only on the right side and directly behind the truck
-  answer: C
-  explanation: Large trucks have significant blind spots on all four sides. These
-    areas, called 'No-Zones,' are where your vehicle 'disappears' from the truck driver's
-    view.
-- id: 189
-  category: safe_driving_rules
-  question: At a 'T' intersection that does not have any stop or yield signs, who
-    has the right-of-way?
-  choices:
-    A: The vehicle on the through road
-    B: The vehicle on the road that ends
-    C: The vehicle that arrives first
-    D: The vehicle turning right
-  answer: A
-  explanation: At a 'T' intersection, traffic on the through road has the right-of-way.
-    Vehicles on the road that ends must yield to traffic and pedestrians on the through
-    road.
-- id: 190
-  category: license_system
-  question: 'For the first 12 months, a minor with a provisional driver''s license
-    is not allowed to transport passengers under 20 years of age unless:'
-  choices:
-    A: They are driving to a school-sponsored event
-    B: They are accompanied by a licensed California driver 25 years of age or older
-    C: The passengers are their siblings
-    D: They have maintained a clean driving record for 6 months
-  answer: B
-  explanation: A minor's provisional license restrictions are waived if they are accompanied
-    by a licensed parent, guardian, other licensed driver 25 years of age or older,
-    or a certified driving instructor.
-- id: 191
-  category: signs_and_signals
-  question: 'A curb painted green indicates that parking is:'
-  choices:
-    A: Allowed for an unlimited time
-    B: Allowed for a limited time, as indicated by a sign or curb marking
-    C: For loading and unloading of passengers or freight only
-    D: For emergency vehicles only
-  answer: B
-  explanation: A green curb means you may park for a limited time. The time limit
-    is often posted on a sign or painted directly on the curb.
-- id: 192
-  category: sharing_the_road
-  question: 'In California, it is legal for motorcyclists to ''lane split,'' which
-    means they can:'
-  choices:
-    A: Drive on the shoulder of the road to pass traffic
-    B: Drive between two lanes of stopped or slow-moving traffic
-    C: Use a designated bicycle lane if traffic is congested
-    D: Exceed the speed limit by 10 mph to keep traffic flowing
-  answer: B
-  explanation: Lane splitting, defined as driving a motorcycle between rows of stopped
-    or slow-moving vehicles in the same lane, is legal in California but must be done
-    in a safe and prudent manner.
-- id: 193
-  category: safe_driving_rules
-  question: 'When entering traffic from a stop, such as pulling out from a curb or
-    a private driveway, you need a gap of at least:'
-  choices:
-    A: Half a block on city streets and a full block on the highway
-    B: One car length for every 10 mph of traffic speed
-    C: Two seconds to merge safely
-    D: The length of a school bus
-  answer: A
-  explanation: When entering traffic, you need enough space to get up to the speed
-    of other vehicles. The handbook recommends a gap of about half a block on city
-    streets and a full block on the highway.
-- id: 194
-  category: safe_driving_rules
-  question: 'You may legally pass another vehicle on the right side:'
-  choices:
-    A: When the driver ahead of you is signaling a right turn
-    B: On a one-way street with two or more lanes of traffic moving in your direction
-    C: By driving on the unpaved shoulder of the road
-    D: When another driver is moving too slowly in the fast lane
-  answer: B
-  explanation: You may pass on the right when an open highway is clearly marked for
-    two or more lanes of travel in your direction, or on a one-way street. You may
-    also pass on the right if the driver ahead is signaling a left turn.
-- id: 195
-  category: signs_and_signals
-  question: 'A curb painted white means:'
-  choices:
-    A: No stopping, standing, or parking at any time
-    B: Loading zone for commercial vehicles only
-    C: You may stop only long enough to pick up or drop off passengers or mail
-    D: Parking for a limited time, as posted on a sign
-  answer: C
-  explanation: A white curb indicates you may stop only long enough to pick up or
-    drop off passengers or to deposit mail in an adjacent mailbox.
-- id: 196
-  category: vehicle_information
-  question: If your accelerator pedal becomes stuck while driving, what is the first
-    step you should take?
-  choices:
-    A: Turn off the ignition immediately to cut power to the engine
-    B: Shift to neutral and apply the brakes
-    C: Reach down and try to pull the pedal up with your hand
-    D: Pump the accelerator pedal rapidly to try and unstick it
-  answer: B
-  explanation: If your accelerator sticks, you should shift to neutral to disengage
-    the engine, apply the brakes firmly, and find a safe place to pull over. Turning
-    off the ignition while moving can lock the steering wheel.
-- id: 197
-  category: defensive_driving
-  question: 'To be prepared for road hazards and avoid last-minute moves, you should
-    scan the road ahead of your vehicle by a distance equivalent to:'
-  choices:
-    A: 1-2 seconds
-    B: 3-5 seconds
-    C: 10-15 seconds
-    D: 20-25 seconds
-  answer: C
-  explanation: The California Driver's Handbook recommends scanning the road 10-15
-    seconds ahead to see hazards early. This allows you time to react and avoid making
-    sudden or late moves.
-- id: 198
-  category: penalties_and_points
-  question: In California, a conviction for a serious traffic offense like a DUI or
-    hit-and-run will result in how many points being added to your driving record?
-  choices:
-    A: One point
-    B: Two points
-    C: Three points
-    D: Four points
-  answer: B
-  explanation: Offenses such as DUI, reckless driving, hit-and-run, and driving with
-    a suspended license are considered serious and result in two points on your driving
-    record.
-- id: 199
-  category: sharing_the_road
-  question: 'Neighborhood Electric Vehicles (NEVs) and Low-Speed Vehicles (LSVs) are
-    generally restricted to roads with a speed limit of:'
-  choices:
-    A: 25 mph or less
-    B: 35 mph or less
-    C: 45 mph or less
-    D: Any road except a freeway
-  answer: B
-  explanation: NEVs and LSVs are restricted to roadways with a posted speed limit
-    of 35 mph or less. They are not designed for high-speed roads.
-- id: 200
-  category: defensive_driving
-  question: 'A law enforcement vehicle is driving in a serpentine (S-shaped) pattern
-    across all lanes of traffic. This is a ''traffic break.'' You should:'
-  choices:
-    A: Pass the vehicle on the right shoulder
-    B: Slow down, turn on your hazard lights, and do not pass the officer
-    C: Continue at your current speed until the officer pulls you over
-    D: Immediately pull over to the right and stop
-  answer: B
-  explanation: A traffic break is used by law enforcement to slow or stop traffic
-    to remove hazards from the road. You must slow down, follow the officer at a safe
-    distance, and not attempt to pass.
-- id: 201
-  category: penalties_and_points
-  question: 'A first conviction for driving under the influence (DUI) of alcohol or
-    drugs can result in:'
-  choices:
-    A: A warning and a mandatory online driver education class
-    B: A minimum 30-day license suspension and a small fine
-    C: Up to six months in jail and thousands of dollars in fines and fees
-    D: A lifetime revocation of your driver's license
-  answer: C
-  explanation: Even a first DUI conviction is a serious criminal offense with significant
-    consequences, including potential jail time, license suspension, mandatory DUI
-    programs, and substantial financial costs.
-- id: 202
-  category: sharing_the_road
-  question: 'If you see animals or livestock on or near the roadway, you should:'
-  choices:
-    A: Honk your horn repeatedly to scare them off the road
-    B: Slow down, proceed with caution, and follow directions from the person in charge
-      of them
-    C: Speed up to pass them as quickly as possible
-    D: Assume the animals will not enter the road and maintain your speed
-  answer: B
-  explanation: When you encounter animals on the road, slow down and be prepared to
-    stop. If there is a person directing the animals, follow their instructions. Do
-    not make loud noises that could startle the animals and cause them to act unpredictably.
-- id: 203
-  category: driver_responsibility
-  question: 'California''s Compulsory Financial Responsibility Law requires every
-    driver and vehicle owner to:'
-  choices:
-    A: Pay an annual 'road usage' fee to the DMV
-    B: Maintain liability insurance or another form of financial responsibility
-    C: Have a valid credit card in the vehicle at all times
-    D: Pass a smog check every year, regardless of vehicle age
-  answer: B
-  explanation: This law requires that drivers and vehicle owners be able to pay for
-    damages they cause. This is typically done by maintaining liability insurance,
-    but other forms like a surety bond or a DMV-issued self-insurance certificate
-    are also acceptable.
-- id: 204
-  category: license_system
-  question: According to the webpage's data layer, what is the defined 'task' associated
-    with the California Driver's Handbook page?
-  choices:
-    A: informational,testing
-    B: educational,licensing
-    C: renewal,payment
-    D: vehicle_registration,forms
-  answer: B
-  explanation: The `dataLayer` JavaScript code on the page specifies `dataLayer.push({"task":"educational,licensing",...})`,
-    indicating the page's function is related to education and licensing.
-- id: 205
-  category: driver_responsibility
-  question: In the webpage's tracking script, what value is assigned to the 'conLang'
-    variable to specify the content language?
-  choices:
-    A: en-CA
-    B: eng
-    C: en_US
-    D: english
-  answer: C
-  explanation: The `dataLayer` script includes the key-value pair `"conLang":"en_US"`,
-    which designates the content language as US English.
-- id: 206
-  category: signs_and_signals
-  question: What is the hexadecimal color code for the CSS variable `--wp-admin-theme-color`
-    used in the website's styling?
-  choices:
-    A: '#7a00df'
-    B: '#313131'
-    C: '#005a87'
-    D: '#007cba'
-  answer: D
-  explanation: The `:root` style definitions in the CSS specify that `--wp-admin-theme-color`
-    is set to `#007cba`.
-- id: 207
-  category: defensive_driving
-  question: What is the standard border width, in pixels, defined by the CSS variable
-    `--wp-admin-border-width-focus` for focused elements?
-  choices:
-    A: 1px
-    B: 1.5px
-    C: 2px
-    D: 3px
-  answer: C
-  explanation: The CSS code defines the variable `--wp-admin-border-width-focus` with
-    a value of `2px`.
-- id: 208
-  category: signs_and_signals
-  question: Which hexadecimal color code is applied to elements with the class `.has-very-dark-gray-background-color`?
-  choices:
-    A: '#eee'
-    B: '#313131'
-    C: '#444'
-    D: '#ddd'
-  answer: B
-  explanation: The CSS rules state that `.has-very-dark-gray-background-color` sets
-    the `background-color` to `#313131`.
-- id: 209
-  category: signs_and_signals
-  question: The `.has-midnight-gradient-background` class creates a linear gradient.
-    What are the two main colors it transitions between?
-  choices:
-    A: '#330968 and #31cdcf'
-    B: '#fdd79a and #004a59'
-    C: '#020381 and #2874fc'
-    D: '#faaca8 and #dad0ec'
-  answer: C
-  explanation: The CSS for `.has-midnight-gradient-background` is defined as `linear-gradient(135deg,#020381,#2874fc)`.
-- id: 210
-  category: driver_testing
-  question: According to the CSS, what cursor style is applied to elements with the
-    class `.wp-element-button`?
-  choices:
-    A: default
-    B: pointer
-    C: wait
-    D: text
-  answer: B
-  explanation: The CSS rule `.wp-element-button{cursor:pointer}` indicates that the
-    cursor should change to a pointer (hand icon) when hovering over these elements.
-- id: 211
-  category: safe_driving_rules
-  question: When the `.screen-reader-text` element is focused, what `z-index` value
-    is it assigned to ensure it appears above other content?
-  choices:
-    A: '100'
-    B: '1000'
-    C: '10000'
-    D: '100000'
-  answer: D
-  explanation: The CSS for the focused state of `.screen-reader-text` includes `z-index:100000`.
-- id: 212
-  category: vehicle_information
-  question: What padding is applied to a `<h1>` heading element that also has a background,
-    according to the provided CSS?
-  choices:
-    A: 1em 2em
-    B: 1.25em 2.375em
-    C: 15px 23px 14px
-    D: 0.5em 1em 0.5em 0
-  answer: B
-  explanation: The CSS rule `h1:where(.wp-block-heading).has-background` specifies
-    a `padding` of `1.25em 2.375em`.
-- id: 213
-  category: signs_and_signals
-  question: For an image with the `is-style-circle-mask` style, what `border-radius`
-    value is used to create the circular shape?
-  choices:
-    A: 50%
-    B: 100px
-    C: 9999px
-    D: inherit
-  answer: C
-  explanation: The CSS rule `.wp-block-image.is-style-circle-mask img` sets the `border-radius`
-    to `9999px`, a common technique to ensure an element is rendered as a circle.
-- id: 214
-  category: safe_driving_rules
-  question: What are the margin settings for an image block with the `.alignright`
-    class?
-  choices:
-    A: 0.5em on top, 0 on right, 0.5em on bottom, 1em on left
-    B: 1em on top, 0.5em on right, 1em on bottom, 0.5em on left
-    C: 0.5em on all sides
-    D: 1em on top and bottom, 0.5em on left and right
-  answer: A
-  explanation: The CSS for `.wp-block-image .alignright` defines the margin as `margin:.5em
-    0 .5em 1em`, which corresponds to top, right, bottom, and left margins respectively.
-- id: 215
-  category: vehicle_information
-  question: For specific images with an auto-calculated size, what `contain-intrinsic-size`
-    is defined in the CSS to help the browser reserve space?
-  choices:
-    A: 1920px 1080px
-    B: 1024px 768px
-    C: 3000px 1500px
-    D: 800px 600px
-  answer: C
-  explanation: The first CSS rule provided sets `contain-intrinsic-size:3000px 1500px`
-    for images matching the selector.
-- id: 216
-  category: signs_and_signals
-  question: At what angle is the linear gradient for the `.has-hazy-dawn-gradient-background`
-    class set?
-  choices:
-    A: 90deg
-    B: 120deg
-    C: 135deg
-    D: 180deg
-  answer: C
-  explanation: The CSS for `.has-hazy-dawn-gradient-background` is defined as `linear-gradient(135deg,...)`,
-    indicating a 135-degree angle.
-- id: 217
-  category: safe_driving_rules
-  question: What `white-space` property is applied to the `.has-fit-text` class to
-    prevent text from wrapping?
-  choices:
-    A: normal
-    B: pre
-    C: nowrap
-    D: pre-wrap
-  answer: C
-  explanation: The CSS rule for `.has-fit-text` sets `white-space:nowrap!important`,
-    which forces the text to stay on a single line.
-- id: 218
-  category: vehicle_information
-  question: According to the global CSS rules, if an element has its `border-width`
-    set via an inline style, what `border-style` is automatically applied?
-  choices:
-    A: solid
-    B: dotted
-    C: dashed
-    D: none
-  answer: A
-  explanation: The rule `html :where([style*=border-width]){border-style:solid}` ensures
-    that any element with a specified border width will have a solid border style
-    by default.
-- id: 219
-  category: defensive_driving
-  question: What is the default opacity of the button within a `.wp-lightbox-container`
-    before a user interacts with it?
-  choices:
-    A: 1 (fully visible)
-    B: 0.5 (semi-transparent)
-    C: 0 (fully transparent/hidden)
-    D: 0.2 (mostly transparent)
-  answer: C
-  explanation: The CSS for `.wp-lightbox-container button` sets its default `opacity`
-    to `0`, making it invisible until an event like a hover changes it.
-- id: 220
-  category: alcohol_drugs_health
-  question: The button inside a lightbox container has a special visual effect applied
-    to the area behind it. What is the `blur` value for this `backdrop-filter` effect?
-  choices:
-    A: 4px
-    B: 8px
-    C: 16px
-    D: 20px
-  answer: C
-  explanation: The CSS for the lightbox button specifies `backdrop-filter:blur(16px)
-    saturate(180%)`. The blur value is `16px`.
-- id: 221
-  category: signs_and_signals
-  question: The `.has-atomic-cream-gradient-background` class transitions from a light
-    color to a dark color. What is the dark color in this gradient?
-  choices:
-    A: '#31cdcf'
-    B: '#004a59'
-    C: '#2874fc'
-    D: '#67a671'
-  answer: B
-  explanation: The CSS for `.has-atomic-cream-gradient-background` is defined as `linear-gradient(135deg,#fdd79a,#004a59)`,
-    with `#004a59` being the second (darker) color.
-- id: 222
-  category: penalties_and_points
-  question: On screens with a maximum width of 600px, what value is assigned to the
-    `--wp-admin--admin-bar--position-offset` variable for sticky elements?
-  choices:
-    A: var(--wp-admin--admin-bar--height,0px)
-    B: 0px
-    C: 32px
-    D: -1px
-  answer: B
-  explanation: The media query `@media screen and (max-width:600px)` contains a rule
-    that sets `--wp-admin--admin-bar--position-offset` to `0px` for smaller screens.
-- id: 223
-  category: safe_driving_rules
-  question: In the website's code, what is the specified `border-radius` for a standard
-    button link with the class '.wp-block-button__link'?
-  choices:
-    A: 4px
-    B: 10px
-    C: 50%
-    D: 9999px
-  answer: D
-  explanation: The CSS rule for '.wp-block-button__link' includes 'border-radius:9999px;',
-    which creates a 'pill' or oval shape for the button.
-- id: 224
-  category: driver_testing
-  question: The website's styling defines a class for large text called '.is-large-text'.
-    What font size does this class apply?
-  choices:
-    A: 1em
-    B: 2.25em
-    C: 3em
-    D: 8.4em
-  answer: B
-  explanation: 'The manual text specifies the CSS rule: ''.is-large-text{font-size:2.25em}''.'
-- id: 225
-  category: vehicle_information
-  question: What is the defined aspect ratio for the preset named '--wp--preset--aspect-ratio--16-9'?
-  choices:
-    A: 16/9
-    B: 9/16
-    C: 4/3
-    D: '1'
-  answer: A
-  explanation: 'The root styles in the provided text define ''--wp--preset--aspect-ratio--16-9:
-    16/9;''.'
-- id: 226
-  category: penalties_and_points
-  question: What is the stacking order value, or `z-index`, assigned to the main lightbox
-    overlay class '.wp-lightbox-overlay'?
-  choices:
-    A: '100'
-    B: '1000'
-    C: '100000'
-    D: '5000000'
-  answer: C
-  explanation: The CSS rule for '.wp-lightbox-overlay' sets its 'z-index' property
-    to '100000' to ensure it appears above other page content.
-- id: 227
-  category: alcohol_drugs_health
-  question: The style for a paragraph with a drop cap, defined as '.has-drop-cap',
-    sets the first letter to a very large font size. What is that font size?
-  choices:
-    A: 2.25em
-    B: 3em
-    C: 8.4em
-    D: 1.125em
-  answer: C
-  explanation: The CSS rule for '.has-drop-cap:not(:focus):first-letter' specifies
-    'font-size:8.4em;'.
-- id: 228
-  category: signs_and_signals
-  question: Which preset color name corresponds to the hex code '#00d084' in the website's
-    color palette?
-  choices:
-    A: light-green-cyan
-    B: vivid-green-cyan
-    C: pale-cyan-blue
-    D: electric-grass
-  answer: B
-  explanation: 'The text defines the variable ''--wp--preset--color--vivid-green-cyan:
-    #00d084;''.'
-- id: 229
-  category: sharing_the_road
-  question: The website defines a gradient preset named '--wp--preset--gradient--blush-bordeaux'.
-    What is the starting color of this gradient?
-  choices:
-    A: rgb(254,205,165)
-    B: rgb(254,45,45)
-    C: rgb(107,0,62)
-    D: rgb(255,206,236)
-  answer: A
-  explanation: The definition for '--wp--preset--gradient--blush-bordeaux' is 'linear-gradient(135deg,rgb(254,205,165)
-    0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)'. The starting color at 0% is rgb(254,205,165).
-- id: 230
-  category: defensive_driving
-  question: For the lightbox zoom-out animation, what is the final state of the 'transform'
-    property in the '@keyframes lightbox-zoom-out' rule?
-  choices:
-    A: translate(-50%,-50%) scale(1)
-    B: translate(0,0) scale(0)
-    C: translate(calc((-100vw + var(--wp--lightbox-scrollbar-width))/2 + var(--wp--lightbox-initial-left-position)),calc(-50vh
-      + var(--wp--lightbox-initial-top-position))) scale(var(--wp--lightbox-scale))
-    D: scale(0)
-  answer: C
-  explanation: The 'to' state of the '@keyframes lightbox-zoom-out' animation rule
-    sets the transform property to return the image to its original position and scale
-    on the page.
-- id: 231
-  category: safe_driving_rules
-  question: What is the specified `text-decoration` for the link inside a button,
-    styled with the class '.wp-block-button__link'?
-  choices:
-    A: underline
-    B: overline
-    C: line-through
-    D: none
-  answer: D
-  explanation: The CSS rule for '.wp-block-button__link' explicitly states 'text-decoration:none;'
-    to remove the default underline from the link.
-- id: 232
-  category: vehicle_information
-  question: What is the `font-weight` specified for the first letter in a paragraph
-    with a drop cap ('.has-drop-cap')?
-  choices:
-    A: '100'
-    B: '400'
-    C: '700'
-    D: '900'
-  answer: A
-  explanation: The CSS rule for '.has-drop-cap:not(:focus):first-letter' includes
-    'font-weight:100;', which indicates a very light or thin font weight.
-- id: 233
-  category: license_system
-  question: According to the website's code, what is the background color of a file
-    download button styled with the class '.wp-block-file__button'?
-  choices:
-    A: '#ffffff'
-    B: '#0077c8'
-    C: '#32373c'
-    D: '#cf2e2e'
-  answer: C
-  explanation: The CSS rule '.wp-block-file__button{background:#32373c;...}' sets
-    the background color to a dark gray.
-- id: 234
-  category: driver_responsibility
-  question: What is the `opacity` of the '.scrim' element within the lightbox overlay,
-    which provides a semi-transparent background?
-  choices:
-    A: '0.5'
-    B: '0.7'
-    C: '0.9'
-    D: '1.0'
-  answer: C
-  explanation: The CSS rule for '.wp-lightbox-overlay .scrim' sets the opacity to
-    '.9', making the background mostly opaque but still slightly transparent.
-- id: 235
-  category: safe_driving_rules
-  question: What is the duration of the transition effect for the lightbox button's
-    opacity, as defined in the CSS?
-  choices:
-    A: 0.2 seconds
-    B: 0.4 seconds
-    C: 1 second
-    D: There is no transition
-  answer: A
-  explanation: The rule '.wp-lightbox-container button{transition:opacity .2s ease}'
-    specifies a 0.2-second transition for the opacity property.
-- id: 236
-  category: sharing_the_road
-  question: The gradient preset '--wp--preset--gradient--pale-ocean' transitions between
-    three colors. What is the middle color in this gradient?
-  choices:
-    A: rgb(255,245,203)
-    B: rgb(51,167,181)
-    C: rgb(182,227,212)
-    D: rgb(113,206,126)
-  answer: C
-  explanation: The definition for '--wp--preset--gradient--pale-ocean' is 'linear-gradient(135deg,rgb(255,245,203)
-    0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)'. The color at the 50% mark is rgb(182,227,212).
-- id: 237
-  category: penalties_and_points
-  question: What is the `z-index` of the close button within the lightbox overlay,
-    ensuring it appears above the image container?
-  choices:
-    A: '100'
-    B: '999999'
-    C: '5000000'
-    D: '9999999999'
-  answer: C
-  explanation: The CSS rule for '.wp-lightbox-overlay .close-button' sets the 'z-index'
-    to '5000000', placing it above most other lightbox elements.
-- id: 238
-  category: driver_testing
-  question: The website's CSS defines a font size for '.is-regular-text'. What is
-    this size?
-  choices:
-    A: .875em
-    B: 1em
-    C: 1.125em
-    D: 2.25em
-  answer: B
-  explanation: The provided text includes the rule '.is-regular-text{font-size:1em}',
-    which represents the standard or base font size.
-- id: 239
-  category: safe_driving_rules
-  question: When a paragraph has a background color, what padding is applied to it
-    according to the rule ':root :where(p.has-background)'?
-  choices:
-    A: 1em 2em
-    B: 1.25em 2.375em
-    C: 0.5em 1em
-    D: No padding is applied
-  answer: B
-  explanation: The CSS rule ':root :where(p.has-background){padding:1.25em 2.375em}'
-    specifies the padding for paragraphs that have a background style.
-- id: 240
-  category: signs_and_signals
-  question: What is the name of the gradient preset that is defined as 'linear-gradient(135deg,rgb(6,147,227)
-    0%,rgb(155,81,224) 100%)'?
-  choices:
-    A: vivid-cyan-blue-to-vivid-purple
-    B: cool-to-warm-spectrum
-    C: blush-light-purple
-    D: pale-ocean
-  answer: A
-  explanation: The provided text explicitly defines '--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple'
-    with this specific linear-gradient value.
-- id: 241
-  category: driver_responsibility
-  question: In the DMV website's design specifications, what is the definition of
-    the '--wp--preset--gradient--midnight' style?
-  choices:
-    A: A linear gradient from black to dark blue
-    B: A linear gradient from rgb(2,3,129) to rgb(40,116,252)
-    C: A radial gradient from dark purple to black
-    D: A linear gradient from rgb(255,245,203) to rgb(51,167,181)
-  answer: B
-  explanation: 'The provided text defines ''--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)
-    0%,rgb(40,116,252) 100%);''.'
-- id: 242
-  category: driver_responsibility
-  question: When reviewing the DMV website's layout code, the '--wp--preset--font-size--medium'
-    is defined as what value?
-  choices:
-    A: 18px
-    B: 21px
-    C: 28px
-    D: 32px
-  answer: C
-  explanation: 'The provided text defines the medium font size preset as ''--wp--preset--font-size--medium:
-    28px;''.'
-- id: 243
-  category: driver_responsibility
-  question: The DMV website's CSS includes a preset for a 'tiny' font size. What is
-    its defined pixel value?
-  choices:
-    A: 14px
-    B: 18px
-    C: 20px
-    D: 12px
-  answer: A
-  explanation: 'The provided text lists the ''tiny'' font size as ''--wp--preset--font-size--tiny:
-    14px;''.'
-- id: 244
-  category: driver_responsibility
-  question: In the website's technical specifications, what is the value of the spacing
-    preset '--wp--preset--spacing--30'?
-  choices:
-    A: 0.44rem
-    B: 1rem
-    C: 0.67rem
-    D: 1.5rem
-  answer: C
-  explanation: 'The provided text defines this spacing preset as ''--wp--preset--spacing--30:
-    0.67rem;''.'
-- id: 245
-  category: driver_responsibility
-  question: The DMV website's layout rules define a spacing preset named '--wp--preset--spacing--40'.
-    What is its value?
-  choices:
-    A: 0.67rem
-    B: 1rem
-    C: 1.5rem
-    D: 2.25rem
-  answer: B
-  explanation: 'According to the provided text, the value for this spacing preset
-    is ''--wp--preset--spacing--40: 1rem;''.'
-- id: 246
-  category: driver_responsibility
-  question: Based on the provided website code, what is the defined value for the
-    spacing variable '--wp--preset--spacing--50'?
-  choices:
-    A: 1rem
-    B: 1.5rem
-    C: 2.25rem
-    D: 3.38rem
-  answer: B
-  explanation: 'The provided text specifies ''--wp--preset--spacing--50: 1.5rem;''.'
-- id: 247
-  category: driver_responsibility
-  question: According to the provided code, what is the CSS definition for the '--wp--preset--shadow--deep'
-    effect?
-  choices:
-    A: 6px 6px 9px rgba(0, 0, 0, 0.2)
-    B: 12px 12px 50px rgba(0, 0, 0, 0.4)
-    C: 6px 6px 0px rgba(0, 0, 0, 0.2)
-    D: 12px 12px 25px rgba(0, 0, 0, 0.5)
-  answer: B
-  explanation: 'The provided text defines the ''deep'' shadow preset as ''--wp--preset--shadow--deep:
-    12px 12px 50px rgba(0, 0, 0, 0.4);''.'
-- id: 248
-  category: driver_responsibility
-  question: The DMV website's color palette includes a preset named 'pale-pink'. What
-    is its corresponding hex color code?
-  choices:
-    A: '#ffffff'
-    B: '#cf2e2e'
-    C: '#f78da7'
-    D: '#abb8c3'
-  answer: C
-  explanation: 'The provided text lists the hex code for pale-pink in the full, un-truncated
-    CSS: ''--wp--preset--color--pale-pink: #f78da7;''.'
-- id: 249
-  category: driver_responsibility
-  question: According to the provided code, the color preset 'light-green-cyan' is
-    assigned which hex code?
-  choices:
-    A: '#7bdcb5'
-    B: '#00d084'
-    C: '#8ed1fc'
-    D: '#9b51e0'
-  answer: A
-  explanation: 'The provided text lists the hex code for this color in the full, un-truncated
-    CSS: ''--wp--preset--color--light-green-cyan: #7bdcb5;''.'
-- id: 250
-  category: driver_responsibility
-  question: A script on the DMV website is designed to enhance browser functionality.
-    What class name does it remove from the main HTML element upon loading?
-  choices:
-    A: js
-    B: no-script
-    C: no-js
-    D: html-fallback
-  answer: C
-  explanation: 'The provided JavaScript code includes the line: ''document.documentElement.className
-    = document.documentElement.className.replace(''no-js'', " ");'', which removes
-    the ''no-js'' class.'
-- id: 251
-  category: driver_responsibility
-  question: The script that loads webfonts for the DMV website includes a check to
-    ensure secure loading. How does it determine whether to use 'https' or 'http'?
-  choices:
-    A: It always defaults to 'https'
-    B: It checks if the browser is a modern version
-    C: It checks if the current page's protocol is 'https'
-    D: It always defaults to 'http'
-  answer: C
-  explanation: 'The code snippet ''wf.src = (''https:'' == document.location.protocol
-    ? ''https'' : ''http'')'' shows that it checks the protocol of the current document''s
-    location.'
-- id: 252
-  category: driver_responsibility
-  question: The DMV website uses Google Tag Manager for analytics, which is loaded
-    in a hidden iframe. What style properties are used to hide this element?
-  choices:
-    A: opacity:0; z-index:-1;
-    B: height:0; width:0;
-    C: display:none; visibility:hidden;
-    D: position:absolute; left:-9999px;
-  answer: C
-  explanation: The provided HTML for the iframe includes the attribute 'style="display:none;visibility:hidden"'.
-- id: 253
-  category: driver_responsibility
-  question: The button to activate the DMV chatbot has an accessibility attribute,
-    'aria-controls'. What value is assigned to this attribute?
-  choices:
-    A: js-chatbot-show
-    B: chatbot__show-btn
-    C: js-chatbot-dialog
-    D: GTM-KHCVGH4
-  answer: C
-  explanation: The provided button element code is '<button ... aria-controls="js-chatbot-dialog">',
-    indicating it controls the chatbot dialog element.
-- id: 254
-  category: driver_responsibility
-  question: In the website's CSS layout rules, what is the defined gap size for flexible
-    column blocks ('.wp-block-columns.is-layout-flex')?
-  choices:
-    A: 0.5em
-    B: 1.25em
-    C: 2em
-    D: 1rem
-  answer: C
-  explanation: 'The provided CSS states: '':where(.wp-block-columns.is-layout-flex){gap:
-    2em;}''.'
-- id: 255
-  category: driver_responsibility
-  question: According to the provided CSS, what is the specified gap size for post
-    template grids ('.wp-block-post-template.is-layout-grid')?
-  choices:
-    A: 2em
-    B: 1.25em
-    C: 0.5em
-    D: 1.5rem
-  answer: B
-  explanation: 'The provided CSS specifies: '':where(.wp-block-post-template.is-layout-grid){gap:
-    1.25em;}''.'
-- id: 256
-  category: driver_responsibility
-  question: The button element used to show the DMV chatbot is styled using a specific
-    CSS class. What is the name of that class?
-  choices:
-    A: js-chatbot-show
-    B: chatbot__show-btn
-    C: js-chatbot-dialog
-    D: wp-block-button
-  answer: B
-  explanation: The provided HTML for the button includes the attribute 'class="chatbot__show-btn"'.
-- id: 257
-  category: vehicle_information
-  question: According to the DMV's online 'Vehicle Registration' menu, which of the
-    following services is offered?
-  choices:
-    A: Calculate vehicle property tax
-    B: Submit Proof of Insurance
-    C: Report a vehicle sale
-    D: Apply for a commercial vehicle permit
-  answer: B
-  explanation: The text lists 'Submit Proof of Insurance' as an option under the 'Vehicle
-    Registration' menu on the DMV website.
-- id: 258
-  category: driver_responsibility
-  question: Under the 'Appointments' menu on the DMV website, what service allows
-    you to join the line at a DMV office remotely before you arrive?
-  choices:
-    A: Schedule Appointment
-    B: Virtual Office Visit
-    C: Get in Line Now
-    D: Online Testing
-  answer: C
-  explanation: The text shows 'Get in Line Now' as a service offered under the 'Appointments'
-    menu, which allows customers to secure their place in line at a physical office.
-- id: 259
-  category: driver_testing
-  question: In addition to Driver Handbooks and Practice Tests, what other type of
-    informational guide is available under the DMV's 'Testing' menu?
-  choices:
-    A: Vehicle Maintenance Manuals
-    B: Traffic Law Case Studies
-    C: Specialty Driver Guides
-    D: Insurance Comparison Charts
-  answer: C
-  explanation: The 'Testing' menu on the DMV website lists 'Specialty Driver Guides'
-    as an available resource for drivers.
-- id: 260
-  category: driver_responsibility
-  question: The DMV's 'Check Status' online service allows you to check the status
-    of various applications and cases. Which of the following is listed as a checkable
-    status?
-  choices:
-    A: REAL ID Application Status
-    B: Driving School Complaint Status
-    C: IBC Case Status
-    D: Smog Check Exemption Status
-  answer: C
-  explanation: The 'Check Status' menu on the DMV website specifically lists 'IBC
-    Case Status' as an option.
-- id: 261
-  category: driver_testing
-  question: What is the final section of the California Driver's Handbook, according
-    to the provided Table of Contents?
-  choices:
-    A: Driver Safety
-    B: Glossary
-    C: Index
-    D: Copyright
-  answer: B
-  explanation: 'The Table of Contents lists ''Section 14: Glossary'' as the last numbered
-    section of the handbook.'
-- id: 262
-  category: driver_responsibility
-  question: The Secretary's Message in the driver's handbook states that the handbook
-    is available in how many languages to serve Californians?
-  choices:
-    A: Three
-    B: Five
-    C: Seven
-    D: Nine
-  answer: D
-  explanation: The Secretary's Message explicitly states, 'The California Driver’s
-    Handbook is available in nine languages...'
-- id: 263
-  category: sharing_the_road
-  question: In the Secretary's Message, a driver's license is noted as enabling which
-    group of drivers to transport goods and support the economy?
-  choices:
-    A: Delivery drivers
-    B: Rideshare drivers
-    C: Truck drivers
-    D: Commuter van drivers
-  answer: C
-  explanation: The message states, 'It also enables truck drivers to transport goods
-    and services to support our economy.'
-- id: 264
-  category: driver_responsibility
-  question: What technology does the DMV use to provide translation for its chatbot
-    and live chat services?
-  choices:
-    A: In-house bilingual staff
-    B: A dedicated state translation department
-    C: Machine translation from third-party vendors
-    D: A community volunteer translation program
-  answer: C
-  explanation: The 'Third-Party Translation Disclaimer' states, 'The DMV chatbot and
-    live chat services use third-party vendors to provide machine translation.'
-- id: 265
-  category: driver_responsibility
-  question: If there are discrepancies or differences between the English version
-    of the DMV website and a translated version, what is the legal effect?
-  choices:
-    A: The translated version takes precedence if it is the user's native language.
-    B: Both versions are considered equally valid.
-    C: The discrepancies are not binding and have no legal effect.
-    D: A legal review is required to determine the correct information.
-  answer: C
-  explanation: The disclaimer states, 'Any discrepancies or differences created in
-    the translation are not binding and have no legal effect for compliance or enforcement
-    purposes.'
-- id: 266
-  category: driver_responsibility
-  question: Which of the following is listed as a primary link in the utility navigation
-    bar at the top of the DMV website?
-  choices:
-    A: Appointments
-    B: MyDMV
-    C: Locations & Hours
-    D: Contact Us
-  answer: B
-  explanation: The utility navigation bar, labeled 'nav-utility' in the text, contains
-    the links REAL ID, Online Services, Translate, and MyDMV.
-- id: 267
-  category: safe_driving_rules
-  question: Based on the handbook's Table of Contents, which section is extensive
-    enough that it is broken into multiple 'Continued' parts?
-  choices:
-    A: 'Section 6: Navigating the Roads'
-    B: 'Section 7: Laws and Rules of the Road'
-    C: 'Section 8: Safe Driving'
-    D: All of the above
-  answer: D
-  explanation: The provided Table of Contents shows 'Continued' entries for Section
-    6, Section 7, and Section 8, indicating they are all large sections.
-- id: 268
-  category: sharing_the_road
-  question: The Secretary's Message emphasizes that the rules of the road must be
-    followed by all users, including drivers of cars, commercial vehicles, and which
-    other two groups?
-  choices:
-    A: Pedestrians and skaters
-    B: Motorcycles and bicycles
-    C: Light-rail vehicles and buses
-    D: Scooters and mopeds
-  answer: B
-  explanation: The message states, 'Whether driving a car, motorcycle, commercial
-    vehicle or riding a bicycle, it is critical we adhere to the rules...'
-- id: 269
-  category: driver_responsibility
-  question: When your conversation with the DMV Virtual Assistant is over, what option
-    are you given regarding the conversation?
-  choices:
-    A: Rate the helpfulness of the assistant
-    B: Save the transcript
-    C: Email the conversation to yourself
-    D: Delete the conversation permanently
-  answer: B
-  explanation: The General Disclaimer for the Virtual Assistant states, 'When your
-    chat is over, you can save the transcript.'
-- id: 270
-  category: license_system
-  question: According to the 'Check Status' menu on the DMV website, you can check
-    the progress of which of these personal information updates?
-  choices:
-    A: Name Change Status
-    B: Gender Category Update Status
-    C: Voter Registration Status
-    D: Change of Address Status
-  answer: D
-  explanation: The 'Check Status' menu explicitly lists 'Change of Address Status'
-    as an option for users to track.
-- id: 271
-  category: license_system
-  question: According to the Table of Contents, which section of the California Driver's
-    Handbook covers the process of 'Getting an Instruction Permit and Driver’s License'?
-  choices:
-    A: Section 1
-    B: Section 2
-    C: Section 3
-    D: Section 4
-  answer: B
-  explanation: The handbook's Table of Contents clearly titles 'Section 2' as 'Getting
-    an Instruction Permit and Driver’s License'.
-- id: 272
-  category: driver_responsibility
-  question: What is the primary security warning given by the DMV regarding the use
-    of its Virtual Assistant?
-  choices:
-    A: Do not use it on a public Wi-Fi network
-    B: Do not include any personal information
-    C: Do not share your chat transcript
-    D: Do not use it for financial transactions
-  answer: B
-  explanation: The General Disclaimer for the DMV Virtual Assistant begins with the
-    instruction, 'please do not include any personal information.'
-- id: 273
-  category: driver_responsibility
-  question: 'According to the Secretary of the California State Transportation Agency,
-    driving or riding is considered a:'
-  choices:
-    A: Right
-    B: Requirement
-    C: Privilege
-    D: Hobby
-  answer: C
-  explanation: The Secretary's message states, 'Remember that driving or riding is
-    a privilege, and above all, safety must be the priority.'
-- id: 274
-  category: safe_driving_rules
-  question: 'The Secretary''s message in the driver''s handbook emphasizes that the
-    number one priority for all road users must be:'
-  choices:
-    A: Speed
-    B: Convenience
-    C: Safety
-    D: Following directions
-  answer: C
-  explanation: The text from the Secretary's message clearly states, '...above all,
-    safety must be the priority.'
-- id: 275
-  category: sharing_the_road
-  question: 'In addition to other drivers, the Secretary''s message specifically reminds
-    you to pay attention to:'
-  choices:
-    A: Road construction and animals
-    B: Traffic signs and signals only
-    C: Bicyclists and pedestrians
-    D: Emergency vehicles and law enforcement
-  answer: C
-  explanation: The message advises drivers to '...pay attention to other drivers,
-    bicyclists and pedestrians...'
-- id: 276
-  category: driver_testing
-  question: In addition to English and Spanish, the California Driver's Handbook is
-    available as a PDF in which of the following languages?
-  choices:
-    A: German
-    B: French
-    C: Korean
-    D: Vietnamese
-  answer: D
-  explanation: The text lists available PDF languages, which include 'ngôn ngữ tiếng
-    Việt (Vietnamese)' among others like Russian, Armenian, Hindi, Punjabi, and Chinese.
-- id: 277
-  category: driver_testing
-  question: For individuals who communicate using American Sign Language (ASL), where
-    can a video version of the driver's handbook be found?
-  choices:
-    A: On a special DVD from the DMV
-    B: On the main DMV website page
-    C: On YouTube
-    D: At local field offices
-  answer: C
-  explanation: The text includes a section for 'American Sign Language Video' with
-    a link to 'Play Video on YouTube'.
-- id: 278
-  category: driver_responsibility
-  question: According to the DMV's disclaimer, what is the primary purpose of providing
-    the Google™ Translate tool on its website?
-  choices:
-    A: For official legal translation
-    B: For information and convenience only
-    C: To replace the need for an interpreter
-    D: For filling out official forms in other languages
-  answer: B
-  explanation: The disclaimer states, 'This translation application tool is provided
-    for purposes of information and convenience only.'
-- id: 279
-  category: driver_responsibility
-  question: What is the legal effect of any discrepancies or differences created in
-    a machine translation of the DMV website or chatbot?
-  choices:
-    A: They are legally binding
-    B: They can be used for compliance purposes
-    C: They are not binding and have no legal effect
-    D: They must be reported to the DMV legal team
-  answer: C
-  explanation: The disclaimers for both the website and chatbot state, 'Any discrepancies
-    or differences created in the translation are not binding and have no legal effect
-    for compliance or enforcement purposes.'
-- id: 280
-  category: license_system
-  question: 'The Secretary''s message encourages people to use the DMV''s online services
-    because doing so can be a:'
-  choices:
-    A: Guaranteed approval
-    B: Timesaver
-    C: Way to avoid all fees
-    D: Method to get a temporary license
-  answer: B
-  explanation: The message states, 'Try online first, as it can be a timesaver.'
-- id: 281
-  category: driver_responsibility
-  question: 'According to the website footer, the content of the California DMV website
-    is copyrighted by:'
-  choices:
-    A: The Department of Motor Vehicles
-    B: Google™
-    C: The State of California
-    D: The California State Transportation Agency
-  answer: C
-  explanation: The footer contains the notice 'Copyright &copy; 2026 State of California'.
-- id: 282
-  category: driver_responsibility
-  question: Which of the following is listed in the website's footer as a legal or
-    policy information page?
-  choices:
-    A: Vehicle Registration
-    B: Conditions of Use
-    C: Practice Tests
-    D: Office Locations
-  answer: B
-  explanation: The footer navigation lists 'Conditions of Use' along with other policy
-    pages like 'Privacy Policy' and 'Cookie Policy'.
-- id: 283
-  category: vehicle_information
-  question: Which of the following types of DMV documents cannot be translated using
-    the website's automatic translation tool?
-  choices:
-    A: The Driver's Handbook
-    B: Website disclaimers
-    C: News releases
-    D: Publications
-  answer: D
-  explanation: The Google™ Translate Disclaimer explicitly lists 'Publications' as
-    one of the page types that cannot be translated.
-- id: 284
-  category: driver_responsibility
-  question: 'The DMV''s modernization efforts aim to make the digital experience for
-    customers:'
-  choices:
-    A: More secure but slower
-    B: Available only during business hours
-    C: Completely automated without human help
-    D: Easier, faster, and more convenient
-  answer: D
-  explanation: The text states, 'The DMV has been modernizing interactions with its
-    customers, making Californians’ digital experience easier, faster and more convenient.'
+  id: 252

--- a/data/states/ca/questions_es.yaml
+++ b/data/states/ca/questions_es.yaml
@@ -1,7 +1,7 @@
 metadata:
   source: 2025 California Driver Handbook (dmv.ca.gov)
   source_original: 2025 California Driver Handbook (dmv.ca.gov)
-  total_questions: 284
+  total_questions: 252
   language: es
   categories:
   - alcohol_drugs_health
@@ -10,213 +10,1529 @@ metadata:
   - driver_testing
   - license_system
   - penalties_and_points
-  - right_of_way
   - safe_driving_rules
   - sharing_the_road
   - signs_and_signals
   - vehicle_information
 questions:
 - id: 1
-  category: safe_driving_rules
-  question: ¿Cuál es el límite de velocidad en una zona escolar cuando hay niños presentes,
-    a menos que se indique lo contrario?
-  choices:
-    A: 15 mph
-    B: 20 mph
-    C: 25 mph
-    D: 30 mph
-  answer: C
-  explanation: Según el Manual del Automovilista de California, el límite de velocidad
-    es de 25 mph al conducir a menos de 500 pies de una escuela mientras los niños
-    están afuera o cruzando la calle, a menos que se indique lo contrario.
-- id: 2
-  category: safe_driving_rules
-  question: 'La "Ley de Velocidad Básica" (Basic Speed Law) de California establece
-    que usted debe:'
-  choices:
-    A: Nunca conducir más rápido que el límite de velocidad señalizado
-    B: Nunca conducir más rápido de lo que sea seguro para las condiciones actuales
-    C: Siempre conducir al ritmo del tráfico
-    D: Mantener su velocidad cerca de la de otros vehículos
-  answer: B
-  explanation: La Ley de Velocidad Básica establece que nunca debe conducir más rápido
-    de lo que sea seguro para las condiciones actuales, independientemente del límite
-    de velocidad señalizado.
-- id: 3
-  category: alcohol_drugs_health
-  question: Es ilegal que una persona de 21 años de edad o más conduzca con una concentración
-    de alcohol en sangre (BAC) de ___ o superior.
-  choices:
-    A: 0.04%
-    B: 0.06%
-    C: 0.08%
-    D: 0.10%
-  answer: C
-  explanation: La ley de California establece que es ilegal que cualquier persona
-    de 21 años o más conduzca con un BAC de 0.08% o superior.
-- id: 4
-  category: sharing_the_road
-  question: 'Cuando un autobús escolar con sus luces rojas intermitentes está detenido
-    delante de usted en su lado de la carretera, usted debe:'
-  choices:
-    A: Detenerse hasta que crea que todos los niños han bajado
-    B: Detenerse hasta que las luces rojas dejen de parpadear
-    C: Cambiar de carril, conducir despacio y pasar con cuidado
-    D: Reducir la velocidad a 15 mph al pasar
-  answer: B
-  explanation: Debe detenerse ante un autobús escolar con luces rojas intermitentes
-    y permanecer detenido hasta que las luces dejen de parpadear. No hacerlo puede
-    resultar en una multa y la suspensión de la licencia.
-- id: 5
-  category: sharing_the_road
-  question: 'Usted debe ceder el derecho de paso a un vehículo de emergencia:'
-  choices:
-    A: Conduciendo lo más cerca posible del borde derecho de la carretera y deteniéndose
-    B: Moviéndose al carril derecho y conduciendo despacio
-    C: Deteniéndose inmediatamente en su carril actual
-    D: Acelerando para apartarse de su camino
-  answer: A
-  explanation: Cuando escuche una sirena o vea luces rojas intermitentes de un vehículo
-    de emergencia, debe hacerse a un lado hacia el borde derecho de la carretera y
-    detenerse hasta que pase.
-- id: 6
-  category: driver_responsibility
-  question: Según la ley de California, ¿cuándo puede usar un teléfono celular de
-    mano mientras conduce?
-  choices:
-    A: Cuando esté detenido en un semáforo en rojo
-    B: Solo en una emergencia para pedir ayuda
-    C: Cuando el tráfico se mueva a menos de 15 mph
-    D: Cuando esté conduciendo en una carretera rural
-  answer: B
-  explanation: Solo puede usar un teléfono celular de mano mientras conduce en una
-    situación de emergencia para llamar a las autoridades, a un proveedor médico,
-    al departamento de bomberos u otros servicios de emergencia.
-- id: 7
-  category: safe_driving_rules
-  question: 'Al estacionar cuesta arriba en una calle de doble sentido sin bordillo,
-    sus ruedas delanteras deben estar:'
-  choices:
-    A: Giradas hacia la izquierda (hacia la calle)
-    B: Giradas hacia la derecha (lejos de la calle)
-    C: Paralelas al borde de la carretera
-    D: Apuntando recto hacia adelante
-  answer: B
-  explanation: Al estacionar cuesta arriba o cuesta abajo sin bordillo, gire las ruedas
-    hacia la derecha (hacia el lado de la carretera) para que el vehículo ruede lejos
-    del centro de la carretera si fallan los frenos.
-- id: 8
-  category: signs_and_signals
-  question: 'Una luz roja intermitente en una intersección significa:'
-  choices:
-    A: Reducir la velocidad antes de entrar
-    B: Detenerse antes de entrar, luego avanzar cuando sea seguro
-    C: Detenerse y esperar la luz verde
-    D: Ceder el paso a todo el tráfico antes de entrar
-  answer: B
-  explanation: Una señal de tráfico con luz roja intermitente significa "ALTO". Después
-    de detenerse, puede avanzar cuando sea seguro, respetando las reglas de derecho
-    de paso.
-- id: 9
-  category: signs_and_signals
-  question: 'Dos líneas amarillas continuas en el centro de la calzada significan:'
-  choices:
-    A: Se permite rebasar desde cualquier dirección
-    B: Se permite rebasar solo si usted está en el lado derecho
-    C: No se permite rebasar desde ninguna dirección
-    D: La carretera se estrecha más adelante
-  answer: C
-  explanation: Dos líneas amarillas continuas indican que no se permite rebasar. No
-    debe conducir sobre estas líneas para rebasar a otros vehículos.
-- id: 10
-  category: defensive_driving
-  question: 'Para evitar seguir a otro vehículo demasiado cerca (tailgating), el Manual
-    del Automovilista de California recomienda usar la:'
-  choices:
-    A: Regla de los 2 segundos
-    B: Regla de los 3 segundos
-    C: Regla de los 4 segundos
-    D: Regla de los 5 segundos
-  answer: B
-  explanation: Para evitar seguir demasiado cerca, use la "regla de los 3 segundos"
-    para asegurarse de tener suficiente espacio para detenerse de manera segura si
-    el vehículo delante de usted frena repentinamente.
-- id: 11
-  category: penalties_and_points
-  question: 'Debe notificar al DMV en un plazo de 10 días si se ve involucrado en
-    una colisión que cause:'
-  choices:
-    A: Cualquier daño al vehículo
-    B: Más de $500 en daños
-    C: Más de $1,000 en daños o si alguien resulta herido o fallece
-    D: Que su vehículo tenga que ser remolcado
-  answer: C
-  explanation: Usted (o su agente de seguros, corredor o representante legal) debe
-    informar una colisión al DMV en un plazo de 10 días si causó más de $1,000 en
-    daños a la propiedad o si alguien resultó herido o falleció.
-- id: 12
-  category: sharing_the_road
-  question: 'Si un peatón está en un cruce de peatones, usted debe:'
-  choices:
-    A: Tocar la bocina para advertirle
-    B: Ceder el derecho de paso al peatón
-    C: Conducir alrededor de él con cuidado
-    D: Detenerse solo si está en su lado de la carretera
-  answer: B
-  explanation: Los peatones tienen el derecho de paso en los cruces de peatones marcados
-    o no marcados. Usted debe ceder el paso y permitirles cruzar de manera segura.
-- id: 13
   category: license_system
-  question: 'Con una licencia de conducir básica Clase C, una persona puede conducir:'
+  question: ¿A qué número de teléfono deben llamar las personas sordas, con dificultades
+    auditivas o con impedimentos del habla para recibir asistencia del DMV?
   choices:
-    A: Un vehículo de 3 ejes si el peso bruto del vehículo es inferior a 6,000 libras
-    B: Cualquier vehículo comercial
-    C: Un vehículo que remolca dos remolques
-    D: Una motocicleta
-  answer: A
-  explanation: Una licencia de conducir Clase C le permite conducir un vehículo de
-    2 ejes con un peso bruto vehicular (GVWR) de 26,000 libras o menos, o un vehículo
-    de 3 ejes que pese 6,000 libras o menos en bruto.
-- id: 14
-  category: defensive_driving
-  question: 'Al cambiar de carril, debe revisar sus puntos ciegos:'
-  choices:
-    A: Mirando por el espejo retrovisor
-    B: Mirando por los espejos laterales
-    C: Girando la cabeza y mirando por encima del hombro
-    D: Usando su cámara de reversa
-  answer: C
-  explanation: Los espejos no muestran sus puntos ciegos. Debe girar la cabeza y mirar
-    por encima del hombro para asegurarse de que un carril esté despejado antes de
-    cambiar de carril.
-- id: 15
-  category: safe_driving_rules
-  question: ¿Cuál es el principio fundamental de la 'Ley de Velocidad Básica' (Basic
-    Speed Law) de California?
-  choices:
-    A: Nunca puede conducir más rápido que el límite de velocidad establecido.
-    B: Nunca puede conducir más rápido de lo que sea seguro para las condiciones actuales.
-    C: Siempre debe conducir al ritmo del flujo del tráfico, independientemente del
-      límite de velocidad.
-    D: Debe conducir al menos 10 mph por debajo del límite de velocidad en caso de
-      mal tiempo.
+    A: 1-800-777-0133
+    B: 1-800-368-4327
+    C: 1-800-555-0199
+    D: 1-800-DMV-HELP
   answer: B
-  explanation: La 'Ley de Velocidad Básica' de California establece que nunca se debe
-    conducir más rápido de lo que sea seguro para las condiciones actuales, independientemente
-    del límite de velocidad indicado.
-- id: 16
-  category: alcohol_drugs_health
-  question: ¿Cuál es el límite legal de concentración de alcohol en sangre (BAC) para
-    un conductor de 21 años de edad o más?
+  explanation: De acuerdo con la sección de Servicios del DMV, las personas sordas,
+    con dificultades auditivas o con impedimentos del habla pueden llamar al 1-800-368-4327
+    para recibir asistencia.
+- id: 2
+  category: license_system
+  question: ¿Qué tipo de licencia de conducir necesita la mayoría de las personas
+    para conducir un vehículo de pasajeros estándar en California?
   choices:
-    A: 0.04%
-    B: 0.06%
-    C: 0.08%
-    D: 0.10%
+    A: Clase A comercial
+    B: Clase B no comercial
+    C: Clase C no comercial
+    D: Clase C comercial
   answer: C
-  explanation: Es ilegal que cualquier persona de 21 años de edad o más opere un vehículo
-    con una concentración de alcohol en sangre (BAC) de 0.08% o superior.
+  explanation: El manual establece que debe tener la licencia correcta para conducir
+    su tipo de vehículo, y la mayoría de las personas necesitan una licencia de conducir
+    Clase C no comercial.
+- id: 3
+  category: license_system
+  question: A partir de mayo de 2025, ¿qué le permitirá hacer una licencia de conducir
+    o tarjeta de identificación que cumpla con la ley REAL ID?
+  choices:
+    A: Conducir vehículos comerciales a través de las fronteras estatales
+    B: Abordar un avión para vuelos nacionales
+    C: Viajar internacionalmente sin pasaporte
+    D: Votar en elecciones federales
+  answer: B
+  explanation: A partir de mayo de 2025, su licencia de conducir o tarjeta de identificación
+    debe cumplir con la ley REAL ID si la utiliza para abordar un avión en vuelos
+    nacionales, ingresar a bases militares o entrar a la mayoría de las instalaciones
+    federales.
+- id: 4
+  category: license_system
+  question: ¿Cuál de las siguientes afirmaciones es verdadera con respecto a las licencias
+    de conducir para residentes indocumentados en California?
+  choices:
+    A: Solo se emiten para fines de conducción comercial.
+    B: No están disponibles en el estado de California.
+    C: California ofrece licencias de conducir para todos los residentes, independientemente
+      de su estatus migratorio.
+    D: Solo son válidas por un máximo de 6 meses.
+  answer: C
+  explanation: El manual establece explícitamente que California ofrece licencias
+    de conducir para todos los residentes, independientemente de su estatus migratorio.
+- id: 5
+  category: license_system
+  question: ¿Cuál es una restricción de una tarjeta de identificación (ID) de California?
+  choices:
+    A: Solo se emite a personas mayores de 18 años.
+    B: No le permite conducir.
+    C: No puede utilizarse para fines de identificación oficial.
+    D: Requiere aprobar un examen de la vista y de conocimientos.
+  answer: B
+  explanation: Las tarjetas de identificación se emiten con fines de identificación
+    a personas elegibles de cualquier edad, pero el manual señala que no le permiten
+    conducir.
+- id: 6
+  category: license_system
+  question: Al solicitar un permiso de instrucción o una licencia de conducir, ¿cuántos
+    comprobantes de residencia en California se requieren generalmente?
+  choices:
+    A: Uno
+    B: Dos
+    C: Tres
+    D: Cuatro
+  answer: B
+  explanation: Para solicitar un permiso de instrucción o una licencia de conducir,
+    debe proporcionar dos comprobantes de residencia para demostrar que vive en California
+    (aunque pueden aplicarse excepciones).
+- id: 7
+  category: driver_testing
+  question: ¿Cuál de los siguientes es un requisito para solicitar un permiso de instrucción
+    Clase C?
+  choices:
+    A: Aprobar un examen de conducción al volante
+    B: Pagar una tarifa de solicitud reembolsable
+    C: Aprobar un examen de la vista
+    D: Ser propietario de un vehículo registrado
+  answer: C
+  explanation: Solicitar un permiso de instrucción Clase C requiere que complete una
+    solicitud, proporcione documentos, pague una tarifa no reembolsable, apruebe su(s)
+    examen(es) de conocimientos y apruebe un examen de la vista.
+- id: 8
+  category: license_system
+  question: ¿Cuál es el requisito de edad mínima para solicitar un permiso de instrucción
+    si es menor de 18 años?
+  choices:
+    A: 15 años
+    B: 15½ años
+    C: 16 años
+    D: 16½ años
+  answer: B
+  explanation: Si es menor de 18 años, debe tener al menos 15 años y medio para solicitar
+    un permiso de instrucción.
+- id: 9
+  category: driver_testing
+  question: Si es menor de 18 años, ¿cuándo puede empezar a usar su permiso de instrucción
+    para practicar la conducción?
+  choices:
+    A: Inmediatamente después de aprobar el examen escrito de conocimientos
+    B: Después de comenzar el entrenamiento de conducción al volante con un instructor
+      que valide el permiso
+    C: Tan pronto como su padre, madre o tutor firme el permiso
+    D: Después de haber tenido el permiso durante al menos 30 días
+  answer: B
+  explanation: Los menores deben esperar para usar su permiso de instrucción hasta
+    que comiencen el entrenamiento de conducción al volante con un instructor que
+    validará el permiso.
+- id: 10
+  category: driver_testing
+  question: ¿Qué deben llevar consigo los instructores de las escuelas de manejo autorizadas
+    por el DMV?
+  choices:
+    A: Una licencia de conducir comercial
+    B: Una copia del Código de Vehículos de California
+    C: Una tarjeta de identificación de instructor
+    D: Comprobante de seguro para vehículos de doble control
+  answer: C
+  explanation: El manual establece que los instructores de las escuelas de manejo
+    deben llevar una tarjeta de identificación de instructor, y usted debe pedir verla.
+- id: 11
+  category: driver_testing
+  question: Si usted es un adulto que practica la conducción con un permiso de instrucción,
+    ¿quién debe acompañarlo en el vehículo?
+  choices:
+    A: Un conductor con licencia de California que tenga al menos 18 años de edad
+    B: Un conductor con licencia de California que tenga al menos 25 años de edad
+    C: Cualquier conductor con licencia de cualquier estado
+    D: Un instructor de manejo certificado por el DMV
+  answer: A
+  explanation: Para obtener su licencia de conducir, debe practicar la conducción
+    con un conductor con licencia de California que tenga al menos 18 años de edad
+    (o 25 para menores).
+- id: 12
+  category: driver_testing
+  question: Si es menor de 18 años, ¿cuántas horas de práctica de conducción debe
+    completar antes de solicitar una licencia de conducir?
+  choices:
+    A: 30 horas
+    B: 40 horas
+    C: 50 horas
+    D: 60 horas
+  answer: C
+  explanation: Los menores deben practicar la conducción durante al menos 50 horas
+    con un conductor con licencia de California que tenga al menos 25 años de edad.
+- id: 13
+  category: driver_testing
+  question: De las horas de práctica de conducción requeridas para menores, ¿cuántas
+    deben completarse por la noche?
+  choices:
+    A: 5 horas
+    B: 10 horas
+    C: 15 horas
+    D: 20 horas
+  answer: B
+  explanation: El manual especifica que de las 50 horas de práctica requeridas para
+    menores, diez horas deben ser por la noche.
+- id: 14
+  category: driver_testing
+  question: Si es menor de 18 años, ¿cuánto tiempo debe tener su permiso de instrucción
+    antes de programar su examen de conducción al volante?
+  choices:
+    A: Al menos 3 meses
+    B: Al menos 6 meses
+    C: Al menos 9 meses
+    D: Al menos 12 meses
+  answer: B
+  explanation: Los menores deben tener un permiso de instrucción de California o de
+    otro estado durante al menos 6 meses (o cumplir 18 años) antes de programar el
+    examen de conducción al volante.
+- id: 15
+  category: driver_responsibility
+  question: Cuando un menor (menor de 18 años) practica la conducción con un permiso
+    de instrucción, ¿qué edad mínima debe tener el conductor con licencia de California
+    que lo acompaña?
+  choices:
+    A: 18 años de edad
+    B: 21 años de edad
+    C: 25 años de edad
+    D: 30 años de edad
+  answer: C
+  explanation: Los menores deben practicar la conducción con un conductor con licencia
+    de California que tenga al menos 25 años de edad.
+- id: 16
+  category: license_system
+  question: ¿Cuántas horas de práctica de conducción debe completar un menor antes
+    de programar un examen de conducción al volante?
+  choices:
+    A: 30 horas
+    B: 40 horas
+    C: 50 horas
+    D: 60 horas
+  answer: C
+  explanation: Los menores deben practicar la conducción durante al menos 50 horas
+    con un conductor con licencia de California que tenga al menos 25 años de edad,
+    y 10 de esas horas deben ser por la noche.
 - id: 17
+  category: license_system
+  question: Durante los primeros 12 meses de tener una licencia provisional, ¿entre
+    qué horas tiene restringido conducir un menor?
+  choices:
+    A: 10 p.m. y 5 a.m.
+    B: 11 p.m. y 5 a.m.
+    C: Medianoche y 6 a.m.
+    D: 11 p.m. y 6 a.m.
+  answer: B
+  explanation: Como conductor provisional, no puede conducir entre las 11 p.m. y las
+    5 a.m. durante los primeros 12 meses que tenga su licencia.
+- id: 18
+  category: license_system
+  question: Si un conductor provisional necesita conducir durante las horas restringidas
+    por motivos de trabajo, ¿qué debe llevar consigo?
+  choices:
+    A: Una nota firmada por un médico
+    B: Una nota firmada por el director de su escuela
+    C: Una nota firmada por su empleador que confirme el empleo
+    D: Una copia de su talón de pago más reciente
+  answer: C
+  explanation: Si debe conducir por motivos de trabajo durante las horas restringidas,
+    debe llevar una nota firmada por su empleador que confirme su empleo.
+- id: 19
+  category: driver_testing
+  question: ¿Cuánto tiempo debe esperar un menor para volver a tomar un examen de
+    conocimientos reprobado?
+  choices:
+    A: 3 días
+    B: 7 días
+    C: 14 días
+    D: 30 días
+  answer: B
+  explanation: Los menores deben esperar siete días para volver a tomar un examen
+    de conocimientos reprobado, sin incluir el día del reprobado.
+- id: 20
+  category: vehicle_information
+  question: ¿Cuál es la profundidad mínima requerida de la banda de rodadura de los
+    neumáticos para un vehículo utilizado en el examen de conducción al volante?
+  choices:
+    A: 1/16 de pulgada
+    B: 1/32 de pulgada
+    C: 2/32 de pulgada
+    D: 1/8 de pulgada
+  answer: B
+  explanation: El manual establece que los neumáticos deben tener al menos 1/32 de
+    pulgada de profundidad de banda de rodadura uniforme, y no se permiten neumáticos
+    de repuesto temporales (tipo "donut").
+- id: 21
+  category: vehicle_information
+  question: 'Durante la inspección previa a la conducción, la bocina de su vehículo
+    debe ser lo suficientemente fuerte como para ser escuchada desde una distancia
+    de al menos:'
+  choices:
+    A: 100 pies
+    B: 200 pies
+    C: 300 pies
+    D: 500 pies
+  answer: B
+  explanation: La bocina del vehículo debe estar diseñada para el vehículo, en condiciones
+    de funcionamiento adecuadas y ser lo suficientemente fuerte como para ser escuchada
+    desde una distancia de al menos 200 pies.
+- id: 22
+  category: driver_testing
+  question: ¿Cuál de las siguientes tecnologías del vehículo está permitido utilizar
+    durante el examen de conducción al volante?
+  choices:
+    A: Estacionamiento en paralelo automatizado
+    B: Advertencias de salida de carril
+    C: Control de crucero adaptativo
+    D: Cámaras de visión trasera (backup cameras)
+  answer: D
+  explanation: La tecnología de seguridad del vehículo, como las cámaras de visión
+    trasera y los monitores de punto ciego, se pueden utilizar en el examen de conducción,
+    pero no se permiten los sistemas avanzados de asistencia al conductor, como el
+    estacionamiento en paralelo automatizado.
+- id: 23
+  category: license_system
+  question: Si se muda, ¿cuántos días tiene para notificar al DMV su nueva dirección?
+  choices:
+    A: 5 días
+    B: 10 días
+    C: 14 días
+    D: 30 días
+  answer: B
+  explanation: Si se muda, debe notificar al DMV su nueva dirección dentro de los
+    diez días.
+- id: 24
+  category: license_system
+  question: 'Si se encuentra fuera del estado y no puede renovar su licencia de conducir,
+    puede solicitar una extensión de hasta:'
+  choices:
+    A: 30 días
+    B: 6 meses
+    C: 1 año
+    D: 2 años
+  answer: C
+  explanation: Si se encuentra fuera del estado y no puede renovar, puede solicitar
+    una extensión de un año de su licencia de conducir enviando una solicitud al DMV.
+- id: 25
+  category: safe_driving_rules
+  question: En lo que respecta a la audición y la conducción, ¿cuál de las siguientes
+    opciones es ilegal en California?
+  choices:
+    A: Escuchar la radio a un volumen alto
+    B: Usar auriculares o tapones para los oídos en ambos oídos mientras conduce
+    C: Conducir si es completamente sordo
+    D: Usar un auricular manos libres en un solo oído
+  answer: B
+  explanation: Según el manual, es ilegal usar auriculares o tapones para los oídos
+    en ambos oídos mientras se conduce.
+- id: 26
+  category: alcohol_drugs_health
+  question: Los médicos están obligados a informar al DMV sobre los pacientes con
+    condiciones médicas que puedan afectar su capacidad para conducir de manera segura
+    si el paciente tiene al menos ¿qué edad?
+  choices:
+    A: 14 años
+    B: 16 años
+    C: 18 años
+    D: 21 años
+  answer: A
+  explanation: Los médicos están obligados a informar al DMV sobre los pacientes que
+    tienen al menos 14 años por condiciones médicas que puedan afectar su capacidad
+    para conducir de manera segura, como una pérdida de conciencia.
+- id: 27
+  category: safe_driving_rules
+  question: Al utilizar el método de dirección de mano a mano (empujar/tirar), ¿dónde
+    deben comenzar sus manos en el volante?
+  choices:
+    A: Las 10 y las 2 en punto
+    B: Las 9 y las 3 en punto o las 8 y las 4 en punto
+    C: Las 11 y la 1 en punto
+    D: Las 7 y las 5 en punto
+  answer: B
+  explanation: Para utilizar el método de dirección de mano a mano, debe comenzar
+    con las manos en las posiciones de las 9 y las 3 en punto o las 8 y las 4 en punto.
+- id: 28
+  category: driver_testing
+  question: ¿A quién se le permite generalmente acompañarlo en el vehículo durante
+    el examen de conducción al volante?
+  choices:
+    A: Un padre o tutor
+    B: Un instructor de manejo con licencia
+    C: Un intérprete
+    D: Solo el examinador
+  answer: D
+  explanation: Solo el examinador tiene permitido acompañarlo durante el examen de
+    conducción. Se hacen excepciones para capacitación, animales de servicio y ciertas
+    situaciones de cumplimiento de la ley.
+- id: 29
+  category: vehicle_information
+  question: ¿Cuántos espejos retrovisores se requieren en su vehículo para el examen
+    de conducción al volante?
+  choices:
+    A: Al menos uno en el lado izquierdo
+    B: Al menos dos, con uno de ellos en el lado izquierdo
+    C: Al menos dos, con uno en el lado derecho
+    D: Tres espejos (izquierdo, derecho y central)
+  answer: B
+  explanation: La inspección previa a la conducción requiere al menos dos espejos
+    retrovisores, y uno de ellos debe estar en el lado izquierdo de su vehículo.
+- id: 30
+  category: vehicle_information
+  question: ¿Cuál es la posición inicial recomendada de las manos para el método de
+    dirección de mano a mano (empujar/tirar)?
+  choices:
+    A: Las 10 y las 2 en punto
+    B: Las 9 y las 3 en punto o las 8 y las 4 en punto
+    C: Las 12 y las 6 en punto
+    D: Las 11 y la 1 en punto
+  answer: B
+  explanation: Para la dirección de mano a mano, el manual indica comenzar con las
+    manos en las posiciones de las 9 y las 3 en punto o las 8 y las 4 en punto.
+- id: 31
+  category: vehicle_information
+  question: ¿Cuándo es apropiado usar el volante con una sola mano en la posición
+    de las 12 en punto?
+  choices:
+    A: Al conducir en la autopista
+    B: Al recuperarse de un derrape
+    C: Al girar mientras se retrocede para ver hacia dónde se va
+    D: Al estacionar a bajas velocidades
+  answer: C
+  explanation: El manual establece que puede usar el volante con una sola mano en
+    la posición de las 12 en punto cuando esté girando mientras retrocede para ver
+    hacia dónde se dirige detrás de usted.
+- id: 32
+  category: safe_driving_rules
+  question: ¿Con cuánta anticipación debe señalizar antes de cambiar de carril en
+    una autopista?
+  choices:
+    A: Al menos 50 pies
+    B: Al menos 100 pies
+    C: Al menos tres segundos
+    D: Al menos cinco segundos
+  answer: D
+  explanation: Debe señalizar al menos cinco segundos antes de cambiar de carril en
+    una autopista.
+- id: 33
+  category: defensive_driving
+  question: ¿Debe usar su bocina para alertar al tráfico que viene en sentido contrario
+    en carreteras de montaña estrechas si no puede ver al menos a qué distancia hacia
+    adelante?
+  choices:
+    A: 100 pies
+    B: 200 pies
+    C: 300 pies
+    D: 500 pies
+  answer: B
+  explanation: Use su bocina para alertar al tráfico que viene en sentido contrario
+    en carreteras de montaña estrechas donde no pueda ver al menos a 200 pies de distancia.
+- id: 34
+  category: safe_driving_rules
+  question: ¿Cuándo debe cambiar sus luces altas a luces bajas al seguir a otro vehículo?
+  choices:
+    A: A menos de 200 pies
+    B: A menos de 300 pies
+    C: A menos de 400 pies
+    D: A menos de 500 pies
+  answer: B
+  explanation: Debe cambiar sus luces altas a luces bajas a menos de 300 pies de un
+    vehículo al que esté siguiendo.
+- id: 35
+  category: safe_driving_rules
+  question: ¿Qué debe hacer si las condiciones climáticas adversas requieren que use
+    sus limpiaparabrisas?
+  choices:
+    A: Encender las luces altas
+    B: Encender las luces de emergencia
+    C: Encender las luces bajas
+    D: Conducir usando solo las luces de estacionamiento
+  answer: C
+  explanation: Si necesita usar sus limpiaparabrisas debido a la niebla, lluvia o
+    nieve, debe encender las luces bajas.
+- id: 36
+  category: defensive_driving
+  question: Si ve una colisión más adelante y desea advertir a los conductores que
+    vienen detrás de usted, ¿cuál de los siguientes es un método aprobado?
+  choices:
+    A: Tocar la bocina continuamente
+    B: Presionar ligeramente el pedal del freno tres o cuatro veces
+    C: Encender las luces altas
+    D: Virar ligeramente de un lado a otro
+  answer: B
+  explanation: Para advertir a los conductores detrás de usted sobre una colisión
+    o peligro más adelante, puede encender sus luces de emergencia, presionar ligeramente
+    el pedal del freno tres o cuatro veces o usar una señal manual.
+- id: 37
+  category: signs_and_signals
+  question: ¿Qué significa cuando ve dos conjuntos de líneas amarillas dobles continuas
+    con una separación de dos o más pies?
+  choices:
+    A: Es un carril central para girar a la izquierda
+    B: Es una zona de adelantamiento designada
+    C: Se considera una barrera y no debe conducir sobre ella ni cruzarla
+    D: Indica un próximo carril para vehículos con alta ocupación (carpool)
+  answer: C
+  explanation: Dos conjuntos de líneas amarillas dobles continuas con una separación
+    de dos o más pies se consideran una barrera. No conduzca sobre esta barrera ni
+    la cruce, excepto en las aberturas designadas.
+- id: 38
+  category: signs_and_signals
+  question: ¿Qué afirmación es verdadera con respecto a las líneas blancas dobles
+    continuas?
+  choices:
+    A: Puede cruzarlas para entrar en un carril de viaje compartido (carpool)
+    B: Separan el tráfico que va en direcciones opuestas
+    C: Nunca debe cambiar de carril sobre ellas
+    D: Indican un área de apartadero (turnout)
+  answer: C
+  explanation: Las líneas blancas dobles continuas indican una barrera de carril entre
+    un carril de uso regular y uno de uso preferencial. Nunca debe cambiar de carril
+    sobre líneas blancas dobles continuas.
+- id: 39
+  category: signs_and_signals
+  question: ¿Cómo se marca una línea de ceda el paso (yield line) en la carretera?
+  choices:
+    A: Una línea de triángulos blancos sólidos que apuntan hacia los vehículos que
+      se aproximan
+    B: Líneas blancas discontinuas grandes
+    C: Una sola línea amarilla continua
+    D: Una línea de diamantes blancos sólidos
+  answer: A
+  explanation: Una línea de ceda el paso es una línea de triángulos blancos sólidos
+    que indica a los vehículos que se aproximan dónde deben ceder el paso o detenerse.
+    Los triángulos apuntan hacia los vehículos que se aproximan.
+- id: 40
+  category: safe_driving_rules
+  question: Si una carretera tiene varios carriles que viajan en la misma dirección,
+    ¿para qué se utiliza principalmente el carril del extremo izquierdo (Carril número
+    1)?
+  choices:
+    A: Entrar o salir del tráfico
+    B: Conducir lentamente
+    C: Adelantar o girar a la izquierda
+    D: Estacionar
+  answer: C
+  explanation: Debe usar el carril izquierdo (Carril número 1) para adelantar o girar
+    a la izquierda.
+- id: 41
+  category: safe_driving_rules
+  question: Al prepararse para cambiar de carril, ¿cuál de las siguientes afirmaciones
+    es verdadera?
+  choices:
+    A: Debe reducir la velocidad antes de comenzar el cambio de carril
+    B: No es necesario reducir la velocidad antes de un cambio de carril
+    C: Solo necesita revisar sus espejos, no sus puntos ciegos
+    D: Debe zigzaguear entre el tráfico para encontrar el mejor carril
+  answer: B
+  explanation: Al cambiar de carril, asegúrese de que haya suficiente espacio para
+    su vehículo en el carril contiguo. No es necesario reducir la velocidad antes
+    de un cambio de carril.
+- id: 42
+  category: sharing_the_road
+  question: ¿A cuál de los siguientes vehículos se le permite generalmente usar un
+    carril para vehículos de alta ocupación (HOV) sin cumplir con el requisito mínimo
+    de pasajeros?
+  choices:
+    A: Cualquier vehículo que remolque un tráiler
+    B: Una motocicleta
+    C: Un sedán de gasolina con un solo ocupante
+    D: Un camión de reparto comercial
+  answer: B
+  explanation: Para usar un carril HOV, debe cumplir con el requisito mínimo de pasajeros,
+    conducir un vehículo de bajas o nulas emisiones con una calcomanía especial, o
+    ir en una motocicleta (a menos que se indique lo contrario).
+- id: 43
+  category: safe_driving_rules
+  question: ¿Cuál es la distancia máxima que puede conducir en un carril central para
+    girar a la izquierda?
+  choices:
+    A: 50 pies
+    B: 100 pies
+    C: 200 pies
+    D: 300 pies
+  answer: C
+  explanation: Solo puede conducir por 200 pies en el carril central para girar a
+    la izquierda antes de realizar un giro a la izquierda o un giro en U.
+- id: 44
+  category: safe_driving_rules
+  question: ¿Cuándo debe usar un área o carril de apartadero (turnout) para dejar
+    pasar a otros vehículos?
+  choices:
+    A: Cuando conduce lentamente en una carretera de dos carriles, rebasar no es seguro
+      y hay cinco o más vehículos siguiéndolo
+    B: Cuando necesita detenerse y hacer una llamada telefónica
+    C: Cuando conduce por una autopista y desea salir
+    D: Cuando hay tres vehículos siguiéndolo de cerca
+  answer: A
+  explanation: Debe usar un área o carril de apartadero para dejar pasar a otros vehículos
+    cuando conduce lentamente en una carretera de dos carriles, donde rebasar no es
+    seguro y hay cinco o más vehículos siguiéndolo.
+- id: 45
+  category: sharing_the_road
+  question: ¿Con cuánta anticipación a una intersección se le permite conducir en
+    un carril para bicicletas para realizar un giro?
+  choices:
+    A: Dentro de los 50 pies
+    B: Dentro de los 100 pies
+    C: Dentro de los 200 pies
+    D: Dentro de los 300 pies
+  answer: C
+  explanation: Es ilegal conducir en un carril para bicicletas a menos que esté estacionando,
+    entrando o saliendo de la carretera, o girando (dentro de los 200 pies de una
+    intersección).
+- id: 46
+  category: sharing_the_road
+  question: ¿Cuál es la distancia mínima que debe mantenerse entre un vehículo y un
+    ciclista en una vía compartida?
+  choices:
+    A: Dos (2) pies
+    B: Tres (3) pies
+    C: Cuatro (4) pies
+    D: Cinco (5) pies
+  answer: B
+  explanation: Se debe mantener una distancia de tres (3) pies entre el automóvil
+    y el ciclista.
+- id: 47
+  category: safe_driving_rules
+  question: ¿Con cuánta anticipación a un giro debe comenzar a señalizar?
+  choices:
+    A: Aproximadamente 50 pies antes del giro
+    B: Aproximadamente 100 pies antes del giro
+    C: Aproximadamente 200 pies antes del giro
+    D: Aproximadamente 400 pies antes del giro
+  answer: B
+  explanation: Para realizar un giro a la derecha o a la izquierda, debe comenzar
+    a señalizar aproximadamente 100 pies antes del giro.
+- id: 48
+  category: signs_and_signals
+  question: ¿Se le permite girar a la derecha frente a una luz de flecha roja?
+  choices:
+    A: Sí, después de detenerse por completo.
+    B: Sí, si no hay peatones en el cruce peatonal.
+    C: No, debe esperar hasta que la luz cambie a verde.
+    D: No, a menos que se encuentre en un carril exclusivo para girar a la derecha.
+  answer: C
+  explanation: No puede girar a la derecha si está detenido ante una luz de flecha
+    roja. Espere hasta que la luz cambie a verde antes de realizar su giro.
+- id: 49
+  category: sharing_the_road
+  question: ¿Puede cruzar un carril designado para autobuses de tránsito público para
+    realizar un giro a la derecha?
+  choices:
+    A: Sí, puede cruzar un carril de autobús para realizar un giro a la derecha.
+    B: No, es ilegal entrar en un carril de autobús en cualquier momento.
+    C: Sí, pero solo si conduce un vehículo de tránsito público.
+    D: No, a menos que el semáforo esté en verde.
+  answer: A
+  explanation: Es ilegal conducir, detenerse, estacionar o dejar un vehículo en un
+    área designada para autobuses de tránsito público. Sin embargo, puede cruzar un
+    carril de autobús para realizar un giro a la derecha.
+- id: 50
+  category: defensive_driving
+  question: ¿Cómo deben estar posicionadas sus ruedas mientras espera para realizar
+    un giro a la izquierda?
+  choices:
+    A: Apuntando hacia la izquierda
+    B: Apuntando hacia la derecha
+    C: Apuntando hacia adelante
+    D: Giradas ligeramente hacia la acera
+  answer: C
+  explanation: Mantenga sus ruedas apuntando hacia adelante hasta que sea seguro comenzar
+    su giro. Si sus ruedas apuntan hacia la izquierda y un vehículo lo golpea por
+    detrás, podría ser empujado hacia el tráfico en sentido contrario.
+- id: 51
+  category: safe_driving_rules
+  question: ¿Bajo qué condición puede girar a la izquierda con semáforo en rojo?
+  choices:
+    A: Al girar desde una calle de doble sentido hacia una calle de sentido único.
+    B: Al girar desde una calle de sentido único hacia otra calle de sentido único.
+    C: Al girar desde una calle de sentido único hacia una calle de doble sentido.
+    D: Los giros a la izquierda con semáforo en rojo nunca están permitidos.
+  answer: B
+  explanation: Puede girar a la izquierda con semáforo en rojo cuando gira desde una
+    calle de sentido único hacia otra calle de sentido único, siempre que no haya
+    una señal que prohíba el giro.
+- id: 52
+  category: safe_driving_rules
+  question: ¿Cuándo es legal dar una vuelta en U en un distrito residencial?
+  choices:
+    A: En cualquier momento, independientemente del tráfico que se aproxime.
+    B: Si no se aproximan vehículos a menos de 100 pies.
+    C: Si no se aproximan vehículos a menos de 200 pies.
+    D: Las vueltas en U están estrictamente prohibidas en todos los distritos residenciales.
+  answer: C
+  explanation: Puede dar una vuelta en U en un distrito residencial si no se aproximan
+    vehículos a menos de 200 pies.
+- id: 53
+  category: safe_driving_rules
+  question: ¿En cuál de los siguientes lugares NUNCA es legal dar una vuelta en U?
+  choices:
+    A: A través de una línea amarilla doble.
+    B: En una intersección con el semáforo en verde.
+    C: En una carretera dividida si hay una apertura en el divisor central.
+    D: En o sobre un cruce de ferrocarril.
+  answer: D
+  explanation: Nunca debe dar una vuelta en U en o sobre un cruce de ferrocarril.
+- id: 54
+  category: defensive_driving
+  question: Al detenerse detrás de otro vehículo en una intersección, ¿cuánto espacio
+    debe dejar?
+  choices:
+    A: Exactamente la longitud de un automóvil.
+    B: Suficiente espacio para ver sus ruedas traseras.
+    C: Tres segundos de espacio.
+    D: Al menos 10 pies.
+  answer: B
+  explanation: Al detenerse detrás de un vehículo, deje suficiente espacio para ver
+    sus ruedas traseras.
+- id: 55
+  category: safe_driving_rules
+  question: Al incorporarse a una autopista, ¿a qué velocidad debería conducir?
+  choices:
+    A: 10 mph por debajo del límite de velocidad indicado.
+    B: A la velocidad del tráfico o cerca de ella.
+    C: El límite de velocidad exacto indicado.
+    D: 5 mph más rápido que el tráfico de la autopista.
+  answer: B
+  explanation: Al entrar en una autopista, deberá circular a la velocidad del tráfico
+    o cerca de ella.
+- id: 56
+  category: safe_driving_rules
+  question: ¿Cuánto tiempo antes de salir de una autopista debe poner la señal de
+    giro?
+  choices:
+    A: Dos segundos
+    B: Tres segundos
+    C: Cinco segundos (aproximadamente 400 pies)
+    D: Diez segundos (aproximadamente 800 pies)
+  answer: C
+  explanation: Cuando esté en el carril adecuado, ponga la señal cinco segundos (aproximadamente
+    400 pies) antes de salir.
+- id: 57
+  category: safe_driving_rules
+  question: Al girar a la izquierda desde una calle de doble sentido hacia una calle
+    de sentido único con tres o más carriles, ¿en qué carril puede terminar su giro?
+  choices:
+    A: Solo en el carril del extremo izquierdo.
+    B: Solo en el carril central.
+    C: Solo en el carril del extremo derecho.
+    D: Cualquier carril que esté abierto.
+  answer: D
+  explanation: Al girar a la izquierda desde una calle de doble sentido hacia una
+    calle de sentido único, si hay tres o más carriles en su dirección de viaje, puede
+    terminar su giro en cualquier carril que esté abierto.
+- id: 58
+  category: sharing_the_road
+  question: ¿Qué tipo de vía para bicicletas está físicamente separada del tráfico
+    de vehículos motorizados y es para uso exclusivo de ciclistas?
+  choices:
+    A: Carril de bicicletas con zona de amortiguamiento (Buffered bike lane)
+    B: Bulevar para bicicletas (Bicycle boulevard)
+    C: Vía ciclista separada (Separated bikeway)
+    D: Calzada compartida (Shared roadway)
+  answer: C
+  explanation: Una vía ciclista separada está físicamente separada del tráfico de
+    vehículos motorizados y es para uso exclusivo de ciclistas. También se conocen
+    como ciclovías o carriles de bicicletas protegidos.
+- id: 59
+  category: safe_driving_rules
+  question: Al prepararse para salir de una autopista, ¿con cuánta anticipación aproximadamente
+    debe poner la señal?
+  choices:
+    A: 100 pies
+    B: 200 pies
+    C: 300 pies
+    D: 400 pies
+  answer: D
+  explanation: El manual establece que cuando esté en el carril adecuado, debe poner
+    la señal cinco segundos (aproximadamente 400 pies) antes de salir.
+- id: 60
+  category: safe_driving_rules
+  question: 'Al incorporarse al tráfico desde una parada total en una calle de la
+    ciudad, necesita un espacio que sea de aproximadamente:'
+  choices:
+    A: 50 pies
+    B: 100 pies
+    C: 150 pies
+    D: 300 pies
+  answer: C
+  explanation: Para incorporarse, entrar o salir del tráfico, necesita un espacio
+    que sea de media cuadra en las calles de la ciudad, lo cual es aproximadamente
+    150 pies.
+- id: 61
+  category: defensive_driving
+  question: Usted está esperando para girar a la izquierda y un vehículo que viene
+    en sentido contrario tiene encendida la luz direccional derecha. ¿Qué debe hacer?
+  choices:
+    A: Comenzar su giro inmediatamente ya que ellos están girando.
+    B: Esperar a que el vehículo comience su giro antes de iniciar su giro a la izquierda.
+    C: Tocar la bocina para asegurarse de que lo vean antes de girar.
+    D: Girar a la derecha en su lugar para evitar una colisión.
+  answer: B
+  explanation: El manual aconseja no asumir que un vehículo que viene en sentido contrario
+    con la luz direccional derecha encendida va a girar antes de llegar a usted. Debe
+    esperar a que el vehículo comience su giro antes de iniciar el giro a la izquierda.
+- id: 62
+  category: safe_driving_rules
+  question: Para rebasar a otro vehículo de manera segura al acercarse a una colina
+    o curva, ¿a qué distancia mínima debe estar la colina o curva?
+  choices:
+    A: Un cuarto de milla
+    B: Un tercio de milla
+    C: Media milla
+    D: Una milla completa
+  answer: B
+  explanation: Según el manual, para rebasar de manera segura, la colina o curva debe
+    estar al menos a un tercio de milla de distancia.
+- id: 63
+  category: safe_driving_rules
+  question: Es peligroso e ilegal rebasar a otro vehículo a menos de cuántos pies
+    de una intersección, puente, túnel o cruce de ferrocarril?
+  choices:
+    A: 50 pies
+    B: 100 pies
+    C: 200 pies
+    D: 300 pies
+  answer: B
+  explanation: No debe rebasar a menos de 100 pies de una intersección, puente, túnel,
+    cruce de ferrocarril u otra área peligrosa.
+- id: 64
+  category: safe_driving_rules
+  question: ¿Bajo cuál de las siguientes circunstancias se le permite rebasar a un
+    vehículo por la derecha?
+  choices:
+    A: Cuando el conductor delante de usted está señalizando un giro a la derecha.
+    B: Cuando está conduciendo sobre un arcén (shoulder) no pavimentado.
+    C: Cuando el conductor delante de usted está girando a la izquierda y usted puede
+      rebasar con seguridad por la derecha.
+    D: Siempre que el vehículo de adelante circule por debajo del límite de velocidad.
+  answer: C
+  explanation: Puede rebasar por la derecha solo cuando el conductor delante de usted
+    esté girando a la izquierda y usted pueda rebasar con seguridad por la derecha,
+    en una calle de un solo sentido, o en una carretera abierta con dos o más carriles
+    en su dirección.
+- id: 65
+  category: sharing_the_road
+  question: Si otro vehículo lo está rebasando, ¿qué debe hacer?
+  choices:
+    A: Acelerar para evitar que lo rebasen.
+    B: Reducir la velocidad drásticamente y moverse al arcén (shoulder).
+    C: Mantener su posición en el carril y su velocidad.
+    D: Encender sus luces de emergencia.
+  answer: C
+  explanation: Si un vehículo lo está rebasando o señaliza que planea rebasarlo, permita
+    que el vehículo pase manteniendo su posición en el carril y su velocidad.
+- id: 66
+  category: safe_driving_rules
+  question: 'Cuando haya estacionado en paralelo con éxito, su vehículo debe estar
+    paralelo al bordillo (curb) y a una distancia de:'
+  choices:
+    A: 12 pulgadas del bordillo.
+    B: 18 pulgadas del bordillo.
+    C: 24 pulgadas del bordillo.
+    D: 36 pulgadas del bordillo.
+  answer: B
+  explanation: Al enderezarse durante el estacionamiento en paralelo, su vehículo
+    debe estar paralelo y a menos de 18 pulgadas del bordillo.
+- id: 67
+  category: safe_driving_rules
+  question: ¿Hacia dónde debe girar las ruedas delanteras al estacionar cuesta arriba
+    junto a un bordillo (curb)?
+  choices:
+    A: Gire las ruedas delanteras en dirección contraria al bordillo.
+    B: Gire las ruedas delanteras hacia el bordillo.
+    C: Mantenga las ruedas delanteras perfectamente rectas.
+    D: Gire las ruedas delanteras hacia la derecha.
+  answer: A
+  explanation: Cuando esté cuesta arriba, debe girar las ruedas delanteras en dirección
+    contraria al bordillo (hacia la izquierda, hacia el centro de la carretera) y
+    dejar que su vehículo ruede hacia atrás unos centímetros para que la rueda toque
+    suavemente el bordillo.
+- id: 68
+  category: signs_and_signals
+  question: ¿Qué indica un bordillo (curb) pintado de amarillo?
+  choices:
+    A: Detenerse solo el tiempo suficiente para recoger o dejar pasajeros.
+    B: El estacionamiento está reservado para personas con discapacidad.
+    C: No detenerse, pararse ni estacionar en ningún momento.
+    D: Cargar y descargar pasajeros y mercancías por un tiempo limitado.
+  answer: D
+  explanation: Un bordillo pintado de amarillo significa que puede cargar y descargar
+    pasajeros y mercancías. No debe detenerse más tiempo del indicado, y a los conductores
+    de vehículos no comerciales generalmente se les requiere permanecer con su vehículo.
+- id: 69
+  category: safe_driving_rules
+  question: ¿Es ilegal estacionar o dejar su vehículo a menos de cuántos pies de un
+    hidrante de incendios o de la entrada de una estación de bomberos?
+  choices:
+    A: 10 pies
+    B: 15 pies
+    C: 20 pies
+    D: 25 pies
+  answer: B
+  explanation: Nunca debe estacionar o dejar su vehículo a menos de 15 pies de un
+    hidrante de incendios o de la entrada de una estación de bomberos.
+- id: 70
+  category: penalties_and_points
+  question: 'Si debe detenerse en una autopista en una emergencia, su vehículo puede
+    ser retirado si se deja estacionado por más de:'
+  choices:
+    A: 2 horas.
+    B: 4 horas.
+    C: 12 horas.
+    D: 24 horas.
+  answer: B
+  explanation: Un vehículo que se detiene, se estaciona o se deja parado en una autopista
+    por más de cuatro horas puede ser retirado.
+- id: 71
+  category: vehicle_information
+  question: ¿Cuál de las siguientes es una práctica recomendada para maximizar la
+    eficiencia de combustible y reducir las emisiones?
+  choices:
+    A: Acelerar y frenar lo más rápido posible.
+    B: Mantener peso extra en su vehículo para una mejor tracción.
+    C: Eliminar el peso extra de su vehículo.
+    D: Usar combustible de menor octanaje que el recomendado.
+  answer: C
+  explanation: Para conducir de forma ecológica y maximizar la eficiencia del combustible,
+    el manual recomienda eliminar el peso extra de su vehículo, conducir a una velocidad
+    constante e inflar los neumáticos con regularidad.
+- id: 72
+  category: driver_responsibility
+  question: ¿Qué debe hacer cuando un oficial de la ley le pide que se detenga mientras
+    conduce en el carril para vehículos compartidos/HOV?
+  choices:
+    A: Detenerse inmediatamente en el carril para vehículos compartidos.
+    B: Moverse completamente hacia el acotamiento derecho (right shoulder).
+    C: Moverse hacia la mediana central.
+    D: Salir de la autopista en la siguiente rampa de salida disponible antes de detenerse.
+  answer: B
+  explanation: Durante una parada de un oficial de la ley, debe moverse completamente
+    hacia el acotamiento derecho, incluso si se encuentra en el carril para vehículos
+    compartidos/HOV.
+- id: 73
+  category: driver_responsibility
+  question: Durante una parada de tráfico, ¿qué debe hacer generalmente un oficial
+    de la ley antes de comenzar cualquier interrogatorio relacionado con una infracción
+    de tráfico?
+  choices:
+    A: Pedir el registro y el seguro de su vehículo.
+    B: Preguntar si sabe por qué lo detuvieron.
+    C: Indicar el motivo de la parada de tráfico o de peatones.
+    D: Emitir una advertencia por escrito o una citación.
+  answer: C
+  explanation: Los oficiales de la ley deben indicar el motivo de una parada de tráfico
+    o de peatones antes de comenzar cualquier interrogatorio relacionado con una investigación
+    criminal o una infracción de tráfico, a menos que exista una amenaza inminente.
+- id: 74
+  category: driver_responsibility
+  question: ¿Qué tres documentos debe presentar un conductor cuando es detenido por
+    un oficial de la ley?
+  choices:
+    A: Licencia de conducir, pasaporte y registro del vehículo
+    B: Licencia de conducir, comprobante de seguro y registro del vehículo
+    C: Licencia de conducir, certificado de nacimiento y comprobante de seguro
+    D: Registro del vehículo, comprobante de seguro y un certificado de control de
+      contaminación (smog certificate)
+  answer: B
+  explanation: El manual establece que el conductor de un vehículo detenido debe presentar
+    una licencia de conducir, un comprobante de seguro y el registro del vehículo
+    cuando sea detenido por un oficial de la ley.
+- id: 75
+  category: driver_responsibility
+  question: Si un oficial de la ley estatal o local de California le pregunta sobre
+    su estatus migratorio durante una parada de tráfico, ¿qué debe saber?
+  choices:
+    A: Está legalmente obligado a responder la pregunta con la verdad.
+    B: Los oficiales estatales y locales están obligados por ley a hacer esta pregunta.
+    C: La ley de California prohíbe a los oficiales estatales y locales preguntar
+      a los conductores o pasajeros sobre su estatus migratorio.
+    D: Solo los oficiales estatales pueden hacer esta pregunta, mientras que los locales
+      no pueden.
+  answer: C
+  explanation: En California, solo los oficiales de la ley federal pueden preguntar
+    sobre el estatus migratorio. La ley de California prohíbe a los oficiales estatales
+    y locales preguntar a los conductores o pasajeros sobre su estatus migratorio.
+- id: 76
+  category: driver_responsibility
+  question: 'Durante una parada de tráfico, si un oficial les indica a usted y a sus
+    pasajeros que salgan del vehículo, usted debe:'
+  choices:
+    A: Negarse a salir a menos que el oficial tenga una orden de registro.
+    B: Salir del vehículo según las instrucciones.
+    C: Pedir que llegue un supervisor antes de salir del vehículo.
+    D: Salir usted del vehículo pero decirles a sus pasajeros que se queden adentro.
+  answer: B
+  explanation: Durante una parada de tráfico, un oficial puede exigir legalmente que
+    el conductor y todos los pasajeros salgan o permanezcan dentro del vehículo. Si
+    se le indica que salga del vehículo o que permanezca adentro, debe hacerlo.
+- id: 77
+  category: safe_driving_rules
+  question: ¿Bajo qué condiciones puede girar a la derecha en un semáforo con luz
+    roja fija?
+  choices:
+    A: Puede girar a la derecha inmediatamente sin detenerse si la intersección está
+      despejada.
+    B: Nunca puede girar a la derecha con una luz roja fija.
+    C: Puede girar a la derecha si no hay una señal de 'NO TURN ON RED' (no girar
+      en rojo), después de detenerse en la línea de límite y ceder el paso a los peatones.
+    D: Puede girar a la derecha solo si también se ilumina una flecha verde.
+  answer: C
+  explanation: Una luz roja de semáforo significa PARE. Puede girar a la derecha en
+    una luz roja si no hay una señal de NO TURN ON RED colocada, se detiene en la
+    línea de pare o de límite, cede el paso a los peatones y gira cuando sea seguro.
+- id: 78
+  category: safe_driving_rules
+  question: 'Al acercarse a un semáforo con luz roja intermitente, usted debe:'
+  choices:
+    A: Reducir la velocidad y avanzar con precaución sin detenerse.
+    B: Detenerse, y luego puede avanzar cuando sea seguro.
+    C: Ceder el derecho de paso a todo el tráfico a su derecha sin detenerse.
+    D: Esperar a que la luz cambie a verde fijo antes de avanzar.
+  answer: B
+  explanation: Una luz roja intermitente significa PARE. Después de detenerse, puede
+    avanzar cuando sea seguro.
+- id: 79
+  category: safe_driving_rules
+  question: ¿Qué debe hacer si se acerca a una intersección y el semáforo no funciona?
+  choices:
+    A: Continuar por la intersección sin detenerse si se encuentra en la carretera
+      principal.
+    B: Ceder el paso al tráfico a su derecha y avanzar con precaución.
+    C: Detenerse como si la intersección estuviera controlada por señales de PARE
+      (STOP) en todas las direcciones.
+    D: Esperar en la intersección hasta que llegue un oficial de la ley para dirigir
+      el tráfico.
+  answer: C
+  explanation: Cuando un semáforo no funciona, deténgase como si la intersección estuviera
+    controlada por señales de PARE (STOP) en todas las direcciones. Luego avance con
+    precaución cuando sea seguro hacerlo.
+- id: 80
+  category: safe_driving_rules
+  question: ¿Qué indica un semáforo con luz amarilla intermitente?
+  choices:
+    A: Debe detenerse y esperar una luz verde.
+    B: La luz está a punto de ponerse roja, por lo que debe acelerar.
+    C: Es una advertencia para avanzar con precaución; no es necesario detenerse.
+    D: Tiene un giro protegido en la dirección en la que viaja.
+  answer: C
+  explanation: Un semáforo con luz amarilla intermitente es una advertencia para AVANZAR
+    CON PRECAUCIÓN. Reduzca la velocidad y esté alerta. No es necesario detenerse.
+- id: 81
+  category: safe_driving_rules
+  question: 'Si un semáforo muestra una flecha amarilla intermitente, significa que:'
+  choices:
+    A: Su giro está protegido del resto del tráfico.
+    B: Debe detenerse y esperar a que aparezca una flecha verde fija.
+    C: Puede girar, pero su giro no está protegido, por lo que debe ceder el paso
+      al tráfico en sentido contrario.
+    D: La intersección está completamente cerrada para los vehículos que giran.
+  answer: C
+  explanation: Una flecha amarilla intermitente significa que puede girar, pero su
+    giro no está protegido del resto del tráfico. Proceda a girar a la izquierda después
+    de ceder el paso al tráfico en sentido contrario y hágalo con precaución.
+- id: 82
+  category: safe_driving_rules
+  question: 'Cuando vea una luz verde fija en el semáforo, usted debe:'
+  choices:
+    A: Entrar en la intersección inmediatamente sin revisar el tráfico transversal.
+    B: Avanzar, pero solo si tiene suficiente espacio sin crear un peligro para cualquier
+      vehículo, ciclista o peatón que se aproxime.
+    C: Detenerse por completo primero y luego avanzar por la intersección.
+    D: Aumentar la velocidad para asegurarse de despejar la intersección antes de
+      que la luz cambie a amarillo.
+  answer: B
+  explanation: Una luz verde en el semáforo significa SIGA (GO). Sin embargo, aún
+    debe detenerse ante cualquier vehículo, ciclista o peatón que se encuentre en
+    la intersección y avanzar solo si tiene suficiente espacio sin crear una situación
+    de peligro.
+- id: 83
+  category: sharing_the_road
+  question: ¿Qué significa una señal peatonal de "NO CAMINE" (DON'T WALK) intermitente
+    o de una mano levantada intermitente?
+  choices:
+    A: Los peatones deben comenzar a cruzar la calle inmediatamente.
+    B: Los peatones no pueden comenzar a cruzar la calle porque la señal de tráfico
+      está a punto de cambiar.
+    C: Los conductores pueden avanzar por el paso de peatones sin ceder el paso a
+      los peatones.
+    D: El botón de cruce para peatones está roto y necesita reparación.
+  answer: B
+  explanation: Una señal de "NO CAMINE" (DON'T WALK) intermitente o una mano levantada
+    intermitente significa que no debe comenzar a cruzar la calle. La luz del semáforo
+    está a punto de cambiar.
+- id: 84
+  category: driver_responsibility
+  question: 'Si decide grabar una interacción con las fuerzas del orden durante una
+    parada de tráfico, usted debe:'
+  choices:
+    A: Ocultar su dispositivo de grabación para que el oficial no lo vea.
+    B: Buscar en un área oculta para sacar su dispositivo sin preguntarle al oficial.
+    C: Dejar claro de inmediato que está grabando.
+    D: Negarse a entregar su licencia de conducir hasta que termine la grabación.
+  answer: C
+  explanation: Si está grabando, debe dejarlo claro de inmediato. No debe buscar en
+    áreas ocultas para recuperar su dispositivo de grabación sin el permiso del oficial.
+- id: 85
+  category: signs_and_signals
+  question: ¿Qué debe hacer al acercarse a una señal roja de CEDA EL PASO (YIELD)?
+  choices:
+    A: Detenerse por completo siempre, independientemente del tráfico.
+    B: Reducir la velocidad y estar preparado para detenerse para dejar pasar a cualquier
+      vehículo, ciclista o peatón antes de continuar.
+    C: Mantener su velocidad e incorporarse suavemente al tráfico.
+    D: Detenerse solo si hay un paso de peatones marcado.
+  answer: B
+  explanation: Una señal roja de CEDA EL PASO (YIELD) significa que debe reducir la
+    velocidad y estar preparado para detenerse para dejar pasar a cualquier vehículo,
+    ciclista o peatón antes de continuar.
+- id: 86
+  category: signs_and_signals
+  question: ¿Qué significa un semáforo con flecha roja?
+  choices:
+    A: Deténgase, luego puede girar con precaución en la dirección de la flecha.
+    B: Deténgase y no gire hasta que aparezca una luz verde o una flecha verde.
+    C: Ceda el paso al tráfico en sentido contrario antes de realizar el giro.
+    D: El tiempo de giro protegido está terminando, así que complete su giro rápidamente.
+  answer: B
+  explanation: Una flecha roja significa ALTO (STOP). No gire cuando haya una flecha
+    roja. Permanezca detenido hasta que aparezca una luz verde o una flecha verde
+    en el semáforo.
+- id: 87
+  category: vehicle_information
+  question: ¿Cuál de los siguientes trámites se puede completar en un quiosco del
+    DMV?
+  choices:
+    A: Realizar el examen escrito de conocimientos para conductores.
+    B: Presentar el comprobante de seguro y completar la renovación del registro del
+      vehículo.
+    C: Solicitar por primera vez una licencia de conducir de California.
+    D: Pagar una multa de tráfico.
+  answer: B
+  explanation: Los quioscos del DMV ofrecen trámites como completar la renovación
+    del registro del vehículo, recibir una tarjeta/calcomanía de registro de reemplazo,
+    presentar comprobantes de seguro, solicitar el estado de PNO (Operación No Planificada)
+    y obtener expedientes del conductor o del vehículo.
+- id: 88
+  category: driver_responsibility
+  question: 'Antes de comenzar cualquier interrogatorio relacionado con una investigación
+    criminal o una infracción de tráfico, un oficial de la ley debe:'
+  choices:
+    A: Pedir su permiso para registrar su vehículo.
+    B: Indicar el motivo de la parada de tráfico o peatonal, a menos que exista una
+      amenaza inminente.
+    C: Verificar su estatus migratorio.
+    D: Confiscar su teléfono celular.
+  answer: B
+  explanation: Los oficiales de la ley deben indicar el motivo de una parada de tráfico
+    o peatonal antes de comenzar cualquier interrogatorio relacionado con una investigación
+    criminal o infracción de tráfico, a menos que crean razonablemente que ocultar
+    el motivo es necesario para proteger la vida o la propiedad de una amenaza inminente.
+- id: 89
+  category: signs_and_signals
+  question: ¿Qué indica una señal de tráfico de 5 lados (pentágono)?
+  choices:
+    A: Se está acercando a un cruce de ferrocarril.
+    B: Está cerca de una escuela.
+    C: Va en sentido contrario.
+    D: Debe ceder el paso al tráfico en sentido contrario.
+  answer: B
+  explanation: Según el manual, una señal de 5 lados significa que está cerca de una
+    escuela. Debe conducir despacio y detenerse ante los niños en el paso de peatones.
+- id: 90
+  category: signs_and_signals
+  question: ¿Cómo puede saber si conduce en sentido contrario en una carretera por
+    la noche?
+  choices:
+    A: Los reflectores de la carretera brillarán en rojo con sus faros.
+    B: Las luces de la calle parpadearán en amarillo.
+    C: Las líneas pintadas aparecerán como blancas continuas.
+    D: Los reflectores de la carretera brillarán en blanco intenso.
+  answer: A
+  explanation: El manual establece que si conduce de noche, sabrá que va en sentido
+    contrario si los reflectores de la carretera brillan en rojo con las luces de
+    sus faros.
+- id: 91
+  category: safe_driving_rules
+  question: ¿Quién tiene el derecho de paso en una intersección en T sin señales de
+    PARE (STOP) o CEDA EL PASO (YIELD)?
+  choices:
+    A: El vehículo en la carretera que termina.
+    B: Los vehículos, ciclistas y peatones en la carretera principal.
+    C: El vehículo que está girando a la izquierda.
+    D: Cualquier vehículo que viaje a una velocidad mayor.
+  answer: B
+  explanation: En las intersecciones en T sin señales de PARE (STOP) o CEDA EL PASO
+    (YIELD), los vehículos, ciclistas y peatones en la carretera principal (la que
+    continúa recto) tienen el derecho de paso.
+- id: 92
+  category: safe_driving_rules
+  question: Si usted y otro vehículo llegan al mismo tiempo a una intersección sin
+    señales de PARE (STOP) o CEDA EL PASO (YIELD), ¿quién tiene el derecho de paso?
+  choices:
+    A: El vehículo a la izquierda.
+    B: El vehículo a la derecha.
+    C: El vehículo que viaja recto.
+    D: El vehículo que realiza un giro.
+  answer: B
+  explanation: Si un vehículo, peatón o ciclista llega a una intersección no controlada
+    al mismo tiempo que usted, debe ceder el derecho de paso al vehículo, peatón o
+    ciclista que esté a su derecha.
+- id: 93
+  category: safe_driving_rules
+  question: ¿En qué dirección circula el tráfico en una glorieta (roundabout)?
+  choices:
+    A: En el sentido de las agujas del reloj.
+    B: En sentido contrario a las agujas del reloj.
+    C: En un patrón de figura en ocho.
+    D: En la dirección del hueco más grande en el tráfico.
+  answer: B
+  explanation: Al usar una glorieta, debe circular en sentido contrario a las agujas
+    del reloj y no debe detenerse ni rebasar a otros vehículos.
+- id: 94
+  category: defensive_driving
+  question: ¿Por qué nunca debe rebasar a un vehículo detenido en un cruce de peatones?
+  choices:
+    A: El vehículo detenido podría retroceder repentinamente.
+    B: Es posible que no pueda ver a un peatón cruzando la calle.
+    C: Es ilegal cambiar de carril a menos de 100 pies de una intersección.
+    D: El vehículo detenido tiene el derecho de paso para avanzar primero.
+  answer: B
+  explanation: No debe rebasar a un vehículo detenido en un cruce de peatones porque
+    es posible que no pueda ver a un peatón que esté cruzando la calle.
+- id: 95
+  category: sharing_the_road
+  question: ¿Qué significa generalmente cuando un peatón ciego retrae su bastón y
+    se aleja de la intersección?
+  choices:
+    A: Necesita ayuda para cruzar la calle.
+    B: Está esperando a que cambie el semáforo.
+    C: Usted puede avanzar.
+    D: Usted debe tocar la bocina para reconocer su presencia.
+  answer: C
+  explanation: Cuando una persona ciega retrae su bastón y se aleja de la intersección,
+    este gesto generalmente significa que usted puede avanzar.
+- id: 96
+  category: safe_driving_rules
+  question: Si dos vehículos se encuentran en un camino de montaña empinado y estrecho
+    donde ninguno puede pasar al otro, ¿qué vehículo tiene el derecho de paso?
+  choices:
+    A: El vehículo que va cuesta abajo.
+    B: El vehículo que va cuesta arriba.
+    C: El más grande de los dos vehículos.
+    D: El vehículo que llegó al último.
+  answer: B
+  explanation: Si dos vehículos se encuentran en un camino estrecho y empinado y ninguno
+    puede pasar, el vehículo que va cuesta arriba tiene el derecho de paso porque
+    el vehículo que va cuesta abajo tiene más control al retroceder por la colina.
+- id: 97
+  category: sharing_the_road
+  question: Aproximadamente, ¿cuánta distancia necesita para detenerse un vehículo
+    grande que viaja a 55 mph?
+  choices:
+    A: 200 pies
+    B: 300 pies
+    C: 400 pies
+    D: 500 pies
+  answer: C
+  explanation: Según el manual, un vehículo grande que viaja a 55 mph puede tardar
+    hasta 400 pies en detenerse, en comparación con los 300 pies de un vehículo de
+    pasajeros promedio.
+- id: 98
+  category: sharing_the_road
+  question: ¿Por qué los vehículos grandes y los camiones a menudo giran de forma
+    amplia para completar un viraje?
+  choices:
+    A: Sus volantes tienen un radio de giro limitado.
+    B: Las ruedas traseras siguen una trayectoria más corta que las delanteras.
+    C: Necesitan revisar sus puntos ciegos antes de girar.
+    D: Para evitar que vehículos más pequeños los rebasen por el interior.
+  answer: B
+  explanation: Cuando un vehículo gira, las ruedas traseras siguen una trayectoria
+    más corta que las delanteras. Cuanto más largo sea el vehículo, mayor será la
+    diferencia, por lo que los vehículos grandes a menudo deben girar de forma amplia
+    para completar un viraje.
+- id: 99
+  category: sharing_the_road
+  question: Al conducir cerca de vehículos grandes y camiones, ¿por qué lado debe
+    rebasarlos?
+  choices:
+    A: Siempre rebase por el lado derecho.
+    B: Siempre rebase por el lado izquierdo.
+    C: Rebase por el lado que tenga el acotamiento más ancho.
+    D: Rebase por el lado que tenga el punto ciego más pequeño.
+  answer: B
+  explanation: El manual establece que siempre debe rebasar a un vehículo grande por
+    el lado izquierdo y avanzar delante de él después de pasarlo.
+- id: 100
+  category: sharing_the_road
+  question: ¿Cuál es la velocidad máxima a la que puede pasar un autobús, tranvía
+    o trolebús que está detenido en una zona de seguridad o semáforo?
+  choices:
+    A: 5 mph
+    B: 10 mph
+    C: 15 mph
+    D: 20 mph
+  answer: B
+  explanation: Cuando un autobús, tranvía o trolebús está detenido en una zona de
+    seguridad o semáforo, usted puede pasarlo a no más de 10 mph.
+- id: 101
+  category: signs_and_signals
+  question: ¿Cuál es el propósito de una señal de tránsito en forma de diamante?
+  choices:
+    A: Comunicar reglas importantes que debe obedecer.
+    B: Indicar un cruce de ferrocarril más adelante.
+    C: Advertirle sobre condiciones específicas de la carretera y peligros más adelante.
+    D: Marcar una zona escolar.
+  answer: C
+  explanation: Una señal en forma de diamante le advierte sobre condiciones específicas
+    de la carretera y peligros más adelante.
+- id: 102
+  category: safe_driving_rules
+  question: ¿Cuándo es legal detenerse y bloquear una intersección?
+  choices:
+    A: Cuando está girando a la izquierda con luz verde.
+    B: Cuando el tráfico está congestionado y usted sigue al vehículo de adelante.
+    C: Al ceder el paso a un peatón en un paso de peatones no marcado.
+    D: Nunca es legal; es contra la ley detenerse o bloquear una intersección si no
+      hay suficiente espacio para cruzar por completo.
+  answer: D
+  explanation: Es contra la ley detenerse o bloquear una intersección donde no hay
+    suficiente espacio para cruzar por completo antes de que el semáforo cambie a
+    rojo.
+- id: 103
+  category: sharing_the_road
+  question: ¿Qué indica si un peatón hace contacto visual con usted mientras conduce?
+  choices:
+    A: Están admirando su vehículo.
+    B: Están listos para cruzar la calle y usted debe cederles el paso.
+    C: Están esperando a que usted pase antes de cruzar.
+    D: Están señalando que usted tiene el derecho de paso.
+  answer: B
+  explanation: Si un peatón hace contacto visual con usted, significa que está listo
+    para cruzar la calle y usted debe cederle el paso.
+- id: 104
+  category: sharing_the_road
+  question: ¿Bajo cuál de las siguientes condiciones es legal rebasar y pasar a un
+    vehículo de tren ligero o tranvía por el lado izquierdo?
+  choices:
+    A: Cuando conduce en un distrito residencial.
+    B: Cuando se encuentra en una calle de un solo sentido.
+    C: Cuando el tranvía viaja a menos de 15 mph.
+    D: Cuando no hay peatones presentes en el paso de peatones.
+  answer: B
+  explanation: El manual establece que no debe rebasar ni pasar a un vehículo de tren
+    ligero o tranvía por el lado izquierdo a menos que esté en una calle de un solo
+    sentido, las vías estén demasiado cerca del lado derecho o un oficial de tránsito
+    se lo indique.
+- id: 105
+  category: sharing_the_road
+  question: ¿Cuál es la distancia de seguimiento recomendada al conducir detrás de
+    un motociclista?
+  choices:
+    A: Un segundo
+    B: Dos segundos
+    C: Tres segundos
+    D: Cuatro segundos
+  answer: C
+  explanation: Para compartir la carretera de manera segura con los motociclistas,
+    el manual aconseja permitir una distancia de seguimiento segura de tres segundos
+    para evitar golpearlos si frenan repentinamente o se caen.
+- id: 106
+  category: safe_driving_rules
+  question: ¿Qué debe hacer si se encuentra en una intersección cuando ve un vehículo
+    de emergencia usando sirena y luces rojas?
+  choices:
+    A: Detenerse inmediatamente en medio de la intersección.
+    B: Dar marcha atrás para salir de la intersección y despejar el camino.
+    C: Continuar a través de la intersección, luego conducir hacia la derecha y detenerse.
+    D: Hacerse a un lado hacia la izquierda de la intersección y detenerse.
+  answer: C
+  explanation: Si se encuentra en una intersección cuando ve un vehículo de emergencia,
+    debe continuar a través de la intersección, luego conducir hacia la derecha tan
+    pronto como sea seguro y detenerse.
+- id: 107
+  category: safe_driving_rules
+  question: ¿A menos de cuántos pies es ilegal seguir a un vehículo de emergencia
+    cuando su sirena o luces intermitentes están encendidas?
+  choices:
+    A: 100 pies
+    B: 200 pies
+    C: 300 pies
+    D: 500 pies
+  answer: C
+  explanation: Es contra la ley seguir a menos de 300 pies de cualquier camión de
+    bomberos, vehículo policial, ambulancia u otro vehículo de emergencia cuando su
+    sirena o luces intermitentes estén encendidas.
+- id: 108
+  category: signs_and_signals
+  question: ¿Qué tipo de marca se encuentra en la parte trasera de algunos vehículos
+    de movimiento lento, como los vehículos de mantenimiento de carreteras?
+  choices:
+    A: Un diamante amarillo y negro
+    B: Un triángulo naranja y rojo
+    C: Un rectángulo blanco y negro
+    D: Un octágono rojo y blanco
+  answer: B
+  explanation: Algunos vehículos de movimiento lento tienen un triángulo naranja y
+    rojo en su parte trasera, lo que generalmente indica que viajan a 25 mph o menos.
+- id: 109
+  category: safe_driving_rules
+  question: 'Los Vehículos Eléctricos de Vecindario (NEV) y los Vehículos de Baja
+    Velocidad (LSV) tienen restringido circular por carreteras donde el límite de
+    velocidad es mayor a:'
+  choices:
+    A: 25 mph
+    B: 35 mph
+    C: 45 mph
+    D: 55 mph
+  answer: B
+  explanation: Los NEV y LSV alcanzan una velocidad máxima de 25 mph y tienen restringido
+    el acceso a carreteras donde el límite de velocidad es superior a 35 mph.
+- id: 110
+  category: sharing_the_road
+  question: ¿A qué edad la ley exige que un ciclista use casco?
+  choices:
+    A: Menores de 16 años
+    B: Menores de 18 años
+    C: Menores de 21 años
+    D: Todos los ciclistas deben usar casco independientemente de su edad
+  answer: B
+  explanation: Como ciclista, debe usar casco si es menor de 18 años.
+- id: 111
+  category: vehicle_information
+  question: ¿Al andar en bicicleta por la noche, la bicicleta debe estar equipada
+    con una lámpara delantera que emita una luz blanca visible desde qué distancia?
+  choices:
+    A: 100 pies
+    B: 200 pies
+    C: 300 pies
+    D: 500 pies
+  answer: C
+  explanation: Cuando está oscuro, una bicicleta debe tener una lámpara delantera
+    con una luz blanca visible desde 300 pies.
+- id: 112
+  category: sharing_the_road
+  question: Cuando no puede cambiar de carril para rebasar a un ciclista, ¿cuál es
+    la distancia mínima que debe dejar entre su vehículo y el ciclista?
+  choices:
+    A: Un pie
+    B: Dos pies
+    C: Tres pies
+    D: Cuatro pies
+  answer: C
+  explanation: Si no puede cambiar de carril para rebasar a un ciclista, debe dejar
+    al menos tres pies entre su vehículo y el ciclista. Si no puede dejar tres pies
+    de espacio, no lo rebase.
+- id: 113
+  category: safe_driving_rules
+  question: Al prepararse para dar una vuelta, ¿cuál es la distancia máxima antes
+    de la vuelta en la que puede entrar en un carril para bicicletas?
+  choices:
+    A: 50 pies
+    B: 100 pies
+    C: 200 pies
+    D: 300 pies
+  answer: C
+  explanation: Debe entrar en un carril para bicicletas no más de 200 pies antes de
+    comenzar una vuelta.
+- id: 114
+  category: penalties_and_points
+  question: 'Las multas por infracciones de tránsito en una zona de obras pueden ser
+    de:'
+  choices:
+    A: $250 o más
+    B: $500 o más
+    C: $750 o más
+    D: $1,000 o más
+  answer: D
+  explanation: Las multas por infracciones de tránsito en una zona de obras pueden
+    ser de $1,000 o más.
+- id: 115
+  category: penalties_and_points
+  question: ¿Cuál es la sanción para cualquier persona condenada por agredir a un
+    trabajador de carreteras?
+  choices:
+    A: Multas de hasta $500 y hasta 30 días de prisión
+    B: Multas de hasta $1,000 y hasta 6 meses de prisión
+    C: Multas de hasta $2,000 y prisión por hasta un año
+    D: Multas de hasta $5,000 y prisión por hasta dos años
+  answer: C
+  explanation: Cualquier persona condenada por agredir a un trabajador de carreteras
+    se enfrenta a multas de hasta $2,000 y penas de prisión de hasta un año.
+- id: 116
+  category: sharing_the_road
+  question: ¿Por dónde puede circular un ciclista en una carretera de un solo sentido
+    con dos o más carriles?
+  choices:
+    A: Siempre deben circular lo más cerca posible del bordillo derecho.
+    B: Pueden circular cerca del bordillo o borde izquierdo de la carretera.
+    C: Deben circular exactamente en el centro del carril izquierdo.
+    D: No se permiten bicicletas en carreteras de un solo sentido.
+  answer: B
+  explanation: En una carretera de un solo sentido con dos o más carriles, un ciclista
+    puede circular cerca del bordillo izquierdo o del borde de la carretera.
+- id: 117
+  category: defensive_driving
+  question: ¿Bajo qué condiciones puede conducir a través de una zona de seguridad
+    reservada para peatones?
+  choices:
+    A: Cuando no haya peatones presentes.
+    B: Cuando viaje a 10 mph o menos.
+    C: Al ceder el paso a un tranvía.
+    D: Bajo ninguna condición.
+  answer: D
+  explanation: 'Las zonas de seguridad son espacios reservados para peatones. El manual
+    establece explícitamente: ''No conduzca a través de una zona de seguridad bajo
+    ninguna condición''.'
+- id: 118
+  category: penalties_and_points
+  question: ¿Qué sucede con las multas de tránsito en las zonas de construcción o
+    mantenimiento de carreteras cuando hay trabajadores presentes?
+  choices:
+    A: Se reducen a la mitad.
+    B: Siguen siendo las mismas que en las zonas normales.
+    C: Se duplican.
+    D: Se triplican.
+  answer: C
+  explanation: Según el manual, las multas se duplican en las zonas de construcción
+    o mantenimiento de carreteras cuando hay trabajadores presentes.
+- id: 119
+  category: sharing_the_road
+  question: Si está remolcando un tráiler en una carretera con cuatro carriles en
+    su dirección y no hay carriles marcados para vehículos más lentos, ¿en qué carriles
+    puede conducir?
+  choices:
+    A: En cualquiera de los cuatro carriles.
+    B: Solo en el carril del extremo izquierdo.
+    C: En los dos carriles más cercanos al borde derecho de la carretera.
+    D: En los dos carriles más cercanos al borde izquierdo de la carretera.
+  answer: C
+  explanation: Si no hay carriles marcados y hay cuatro o más carriles en su dirección,
+    un vehículo que remolca un tráiler o un camión con tres o más ejes solo puede
+    conducir en los dos carriles más cercanos al borde derecho de la carretera.
+- id: 120
+  category: safe_driving_rules
+  question: ¿Cuándo debe detenerse ante un autobús escolar con luces rojas intermitentes?
+  choices:
+    A: Solo si viaja en la misma dirección que el autobús.
+    B: Desde cualquier dirección, a menos que el autobús esté al otro lado de una
+      carretera dividida o de varios carriles.
+    C: Solo si hay niños cruzando activamente frente a su vehículo.
+    D: Nunca es obligatorio detenerse, pero debe reducir la velocidad a 15 mph.
+  answer: B
+  explanation: Cuando un autobús escolar tiene luces rojas intermitentes, debe detenerse
+    desde cualquier dirección hasta que los niños hayan cruzado de manera segura.
+    Sin embargo, si el autobús está al otro lado de una carretera dividida o de varios
+    carriles (dos o más carriles en cada dirección), no es necesario detenerse.
+- id: 121
   category: safe_driving_rules
   question: ¿Cuál es el límite de velocidad en una intersección a ciegas?
   choices:
@@ -225,684 +1541,1379 @@ questions:
     C: 20 mph
     D: 25 mph
   answer: B
-  explanation: El límite de velocidad para una intersección a ciegas es de 15 mph.
-    Una intersección se considera 'a ciegas' si no hay señales de alto en ninguna
-    esquina y no se puede ver a 100 pies en ninguna dirección durante los últimos
-    100 pies antes de cruzar.
-- id: 18
+  explanation: Una intersección se considera a ciegas si no tiene señales de alto
+    en ninguna esquina y su vista está bloqueada. El límite de velocidad para una
+    intersección a ciegas es de 15 mph.
+- id: 122
   category: safe_driving_rules
-  question: ¿Cuál es el límite de velocidad máximo en la mayoría de los distritos
-    comerciales o residenciales en California?
+  question: ¿Cuál es el límite de velocidad a menos de 100 pies de un cruce de ferrocarril
+    si no puede ver las vías durante 400 pies en ambas direcciones y el cruce no está
+    controlado por barreras o una señal?
   choices:
-    A: 25 mph
-    B: 30 mph
-    C: 35 mph
-    D: 40 mph
-  answer: A
-  explanation: A menos que se indique lo contrario, el límite de velocidad máximo
-    en la mayoría de los distritos comerciales y residenciales es de 25 mph.
-- id: 19
-  category: safe_driving_rules
-  question: ¿Hacia dónde debe girar las ruedas al estacionar cuesta arriba junto a
-    una acera?
-  choices:
-    A: Gire las ruedas hacia la acera.
-    B: Gire las ruedas en dirección contraria a la acera.
-    C: Mantenga las ruedas perfectamente rectas.
-    D: Gire las ruedas paralelas a la calle.
+    A: 10 mph
+    B: 15 mph
+    C: 20 mph
+    D: 25 mph
   answer: B
-  explanation: Al estacionar cuesta arriba junto a una acera, debe girar las ruedas
-    delanteras en dirección contraria a la acera y dejar que el vehículo ruede hacia
-    atrás unos centímetros hasta que la parte trasera de la rueda delantera toque
-    suavemente la acera.
-- id: 20
-  category: signs_and_signals
-  question: ¿Qué significa una señal de tráfico roja intermitente?
-  choices:
-    A: Reduzca la velocidad y ceda el paso al tráfico.
-    B: Deténgase, luego continúe cuando sea seguro.
-    C: Deténgase y espere la luz verde.
-    D: La señal de tráfico está averiada; proceda con precaución.
-  answer: B
-  explanation: Una señal de tráfico roja intermitente significa 'ALTO'. Después de
-    detenerse, puede continuar cuando sea seguro, respetando las reglas del derecho
-    de paso.
-- id: 21
-  category: signs_and_signals
-  question: ¿Qué representan dos juegos de líneas amarillas dobles y continuas que
-    están separadas por dos pies o más?
-  choices:
-    A: Un carril para vehículos con varios pasajeros (carpool).
-    B: Una zona para rebasar.
-    C: Una pared sólida; no conduzca sobre ellas ni las cruce.
-    D: Un carril central compartido para girar.
-  answer: C
-  explanation: Dos juegos de líneas amarillas dobles y continuas que están separadas
-    por dos pies o más se consideran una barrera. No conduzca sobre esta barrera ni
-    la cruce, ni realice un giro a la izquierda o un giro en U a través de ella.
-- id: 22
-  category: sharing_the_road
-  question: ¿Quién tiene el derecho de paso en un cruce de peatones?
-  choices:
-    A: Los vehículos tienen el derecho de paso si el peatón está cruzando imprudentemente.
-    B: Los peatones siempre tienen el derecho de paso en los cruces de peatones marcados
-      o no marcados.
-    C: Los vehículos tienen el derecho de paso si el cruce de peatones no está marcado.
-    D: Las bicicletas tienen el derecho de paso sobre los peatones.
-  answer: B
-  explanation: Los peatones tienen el derecho de paso en los cruces de peatones marcados
-    o no marcados. Los conductores deben ceder el paso y reducir su velocidad o detenerse
-    si es necesario para garantizar la seguridad del peatón.
-- id: 23
-  category: defensive_driving
-  question: ¿Cuál es la distancia mínima de seguimiento recomendada bajo condiciones
-    normales de conducción para evitar una colisión por alcance?
-  choices:
-    A: 1 segundo
-    B: 2 segundos
-    C: 3 segundos
-    D: 5 segundos
-  answer: C
-  explanation: Para evitar seguir demasiado de cerca (tailgating) y las colisiones
-    por alcance, debe usar la 'regla de los 3 segundos' para mantener una distancia
-    de seguimiento segura bajo condiciones normales de conducción.
-- id: 24
-  category: driver_responsibility
-  question: ¿Cuándo debe reportar una colisión de tráfico al DMV?
-  choices:
-    A: Solo si alguien fallece.
-    B: Dentro de los 10 días si los daños superan los $1,000 o si alguien resulta
-      herido o fallece.
-    C: Dentro de los 5 días si los daños superan los $500.
-    D: Solo si la policía no presenta un informe.
-  answer: B
-  explanation: Usted (o su agente de seguros, corredor o representante legal) debe
-    reportar una colisión al DMV dentro de los 10 días si hay más de $1,000 en daños
-    a la propiedad de cualquier persona, o si alguien resulta herido (por leve que
-    sea) o fallece.
-- id: 25
-  category: safe_driving_rules
-  question: ¿Cuándo se requiere que encienda los faros delanteros de su vehículo?
-  choices:
-    A: Solo cuando conduzca por carreteras sin iluminación.
-    B: Desde 30 minutos después de la puesta del sol hasta 30 minutos antes de la
-      salida del sol.
-    C: Desde 1 hora después de la puesta del sol hasta 1 hora antes de la salida del
-      sol.
-    D: Solo cuando no pueda ver a 500 pies delante de usted.
-  answer: B
-  explanation: Debe encender sus faros delanteros 30 minutos después de la puesta
-    del sol y mantenerlos encendidos hasta 30 minutos antes de la salida del sol,
-    o en cualquier momento en que no pueda reconocer claramente a una persona o vehículo
-    desde una distancia de 1,000 pies.
-- id: 26
-  category: sharing_the_road
-  question: ¿Qué debe hacer cuando un vehículo de emergencia con sirena y luces intermitentes
-    se aproxima por detrás?
-  choices:
-    A: Acelerar para mantenerse delante del vehículo de emergencia.
-    B: Detenerse inmediatamente en su carril actual.
-    C: Orillarse al borde derecho de la carretera y detenerse.
-    D: Moverse al carril izquierdo para dejar que pasen por la derecha.
-  answer: C
-  explanation: Debe ceder el derecho de paso a cualquier vehículo policial, camión
-    de bomberos, ambulancia u otro vehículo de emergencia que utilice una sirena y
-    luces rojas. Conduzca hacia el borde derecho de la carretera y deténgase hasta
-    que los vehículos de emergencia hayan pasado.
-- id: 27
-  category: signs_and_signals
-  question: ¿Qué indica una luz de tráfico amarilla continua?
-  choices:
-    A: La luz está a punto de cambiar a verde.
-    B: 'PRECAUCIÓN: La señal roja está a punto de aparecer.'
-    C: Deténgase inmediatamente, independientemente de su posición en la intersección.
-    D: Acelere para despejar la intersección rápidamente.
-  answer: B
-  explanation: Una luz de señal de tráfico amarilla continua significa 'PRECAUCIÓN'.
-    La luz roja está a punto de aparecer. Cuando vea la luz amarilla, deténgase si
-    puede hacerlo de manera segura. Si no puede detenerse de forma segura, cruce la
-    intersección con precaución.
-- id: 28
-  category: driver_responsibility
-  question: Al interactuar con el Asistente Virtual del DMV, ¿qué tipo de información
-    debe evitar incluir?
-  choices:
-    A: Marca y modelo del vehículo
-    B: Información personal
-    C: Preguntas generales sobre conducción
-    D: Comentarios sobre el sitio web
-  answer: B
-  explanation: 'El Descargo de Responsabilidad General establece: ''Al interactuar
-    con el Asistente Virtual del Departamento de Vehículos Motorizados (DMV), por
-    favor no incluya ninguna información personal''.'
-- id: 29
-  category: license_system
-  question: Si surge una discrepancia entre el contenido en inglés y una traducción
-    de terceros en el sitio web del DMV, ¿qué versión es legalmente vinculante?
-  choices:
-    A: La versión traducida
-    B: Ambas versiones son igualmente vinculantes
-    C: La versión en inglés
-    D: Ninguna de las dos versiones
-  answer: C
-  explanation: El Descargo de Responsabilidad de Traducción de Terceros señala que
-    el contenido en inglés es la fuente oficial, y cualquier discrepancia en la traducción
-    'no es vinculante y no tiene efecto legal para fines de cumplimiento o aplicación
-    de la ley'.
-- id: 30
+  explanation: El límite de velocidad es de 15 mph a menos de 100 pies de un cruce
+    de ferrocarril si no puede ver las vías durante 400 pies en ambas direcciones,
+    a menos que el cruce esté controlado por barreras, una señal de advertencia o
+    un guardavía.
+- id: 123
   category: vehicle_information
-  question: ¿Cuál de los siguientes es un servicio proporcionado bajo la sección de
-    Registro de Vehículos?
+  question: Si la carga sobresale más de 4 pies del parachoques trasero de su vehículo
+    durante el día, ¿qué debe mostrarse en ella?
   choices:
-    A: Unirse al programa piloto de mDL
-    B: Enviar comprobante de seguro
-    C: Pagar cargo de restablecimiento
-    D: Exámenes en línea
+    A: Dos luces rojas
+    B: Una bandera cuadrada roja o naranja fluorescente de 12 pulgadas
+    C: Una luz estroboscópica blanca intermitente
+    D: Una señal amarilla en forma de diamante
   answer: B
-  explanation: Según el menú de navegación principal, 'Enviar comprobante de seguro'
-    figura como un servicio bajo la sección de Registro de Vehículos.
-- id: 31
-  category: license_system
-  question: ¿Bajo los servicios de Licencias de Conducir e Identificaciones, a qué
-    programa piloto se invita a los usuarios a unirse?
-  choices:
-    A: El Piloto de mDL (mDL Pilot)
-    B: El Piloto de Oficina Virtual
-    C: El Piloto de Conductor Seguro
-    D: El Piloto de Exámenes en Línea
-  answer: A
-  explanation: El menú de navegación de Licencias de Conducir e Identificaciones incluye
-    una opción para 'Unirse al Piloto de mDL'.
-- id: 32
+  explanation: La carga que sobresale más de 4 pies del parachoques trasero del vehículo
+    debe mostrar una bandera cuadrada roja o naranja fluorescente de 12 pulgadas.
+    Por la noche, esta carga debe estar marcada con dos luces rojas.
+- id: 124
   category: penalties_and_points
-  question: ¿Cuál de los siguientes cargos relacionados con multas se puede pagar
-    a través del sistema de pago en línea del DMV?
+  question: ¿Cuál es la sanción para una persona condenada por homicidio involuntario
+    resultante de evadir a las autoridades durante una persecución?
   choices:
-    A: Multas por exceso de velocidad
-    B: Citaciones de estacionamiento
-    C: Pago de cheque sin fondos (Dishonored Check Payment)
-    D: Cargos administrativos de la corte
+    A: Encarcelamiento en una cárcel del condado por un año o menos
+    B: Una multa máxima de $1,000 y la confiscación del vehículo por 30 días
+    C: Encarcelamiento en una prisión estatal por un mínimo de 4 a 10 años
+    D: Un curso obligatorio de escuela para infractores de tránsito
   answer: C
-  explanation: La sección 'Realizar un pago' enumera explícitamente 'Pago de cheque
-    sin fondos' y 'Pagar cargo de restablecimiento' como opciones de pago en línea.
-- id: 33
-  category: driver_testing
-  question: ¿Qué sección del Manual del Automovilista de California cubre 'El proceso
-    de exámenes'?
+  explanation: Una persona condenada por homicidio involuntario resultante de evadir
+    a las autoridades durante una persecución está sujeta a encarcelamiento en una
+    prisión estatal por un mínimo de 4 a 10 años.
+- id: 125
+  category: penalties_and_points
+  question: Como adulto, su licencia de conducir puede ser suspendida si su historial
+    de conductor muestra ¿cuál de los siguientes totales de puntos?
   choices:
-    A: Sección 1
-    B: Sección 2
-    C: Sección 3
-    D: Sección 4
+    A: 2 puntos en 12 meses
+    B: 3 puntos en 24 meses
+    C: 4 puntos en 12 meses
+    D: 5 puntos en 36 meses
   answer: C
-  explanation: 'El índice enumera la ''Sección 3: El proceso de exámenes'' en el Manual
-    del Automovilista de California.'
-- id: 34
+  explanation: Como adulto, su licencia puede ser suspendida si su historial de conductor
+    muestra 4 puntos en 12 meses, 6 puntos en 24 meses u 8 puntos en 36 meses.
+- id: 126
+  category: driver_responsibility
+  question: ¿Con qué frecuencia puede asistir a una escuela para infractores de tránsito
+    para que una infracción de un punto no sea reportada a su compañía de seguros?
+  choices:
+    A: Una vez en cualquier período de 12 meses
+    B: Una vez en cualquier período de 18 meses
+    C: Una vez en cualquier período de 24 meses
+    D: Una vez en cualquier período de 36 meses
+  answer: B
+  explanation: Si recibe una infracción de tránsito de un punto, puede optar por asistir
+    a una escuela para infractores de tránsito para que la citación no sea reportada
+    a su compañía de seguros una vez en cualquier período de 18 meses.
+- id: 127
   category: safe_driving_rules
-  question: Según el índice del Manual del Automovilista de California, ¿qué sección
-    está dedicada a las 'Leyes y reglas de la carretera'?
+  question: ¿Cuál es el límite de velocidad en un callejón?
   choices:
-    A: Sección 5
-    B: Sección 6
-    C: Sección 7
-    D: Sección 8
-  answer: C
-  explanation: 'El índice enumera explícitamente la ''Sección 7: Leyes y reglas de
-    la carretera''.'
-- id: 35
-  category: defensive_driving
-  question: ¿Qué sección del Manual del Automovilista de California introduce el tema
-    de 'Conducción segura'?
-  choices:
-    A: Sección 5
-    B: Sección 6
-    C: Sección 7
-    D: Sección 8
-  answer: D
-  explanation: 'El índice describe la ''Sección 8: Conducción segura'' para el Manual
-    del Automovilista de California.'
-- id: 36
-  category: driver_testing
-  question: ¿Qué recursos están disponibles bajo el menú de Exámenes en línea del
-    DMV para ayudar a prepararse para un examen de conducir?
-  choices:
-    A: Instructores virtuales en vivo
-    B: Exámenes de práctica y videos instructivos
-    C: Simuladores de manejo
-    D: Servicios de calificación acelerada
+    A: 10 mph
+    B: 15 mph
+    C: 20 mph
+    D: 25 mph
   answer: B
-  explanation: El menú de Exámenes incluye opciones para 'Exámenes de práctica', 'Videos
-    instructivos', 'Manuales del automovilista' y 'Guías especializadas para conductores'.
-- id: 37
+  explanation: Un callejón es cualquier camino de no más de 25 pies de ancho que se
+    utiliza para acceder a las entradas traseras o laterales de edificios o propiedades.
+    El límite de velocidad en un callejón es de 15 mph.
+- id: 128
   category: driver_responsibility
-  question: ¿Qué debe hacer un usuario para activar el chatbot del Asistente Virtual
-    del DMV?
+  question: ¿Qué puede suceder si una persona sin licencia es sorprendida conduciendo
+    su vehículo?
   choices:
-    A: Crear una cuenta MyDMV
-    B: Aceptar los avisos legales
-    C: Ingresar su número de licencia de conducir
-    D: Pagar un cargo por servicio
-  answer: B
-  explanation: La interfaz del chatbot incluye un estado de error que requiere que
-    los usuarios marquen una casilla que dice 'Acepto' los avisos legales para activar
-    el Asistente Virtual.
-- id: 38
-  category: license_system
-  question: ¿Cuál de los siguientes estados de casos se puede consultar en línea a
-    través del portal del DMV?
-  choices:
-    A: Estado de caso de la corte de tránsito
-    B: Estado de caso de seguridad del conductor
-    C: Estado de incautación del vehículo
-    D: Estado de la verificación de smog
-  answer: B
-  explanation: El menú 'Consultar estado' ofrece una opción para consultar el 'Estado
-    de caso de seguridad del conductor', entre otros servicios.
-- id: 39
-  category: license_system
-  question: ¿Qué sección del Manual del Automovilista de California cubre 'Cambiar,
-    reemplazar y renovar su licencia de conducir'?
-  choices:
-    A: Sección 1
-    B: Sección 2
-    C: Sección 3
-    D: Sección 4
-  answer: D
-  explanation: 'El índice enumera la ''Sección 4: Cambiar, reemplazar y renovar su
-    licencia de conducir''.'
-- id: 40
-  category: vehicle_information
-  question: Si necesita solicitar un registro de su vehículo, ¿en qué menú del DMV
-    debe buscar?
-  choices:
-    A: Registro de vehículos
-    B: Licencias de conducir e identificaciones
-    C: Consultar estado
-    D: Citas
+    A: El vehículo puede ser confiscado por 30 días.
+    B: El vehículo será confiscado permanentemente.
+    C: Recibirá 2 puntos en su historial de conductor.
+    D: Su licencia será revocada automáticamente por un año.
   answer: A
-  explanation: '''Solicitar registro de vehículo'' aparece como un servicio bajo el
-    menú de navegación de ''Registro de vehículos''.'
-- id: 41
-  category: license_system
-  question: ¿Qué servicio permite a los clientes asegurar un lugar en una oficina
-    del DMV sin programar una cita tradicional?
-  choices:
-    A: Oficina Virtual
-    B: Get in Line Now (Hacer fila ahora)
-    C: MyDMV Fast Track
-    D: Exámenes en línea
-  answer: B
-  explanation: Bajo el menú de 'Citas' (Appointments), el DMV ofrece el servicio 'Get
-    in Line Now' junto con la programación de citas tradicional.
-- id: 42
-  category: license_system
-  question: Según el descargo de responsabilidad de traducción, ¿por qué el DMV proporciona
-    traducción automática a través de proveedores externos?
-  choices:
-    A: Para reemplazar la versión en inglés por completo
-    B: Solo para fines de información y conveniencia
-    C: Para proporcionar documentos legalmente vinculantes en todos los idiomas
-    D: Para recopilar datos sobre personas que no hablan inglés
-  answer: B
-  explanation: 'El descargo de responsabilidad establece: ''La traducción automática
-    se proporciona solo para fines de información y conveniencia''.'
-- id: 43
-  category: driver_responsibility
-  question: 'Según el Mensaje del Secretario en el Manual del Automovilista de California,
-    conducir o circular por las carreteras de California se considera:'
-  choices:
-    A: Un derecho constitucional
-    B: Un privilegio
-    C: Un requisito para todos los adultos
-    D: Un pasatiempo opcional
-  answer: B
-  explanation: 'El Mensaje del Secretario establece: ''Recuerde que conducir o circular
-    es un privilegio y, por encima de todo, la seguridad debe ser la prioridad''.'
-- id: 44
-  category: safe_driving_rules
-  question: ¿Qué aconseja el Secretario de la Agencia de Transporte del Estado de
-    California con respecto al uso del teléfono celular mientras se conduce?
-  choices:
-    A: Usarlo solo para navegación
-    B: Dejarlo a un lado cuando esté al volante o al manubrio
-    C: Usar solo dispositivos de manos libres
-    D: Es aceptable durante las horas del día
-  answer: B
-  explanation: El Mensaje del Secretario aconseja explícitamente 'dejar a un lado
-    ese teléfono celular cuando esté al volante o al manubrio. No opere un vehículo,
-    motocicleta o bicicleta mientras esté distraído o incapacitado'.
-- id: 45
-  category: license_system
-  question: ¿Dónde puede un californiano comenzar su solicitud de licencia de conducir
-    desde la comodidad de su hogar?
-  choices:
-    A: Llamando a la línea directa del DMV
-    B: Visitando el sitio web del DMV en dmv.ca.gov
-    C: A través de la barra de herramientas de Google Translate
-    D: Enviando un correo electrónico al Secretario de Transporte
-  answer: B
-  explanation: 'El texto indica: ''La solicitud de licencia de conducir se puede iniciar
-    desde la comodidad del hogar visitando el sitio web del DMV en dmv.ca.gov''.'
-- id: 46
-  category: driver_testing
-  question: ¿En cuántos idiomas está disponible el Manual del Automovilista de California?
-  choices:
-    A: '3'
-    B: '5'
-    C: '9'
-    D: '12'
-  answer: C
-  explanation: El Mensaje del Secretario señala que 'El Manual del Automovilista de
-    California está disponible en nueve idiomas...'
-- id: 47
-  category: alcohol_drugs_health
-  question: 'Según la introducción del manual, operar un vehículo, motocicleta o bicicleta
-    mientras está distraído o incapacitado podría significar:'
-  choices:
-    A: Una citación de tráfico menor
-    B: La diferencia entre la vida y la muerte
-    C: Una suspensión automática de la licencia
-    D: Aumento de las primas de seguro
-  answer: B
-  explanation: 'El Mensaje del Secretario advierte: ''No opere un vehículo, motocicleta
-    o bicicleta mientras esté distraído o incapacitado; podría significar la diferencia
-    entre la vida y la muerte''.'
-- id: 48
-  category: defensive_driving
-  question: ¿Cuál de las siguientes se menciona como una prioridad de seguridad para
-    los conductores en el Mensaje del Secretario?
-  choices:
-    A: Conducir siempre por debajo del límite de velocidad
-    B: Ceder el paso solo a vehículos comerciales
-    C: Abrocharse siempre el cinturón y prestar atención a los demás
-    D: Cambiar a un vehículo más nuevo
-  answer: C
-  explanation: El texto aconseja 'abrocharse siempre el cinturón, seguir las leyes
-    de tránsito, prestar atención a otros conductores, ciclistas y peatones...'
-- id: 49
-  category: license_system
-  question: ¿Qué versión del sitio web del DMV se considera la fuente oficial y precisa
-    para la información y los servicios del programa?
-  choices:
-    A: La versión en español
-    B: La versión traducida por Google
-    C: La versión en inglés
-    D: La versión en lenguaje de señas americano
-  answer: C
-  explanation: 'El Descargo de Responsabilidad de Google Translate establece: ''Las
-    páginas web que se encuentran actualmente en inglés en el sitio web del DMV son
-    la fuente oficial y precisa de la información y los servicios del programa que
-    ofrece el DMV''.'
-- id: 50
-  category: license_system
-  question: Según el descargo de responsabilidad del sitio web del DMV, ¿cuál de las
-    siguientes páginas NO se puede traducir usando Google Translate?
-  choices:
-    A: El Mensaje del Secretario
-    B: El Glosario
-    C: Solicitudes en línea
-    D: La sección de Conducción Segura
-  answer: C
-  explanation: El descargo de responsabilidad enumera 'Formularios, Publicaciones,
-    Ubicaciones de Oficinas Locales, Solicitudes en Línea' como páginas que no se
-    pueden traducir con Google Translate.
-- id: 51
+  explanation: Según el manual, si una persona sin licencia es sorprendida conduciendo
+    su vehículo, este puede ser confiscado por 30 días.
+- id: 129
   category: vehicle_information
-  question: Debido a la expansión de los servicios en línea del DMV, ¿cuál de los
-    siguientes trámites se puede completar en el sitio web del DMV?
+  question: ¿En qué lugar está legalmente permitido colocar un dispositivo electrónico
+    de pago de peaje cuadrado de 5 pulgadas en su parabrisas?
   choices:
-    A: Verificaciones de emisiones (smog)
-    B: Registro de vehículos y renovación de la licencia de conducir
-    C: Exámenes de manejo al volante
-    D: Exámenes de la vista
-  answer: B
-  explanation: 'El Mensaje del Secretario establece: "Algunos de estos trámites incluyen
-    la renovación de la licencia de conducir, el registro de vehículos y otros".'
-- id: 52
-  category: driver_responsibility
-  question: ¿Qué aconseja el DMV si decide guardar la transcripción de su chat con
-    el Asistente Virtual en una computadora pública?
-  choices:
-    A: Tener precaución
-    B: Imprimirla de inmediato
-    C: Enviarla por correo electrónico al DMV
-    D: Compartirla con el administrador del sitio
+    A: En la parte superior central del parabrisas
+    B: En el centro de la línea de visión del conductor
+    C: En la esquina superior del parabrisas del lado del pasajero
+    D: En cualquier lugar del parabrisas siempre que sea transparente
   answer: A
-  explanation: 'El descargo de responsabilidad del chatbot advierte: "Cuando termine
-    su chat, puede guardar la transcripción. Tenga precaución al usar una computadora
-    o dispositivo público".'
-- id: 53
-  category: license_system
-  question: Si surgen discrepancias en la traducción del sitio web del DMV, ¿cuál
-    es el efecto legal para fines de cumplimiento o aplicación de la ley?
-  choices:
-    A: El texto traducido reemplaza al texto en inglés
-    B: Las discrepancias no son vinculantes y no tienen efecto legal
-    C: El usuario está exento de la norma
-    D: El DMV debe proporcionar un traductor certificado
-  answer: B
-  explanation: 'El descargo de responsabilidad establece: "Cualquier discrepancia
-    o diferencia creada en la traducción no es vinculante y no tiene efecto legal
-    para fines de cumplimiento o aplicación de la ley".'
-- id: 54
+  explanation: Los objetos solo pueden colocarse en lugares específicos, incluyendo
+    un cuadrado de 5 pulgadas ubicado en la parte superior central de su parabrisas
+    para un dispositivo electrónico de pago de peaje.
+- id: 130
   category: sharing_the_road
-  question: Según el Mensaje del Secretario, ¿a quiénes deben prestar atención los
-    conductores para compartir la carretera de manera segura?
+  question: ¿Cuál de las siguientes afirmaciones es verdadera con respecto a los cortejos
+    fúnebres?
   choices:
-    A: Solo a otros conductores
-    B: Solo a los peatones en los cruces peatonales
-    C: Otros conductores, ciclistas y peatones
-    D: Solo a los conductores de camiones comerciales
+    A: Puede interrumpir brevemente un cortejo fúnebre si tiene prisa.
+    B: Los vehículos en un cortejo fúnebre deben conducir con los faros apagados.
+    C: Un cortejo fúnebre es encabezado por un oficial de tránsito y tiene el derecho
+      de paso.
+    D: Los cortejos fúnebres deben ceder el derecho de paso a todo el demás tráfico
+      civil.
   answer: C
-  explanation: El Mensaje del Secretario recuerda a los californianos "prestar atención
-    a otros conductores, ciclistas y peatones..."
-- id: 55
-  category: license_system
-  question: ¿Con qué propósito proporciona el DMV servicios de traducción automática
-    en su sitio web y chatbot?
+  explanation: Un cortejo fúnebre es encabezado por un oficial de tránsito y tiene
+    el derecho de paso. Todos los vehículos que participan tienen distintivos en el
+    parabrisas y los faros encendidos. Se le puede multar si interrumpe un cortejo
+    fúnebre.
+- id: 131
+  category: driver_responsibility
+  question: ¿Cuál es la regla con respecto a fumar en un vehículo cuando hay un menor
+    presente?
   choices:
-    A: Para documentación legal oficial
-    B: Solo para fines de información y conveniencia
-    C: Para reemplazar el inglés como idioma oficial
-    D: Para garantizar una precisión perfecta para quienes no hablan inglés
-  answer: B
-  explanation: Los descargos de responsabilidad establecen que "la traducción automática
-    se proporciona solo para fines de información y conveniencia".
-- id: 56
-  category: vehicle_information
-  question: Según el índice del manual, ¿qué sección cubre la Responsabilidad Financiera,
-    los Requisitos de Seguro y las Colisiones?
-  choices:
-    A: Sección 7
-    B: Sección 8
-    C: Sección 9
-    D: Sección 10
-  answer: D
-  explanation: 'El índice proporcionado enumera la "Sección 10: Responsabilidad financiera,
-    requisitos de seguro y colisiones".'
-- id: 57
+    A: Está permitido si las ventanas están bajadas.
+    B: Está permitido solo si el menor está en el asiento trasero.
+    C: No está permitido y usted puede ser multado.
+    D: Está permitido si el vehículo está estacionado.
+  answer: C
+  explanation: El manual establece que no debe fumar cuando hay un menor en el vehículo,
+    y puede ser multado por hacerlo.
+- id: 132
   category: safe_driving_rules
-  question: ¿Quién tiene el derecho de paso en un cruce peatonal que no tiene señales
-    para peatones?
+  question: ¿Cuál es el límite de velocidad en un distrito comercial o residencial
+    a menos que se indique lo contrario?
   choices:
-    A: Los vehículos, si viajan al límite de velocidad.
-    B: Los peatones siempre tienen el derecho de paso en los cruces peatonales.
-    C: Los vehículos, si el peatón no está en un cruce peatonal marcado.
-    D: Los peatones, pero solo si hacen contacto visual con el conductor.
+    A: 15 mph
+    B: 25 mph
+    C: 30 mph
+    D: 35 mph
   answer: B
-  explanation: Los peatones tienen el derecho de paso en los cruces peatonales marcados
-    o no marcados. Los conductores deben ceder el paso y reducir la velocidad o detenerse
-    si es necesario para garantizar la seguridad del peatón.
-- id: 58
-  category: defensive_driving
-  question: Para evitar seguir a alguien demasiado cerca (tailgating), ¿cuánto espacio
-    debe dejar entre su vehículo y el vehículo que está delante de usted en condiciones
-    normales?
+  explanation: El límite de velocidad en distritos comerciales o residenciales es
+    de 25 mph, a menos que se indique lo contrario.
+- id: 133
+  category: penalties_and_points
+  question: ¿Cuál es la sanción si un menor tiene dos colisiones por las que es responsable
+    o condenas por infracciones de tránsito dentro de sus primeros 12 meses de conducción?
   choices:
-    A: 2 segundos
-    B: 3 segundos
-    C: 4 segundos
-    D: 5 segundos
+    A: Su licencia es revocada permanentemente.
+    B: No pueden conducir durante 30 días a menos que estén acompañados por un adulto
+      con licencia de al menos 25 años de edad.
+    C: Su privilegio de conducir se suspende por seis meses.
+    D: Deben volver a tomar los exámenes escrito y de conducción.
   answer: B
-  explanation: 'Para evitar seguir de cerca a otro vehículo, el Manual del Conductor
-    de California recomienda usar la "regla de los 3 segundos": cuando el vehículo
-    de adelante pase por un punto determinado, cuente tres segundos para asegurar
-    una distancia de seguimiento segura.'
-- id: 59
-  category: vehicle_information
-  question: Debe encender sus faros delanteros ___ después de la puesta del sol y
-    dejarlos encendidos hasta ___ antes de la salida del sol.
+  explanation: Según el manual, si un menor tiene dos colisiones por las que es responsable,
+    dos condenas por infracciones de tránsito, o una de cada una, no puede conducir
+    durante 30 días a menos que un adulto con licencia, de al menos 25 años de edad,
+    lo acompañe.
+- id: 134
+  category: penalties_and_points
+  question: Si un menor tiene tres colisiones por las que es responsable o condenas
+    por infracciones de tránsito, ¿qué medida tomará el DMV?
   choices:
-    A: 30 minutos; 30 minutos
-    B: 1 hora; 1 hora
-    C: 15 minutos; 15 minutos
-    D: Inmediatamente; inmediatamente
+    A: Suspender el privilegio de conducir por seis meses y ponerlo en libertad condicional
+      por un año.
+    B: Suspender el privilegio de conducir por 30 días.
+    C: Revocar el privilegio de conducir hasta que cumpla 18 años.
+    D: Exigirles que instalen un dispositivo de interbloqueo de encendido.
   answer: A
-  explanation: La ley de California exige que encienda los faros delanteros 30 minutos
-    después de la puesta del sol y los deje encendidos hasta 30 minutos antes de la
-    salida del sol.
-- id: 60
+  explanation: El manual establece que por tres colisiones por las que es responsable
+    o condenas por infracciones de tránsito, el privilegio de conducir de un menor
+    será suspendido por seis meses y estará en libertad condicional por un año.
+- id: 135
+  category: driver_responsibility
+  question: ¿Cuántos días tiene para solicitar una audiencia administrativa a partir
+    de la fecha en que se envía por correo un aviso de acción propuesta contra su
+    privilegio de conducir?
+  choices:
+    A: 10 días
+    B: 14 días
+    C: 30 días
+    D: 60 días
+  answer: B
+  explanation: Debe solicitar una audiencia dentro de los 10 días posteriores a la
+    notificación personal o 14 días a partir de la fecha en que se envía el aviso
+    por correo. Si no realiza la solicitud a tiempo, perderá su derecho a una audiencia.
+- id: 136
+  category: license_system
+  question: ¿Cuál de los siguientes datos en su expediente de conductor se mantiene
+    confidencial y NO está disponible para el público?
+  choices:
+    A: Condenas por infracciones de tránsito
+    B: Historial de suspensión de licencia
+    C: Condiciones físicas o mentales
+    D: Colisiones por las que es responsable
+  answer: C
+  explanation: La mayor parte de la información en su expediente de conductor está
+    disponible para el público, excepto las condiciones físicas o mentales, la dirección
+    y el número de seguro social.
+- id: 137
+  category: safe_driving_rules
+  question: Para tener tiempo de reaccionar y evitar maniobras de último momento,
+    ¿con cuánta anticipación debe observar el camino?
+  choices:
+    A: Al menos 5 segundos adelante
+    B: Al menos 10 segundos adelante
+    C: Al menos 15 segundos adelante
+    D: Al menos 20 segundos adelante
+  answer: B
+  explanation: Para tener tiempo de reaccionar, evitar maniobras de último momento
+    y peligros, mantenga siempre los ojos en movimiento y observe el camino al menos
+    10 segundos por delante de su vehículo.
+- id: 138
   category: defensive_driving
-  question: ¿Cuál es la mejor manera de revisar sus puntos ciegos antes de cambiar
+  question: ¿Qué debe hacer si otro vehículo se incorpora frente a usted demasiado
+    cerca?
+  choices:
+    A: Tocar la bocina y hacer cambio de luces altas.
+    B: Frenar bruscamente para crear espacio inmediato.
+    C: Quitar el pie del acelerador.
+    D: Virar bruscamente hacia el carril adyacente.
+  answer: C
+  explanation: Si un vehículo se incorpora frente a usted demasiado cerca, quite el
+    pie del acelerador. Esto crea espacio entre usted y el vehículo de adelante.
+- id: 139
+  category: sharing_the_road
+  question: 'Al seguir a un motociclista sobre una superficie metálica, como la rejilla
+    de un puente, usted debe:'
+  choices:
+    A: Crear más espacio delante de su vehículo.
+    B: Tocar la bocina para avisarles que está detrás de ellos.
+    C: Rebasarlos inmediatamente.
+    D: Encender las luces altas.
+  answer: A
+  explanation: Debe crear más espacio delante de su vehículo cuando siga a motociclistas
+    en superficies metálicas (rejillas de puentes, vías de tren, etc.) y grava.
+- id: 140
+  category: safe_driving_rules
+  question: ¿Cuál es la forma adecuada de revisar sus puntos ciegos antes de cambiar
     de carril?
   choices:
-    A: Mirar por el espejo retrovisor.
-    B: Mirar por los espejos laterales.
-    C: Girar la cabeza y mirar por encima del hombro.
-    D: Tocar la bocina para advertir a otros conductores.
+    A: Mirar únicamente por el espejo retrovisor.
+    B: Girar todo el cuerpo para mirar por la ventana trasera.
+    C: Mirar por encima de sus hombros derecho e izquierdo por las ventanas laterales.
+    D: Confiar únicamente en sus espejos laterales.
   answer: C
-  explanation: Para revisar sus puntos ciegos, debe girar la cabeza y mirar por encima
-    del hombro en la dirección en la que planea moverse para ver los vehículos que
-    no son visibles en sus espejos.
-- id: 61
-  category: penalties_and_points
-  question: ¿Si es condenado por huir de un oficial de paz en cumplimiento de su deber
-    sin causar lesiones corporales, a cuál de las siguientes sanciones podría enfrentarse?
-  choices:
-    A: Hasta 1 año en una cárcel del condado.
-    B: Una advertencia y una multa.
-    C: Servicio comunitario obligatorio.
-    D: Revocación permanente de su licencia.
-  answer: A
-  explanation: Cualquier persona condenada por causar una persecución y huir de un
-    oficial de paz es sancionable con el encarcelamiento en una cárcel del condado
-    por no más de un año.
-- id: 62
-  category: signs_and_signals
-  question: 'Una señal de tres lados, roja y blanca, indica que usted debe:'
-  choices:
-    A: Detenerse por completo antes de entrar en la intersección.
-    B: Ceder el paso (Yield) a otros vehículos y peatones.
-    C: Mantener su velocidad e incorporarse.
-    D: Ignorar la señal si no hay otros vehículos visibles.
-  answer: B
-  explanation: Una señal triangular roja de CEDA EL PASO (YIELD) indica que debe reducir
-    la velocidad y estar preparado para detenerse, si es necesario, para dejar pasar
-    a cualquier vehículo, ciclista o peatón antes de continuar.
-- id: 63
-  category: sharing_the_road
-  question: 'Al rebasar a un ciclista en un carril de circulación, debe asegurarse
-    de que haya suficiente ancho para el ciclista y mantener un espacio libre mínimo
-    de:'
-  choices:
-    A: 1 pie
-    B: 2 pies
-    C: 3 pies
-    D: 4 pies
-  answer: C
-  explanation: La ley de California exige que los conductores dejen una distancia
-    de al menos tres pies al rebasar a un ciclista para garantizar su seguridad.
-- id: 64
+  explanation: Para revisar sus puntos ciegos, mire por encima de sus hombros derecho
+    e izquierdo por las ventanas laterales. Solo gire la cabeza cuando mire; no gire
+    todo el cuerpo ni el volante.
+- id: 141
   category: safe_driving_rules
-  question: ¿En cuál de las siguientes situaciones es legal realizar un giro en U
-    (U-turn)?
+  question: Si las luces de un vehículo que viene en sentido contrario son demasiado
+    brillantes por la noche, ¿hacia dónde debe mirar?
   choices:
-    A: En una carretera dividida cruzando una sección divisoria, bordillo o franja
-      de terreno.
-    B: A través de una línea amarilla doble cuando sea seguro y legal.
-    C: En un cruce de ferrocarril.
-    D: En una calle de sentido único.
+    A: Directamente a los faros delanteros que vienen de frente.
+    B: Hacia el borde derecho de su carril.
+    C: Hacia la línea central de la carretera.
+    D: Hacia abajo a su tablero de instrumentos.
   answer: B
-  explanation: Puede realizar un giro en U a través de una línea amarilla doble cuando
-    sea seguro y legal. Es ilegal realizar un giro en U en una calle de sentido único,
-    en un cruce de ferrocarril o a través de una barrera de una carretera dividida.
-- id: 65
-  category: alcohol_drugs_health
-  question: 'Si es menor de 21 años, la ley de ''Tolerancia Cero'' de California establece
-    que es ilegal conducir con un BAC (concentración de alcohol en sangre) de:'
+  explanation: Si las luces de otro vehículo son demasiado brillantes, no mire directamente
+    a los faros delanteros que vienen de frente. En su lugar, mire hacia el borde
+    derecho de su carril.
+- id: 142
+  category: safe_driving_rules
+  question: Cuando está lloviendo, ¿qué luces está obligado a usar mientras conduce?
   choices:
-    A: 0.01% o superior
-    B: 0.04% o superior
-    C: 0.05% o superior
-    D: 0.08% o superior
-  answer: A
-  explanation: La ley de Tolerancia Cero de California establece que es ilegal que
-    cualquier persona menor de 21 años conduzca con un BAC de 0.01% o superior.
-- id: 66
-  category: driver_responsibility
-  question: 'Si se ve involucrado en una colisión que resulte en lesiones o muerte,
-    debe informarlo al DMV en un plazo de:'
+    A: Luces delanteras de alta intensidad (altas)
+    B: Luces delanteras de baja intensidad (bajas)
+    C: Solo sus luces de estacionamiento
+    D: Luces de emergencia
+  answer: B
+  explanation: Cuando esté lloviendo, use sus luces delanteras de baja intensidad.
+    No conduzca usando solo sus luces de estacionamiento.
+- id: 143
+  category: defensive_driving
+  question: 'Si un vehículo con una sola luz encendida conduce hacia usted por la
+    noche, usted debe:'
   choices:
-    A: 24 horas
-    B: 5 días
-    C: 10 días
-    D: 30 días
+    A: Hacer cambio de luces (luces altas) para advertirle.
+    B: Conducir lo más a la izquierda posible.
+    C: Conducir lo más a la derecha posible.
+    D: Detener su vehículo en el carril.
   answer: C
-  explanation: Usted (o su agente de seguros, corredor o representante legal) debe
-    informar la colisión al DMV en un plazo de 10 días si alguien resulta herido o
-    fallece, o si los daños a la propiedad superan los $1,000.
+  explanation: Cuando un vehículo con una sola luz conduce hacia usted, conduzca lo
+    más a la derecha posible. Podría ser un ciclista, un motociclista o un vehículo
+    al que le falta un faro delantero.
+- id: 144
+  category: vehicle_information
+  question: ¿Qué debe hacer antes de bajar una colina empinada para ayudar a prevenir
+    derrapes en superficies resbaladizas?
+  choices:
+    A: Cambiar a una marcha más alta.
+    B: Cambiar a una marcha baja.
+    C: Mantener presionados los frenos durante todo el descenso.
+    D: Poner el vehículo en punto muerto (neutral).
+  answer: B
+  explanation: Para evitar derrapes en superficies resbaladizas, debe cambiar a una
+    marcha baja antes de bajar una colina empinada.
+- id: 145
+  category: defensive_driving
+  question: Si su vehículo comienza a derrapar sobre una superficie resbaladiza, ¿cuál
+    de las siguientes es la acción correcta a tomar?
+  choices:
+    A: Pisar los frenos a fondo inmediatamente.
+    B: Girar el volante en la dirección opuesta al derrape.
+    C: Retirar lentamente el pie del acelerador y no usar los frenos.
+    D: Acelerar rápidamente para recuperar la tracción.
+  answer: C
+  explanation: Si comienza a derrapar, debe retirar lentamente el pie del acelerador,
+    no usar los frenos y girar el volante en la dirección del derrape.
+- id: 146
+  category: vehicle_information
+  question: ¿Cómo debe recuperarse de un derrape por bloqueo de ruedas si su vehículo
+    está equipado con un sistema de frenos antibloqueo (ABS) en las cuatro ruedas?
+  choices:
+    A: Bombear el pedal del freno rápidamente.
+    B: Aplicar presión firme en el pedal del freno.
+    C: Tirar del freno de emergencia.
+    D: Apagar el motor.
+  answer: B
+  explanation: Para salir de un derrape por bloqueo de ruedas si su vehículo está
+    equipado con un sistema de frenos antibloqueo (ABS) en las cuatro ruedas, aplique
+    presión firme en el pedal del freno.
+- id: 147
+  category: penalties_and_points
+  question: ¿Qué sucede con las restricciones, suspensiones o sentencias de libertad
+    condicional existentes en la licencia de conducir de un menor cuando cumple 18
+    años?
+  choices:
+    A: Se borran inmediatamente.
+    B: Se reducen a la mitad.
+    C: No se borran ni terminan.
+    D: Se convierten en una multa.
+  answer: C
+  explanation: 'El manual señala: Cumplir 18 años no borra ni termina las restricciones,
+    suspensiones o sentencias de libertad condicional existentes.'
+- id: 148
+  category: vehicle_information
+  question: ¿Cómo puede secar sus frenos si se mojan mientras conduce?
+  choices:
+    A: Bombear el pedal del freno rápidamente durante un minuto.
+    B: Presionar ligeramente los pedales del acelerador y del freno al mismo tiempo.
+    C: Cambiar a una marcha más baja y avanzar por inercia hasta detenerse.
+    D: Aplicar el freno de emergencia mientras conduce a baja velocidad.
+  answer: B
+  explanation: Según el manual, si sus frenos se mojan, puede secarlos presionando
+    ligeramente los pedales del acelerador y del freno al mismo tiempo hasta que los
+    frenos se sequen.
+- id: 149
+  category: safe_driving_rules
+  question: ¿Cuánto debe reducir su velocidad al conducir en una carretera con nieve
+    compactada?
+  choices:
+    A: Reducir su velocidad de 5 a 10 mph.
+    B: Reducir su velocidad a no más de 5 mph.
+    C: Reducir su velocidad a la mitad.
+    D: Reducir su velocidad en 15 mph.
+  answer: C
+  explanation: El manual establece que debe ajustar su velocidad para diferentes condiciones,
+    específicamente reduciendo su velocidad a la mitad cuando conduzca sobre nieve
+    compactada.
+- id: 150
+  category: safe_driving_rules
+  question: 'Si no puede ver a más de 100 pies en una fuerte tormenta de lluvia o
+    nieve, no es seguro conducir a más de:'
+  choices:
+    A: 20 mph
+    B: 30 mph
+    C: 40 mph
+    D: 50 mph
+  answer: B
+  explanation: El manual aconseja que si no puede ver a más de 100 pies en una fuerte
+    tormenta de lluvia o nieve, no es seguro conducir a más de 30 mph.
+- id: 151
+  category: defensive_driving
+  question: ¿Qué debe hacer si su vehículo comienza a hidroplanear (hydroplane)?
+  choices:
+    A: Aplique los frenos con firmeza y mantenga el volante recto.
+    B: Bombee los frenos rápidamente para recuperar la tracción.
+    C: Reduzca la velocidad gradualmente y no use los frenos.
+    D: Acelere ligeramente para atravesar el agua.
+  answer: C
+  explanation: Si su vehículo comienza a hidroplanear, el manual indica que debe reducir
+    la velocidad gradualmente y no usar los frenos, ya que un frenado repentino puede
+    hacer que pierda el control de su vehículo.
+- id: 152
+  category: vehicle_information
+  question: ¿Cuál de los siguientes es un paso recomendado si su vehículo se queda
+    atascado en la nieve o el lodo?
+  choices:
+    A: Cambie a una marcha alta y haga girar las ruedas rápidamente.
+    B: Cambie a una marcha baja y mantenga las ruedas delanteras rectas.
+    C: Gire el volante bruscamente de un lado a otro mientras acelera.
+    D: Aplique el freno de emergencia antes de pisar el acelerador.
+  answer: B
+  explanation: Cuando se está atascado en la nieve o el lodo, el manual recomienda
+    cambiar a una marcha baja y mantener las ruedas delanteras rectas, mientras pisa
+    suavemente el acelerador y evita que las ruedas patinen.
+- id: 153
+  category: safe_driving_rules
+  question: ¿Por qué debe evitar el uso del control de crucero (cruise control) cuando
+    conduce con vientos fuertes?
+  choices:
+    A: Evita que el vehículo cambie a una marcha más baja.
+    B: Agota la batería del vehículo más rápido en condiciones de viento.
+    C: Necesita mantener el control máximo del acelerador si ocurre una ráfaga.
+    D: Hace que el volante se bloquee durante ráfagas repentinas.
+  answer: C
+  explanation: El manual establece que no debe usar el control de crucero con vientos
+    fuertes para poder mantener el control máximo del acelerador si ocurre una ráfaga.
+- id: 154
+  category: defensive_driving
+  question: ¿Qué luces debe usar al conducir con niebla o humo densos?
+  choices:
+    A: Luces altas (high-beam)
+    B: Luces bajas (low-beam)
+    C: Solo sus luces de estacionamiento
+    D: Solo sus luces antiniebla
+  answer: B
+  explanation: Al conducir con niebla o humo densos, debe usar las luces bajas. Las
+    luces altas se reflejarán y causarán deslumbramiento, y nunca debe conducir usando
+    solo las luces de estacionamiento o antiniebla.
+- id: 155
+  category: sharing_the_road
+  question: ¿Qué debe hacer cuando un oficial de la ley realiza una interrupción del
+    tráfico (traffic break) zigzagueando entre los carriles con las luces de emergencia
+    encendidas?
+  choices:
+    A: Acelere para rebasar al vehículo de patrulla antes de que bloquee su carril.
+    B: Encienda sus luces de emergencia y disminuya lentamente su velocidad.
+    C: Frene repentinamente para detener su vehículo lo más rápido posible.
+    D: Estaciónese en el acotamiento y espere a que el oficial pase.
+  answer: B
+  explanation: Durante una interrupción del tráfico, debe encender sus luces de emergencia
+    para advertir a otros conductores y disminuir lentamente su velocidad hasta alcanzar
+    la misma velocidad que el oficial.
+- id: 156
+  category: driver_responsibility
+  question: ¿Bajo qué circunstancia puede recibir una multa si su pasajero no lleva
+    puesto el cinturón de seguridad?
+  choices:
+    A: Solo si el pasajero viaja en el asiento delantero.
+    B: Si el pasajero es menor de 16 años.
+    C: Solo si el pasajero es menor de 18 años.
+    D: No puede recibir una multa por el hecho de que un pasajero no use el cinturón
+      de seguridad.
+  answer: B
+  explanation: El manual establece que usted y sus pasajeros deben usar cinturones
+    de seguridad, y usted puede recibir una multa si un pasajero menor de 16 años
+    no lleva puesto su cinturón de seguridad.
+- id: 157
+  category: driver_responsibility
+  question: ¿Cómo debe usar el cinturón de seguridad una mujer embarazada?
+  choices:
+    A: El cinturón de regazo debe usarse alto a través del abdomen.
+    B: El cinturón de regazo debe usarse lo más bajo posible debajo del abdomen.
+    C: La correa del hombro debe colocarse detrás de la espalda.
+    D: Las mujeres embarazadas están exentas de usar el cinturón de regazo.
+  answer: B
+  explanation: Si está embarazada, el manual indica que debe usar el cinturón de regazo
+    lo más bajo posible debajo de su abdomen y colocar la correa del hombro entre
+    sus senos y a un lado de la protuberancia del abdomen.
+- id: 158
+  category: driver_responsibility
+  question: 'Un niño debe estar asegurado en un sistema de retención infantil orientado
+    hacia atrás si:'
+  choices:
+    A: Tiene menos de 2 años, pesa menos de 40 libras y mide menos de 3 pies y 4 pulgadas
+      de altura.
+    B: Tiene menos de 4 años, pesa menos de 50 libras y mide menos de 4 pies de altura.
+    C: Tiene menos de 8 años y mide menos de 4 pies y 9 pulgadas de altura.
+    D: Tiene menos de 1 año y pesa menos de 20 libras.
+  answer: A
+  explanation: El manual requiere que los niños menores de 2 años, que pesen menos
+    de 40 libras y midan menos de 3 pies y 4 pulgadas de altura, estén asegurados
+    en un sistema de retención infantil orientado hacia atrás.
+- id: 159
+  category: driver_responsibility
+  question: ¿Cuándo se permite que un niño menor de 8 años viaje en el asiento delantero
+    de un vehículo en un sistema de retención infantil aprobado por el gobierno federal?
+  choices:
+    A: Cuando el niño prefiere sentarse en el asiento delantero.
+    B: Cuando el conductor es el padre o tutor legal del niño.
+    C: Cuando todos los asientos traseros ya están ocupados por niños de 7 años o
+      menos.
+    D: Cuando el vehículo viaja a velocidades inferiores a 30 mph.
+  answer: C
+  explanation: Un niño menor de 8 años puede viajar en el asiento delantero en casos
+    específicos detallados en el manual, como cuando todos los asientos traseros ya
+    están ocupados por niños de 7 años o menos.
+- id: 160
+  category: safe_driving_rules
+  question: ¿Por qué el pavimento puede estar muy resbaladizo cuando empieza a llover
+    después de un período de clima seco y caluroso?
+  choices:
+    A: El calor hace que el asfalto se derrita y se vuelva resbaladizo.
+    B: El aceite y el polvo en la superficie de la carretera aún no han sido lavados.
+    C: La lluvia se mezcla con el escape del vehículo para crear una película resbaladiza.
+    D: La goma de los neumáticos se endurece con el calor, reduciendo la tracción.
+  answer: B
+  explanation: El manual señala que el pavimento puede estar muy resbaladizo ante
+    la primera señal de lluvia, especialmente después de un clima seco y caluroso,
+    porque el aceite y el polvo en la superficie de la carretera no han sido lavados.
+- id: 161
+  category: defensive_driving
+  question: ¿Qué debe hacer inmediatamente después de conducir por una carretera inundada?
+  choices:
+    A: Detenerse y revisar la presión de los neumáticos.
+    B: Probar los frenos para asegurarse de que funcionen correctamente.
+    C: Encender las luces altas para buscar escombros.
+    D: Poner el vehículo en punto muerto (neutral) y acelerar el motor para secarlo.
+  answer: B
+  explanation: El manual establece que si no tiene otra opción más que conducir por
+    una carretera inundada, debe conducir lentamente y, después de atravesar el agua,
+    probar los frenos para asegurarse de que funcionen correctamente.
+- id: 162
+  category: safe_driving_rules
+  question: ¿Cuándo se le permite a un niño usar un cinturón de seguridad debidamente
+    asegurado en lugar de un sistema de sujeción para niños?
+  choices:
+    A: Cuando tienen 6 años o al menos 4 pies de altura.
+    B: Cuando tienen 7 años o al menos 4 pies 5 pulgadas de altura.
+    C: Cuando tienen 8 años o más, o al menos 4 pies 9 pulgadas de altura.
+    D: Cuando tienen 9 años o al menos 5 pies de altura.
+  answer: C
+  explanation: Según el manual, los niños que tienen 8 años o más, o que miden al
+    menos 4 pies 9 pulgadas de altura, pueden usar un cinturón de seguridad debidamente
+    asegurado que cumpla con los estándares federales.
+- id: 163
+  category: vehicle_information
+  question: Para mantener la seguridad al conducir, ¿a qué distancia debe sentarse
+    de la cubierta de la bolsa de aire (airbag)?
+  choices:
+    A: Al menos 5 pulgadas
+    B: Al menos 10 pulgadas
+    C: Al menos 12 pulgadas
+    D: Al menos 15 pulgadas
+  answer: B
+  explanation: El manual indica que debe situarse a al menos 10 pulgadas de la cubierta
+    de la bolsa de aire, medido desde el centro del volante hasta el esternón, siempre
+    que pueda mantener el control total de su vehículo.
+- id: 164
+  category: driver_responsibility
+  question: 'Es ilegal dejar a un niño de seis años o menos desatendido en un vehículo
+    a menos que esté supervisado por una persona que tenga al menos:'
+  choices:
+    A: 10 años
+    B: 12 años
+    C: 14 años
+    D: 16 años
+  answer: B
+  explanation: Es ilegal dejar a un niño de seis años o menos desatendido en un vehículo.
+    Sin embargo, un niño puede ser dejado bajo la supervisión de una persona que tenga
+    al menos 12 años.
+- id: 165
+  category: safe_driving_rules
+  question: ¿Qué establece la Ley de Velocidad Básica (Basic Speed Law) de California?
+  choices:
+    A: Siempre debe conducir al límite de velocidad indicado.
+    B: Nunca debe conducir más rápido de lo que sea seguro para las condiciones actuales
+      de la carretera.
+    C: Debe conducir 5 mph por debajo del límite de velocidad en condiciones climáticas
+      adversas.
+    D: Puede exceder el límite de velocidad para rebasar a otro vehículo de manera
+      segura.
+  answer: B
+  explanation: En California, nunca debe conducir más rápido de lo que sea seguro
+    para las condiciones actuales de la carretera. Esto se conoce como la Ley de Velocidad
+    Básica (Basic Speed Law).
+- id: 166
+  category: safe_driving_rules
+  question: A menos que se indique lo contrario, ¿cuál es el límite de velocidad máximo
+    en una carretera de dos carriles sin división en California?
+  choices:
+    A: 55 mph
+    B: 60 mph
+    C: 65 mph
+    D: 70 mph
+  answer: A
+  explanation: A menos que se indique lo contrario, el límite de velocidad máximo
+    ideal es de 55 mph en una carretera de dos carriles sin división y para vehículos
+    que remolcan tráileres.
+- id: 167
+  category: defensive_driving
+  question: Si se encuentra en una carretera de dos carriles con un vehículo que viene
+    en sentido contrario a la izquierda y un ciclista adelante a su derecha, ¿cuál
+    es la acción más segura?
+  choices:
+    A: Acelerar para rebasar al ciclista antes de que el vehículo llegue a su posición.
+    B: Conducir entre el vehículo y el ciclista.
+    C: Tocar la bocina para que el ciclista se salga de la carretera.
+    D: Reducir la velocidad y dejar pasar al vehículo que viene en sentido contrario
+      antes de moverse a la izquierda para rebasar al ciclista.
+  answer: D
+  explanation: En lugar de conducir entre el vehículo y el ciclista, enfrente un peligro
+    a la vez. Reduzca la velocidad y deje pasar al vehículo que viene en sentido contrario,
+    luego muévase a la izquierda para dejar suficiente espacio para rebasar al ciclista.
+- id: 168
+  category: defensive_driving
+  question: ¿Cuál es un paso recomendado a seguir si experimenta el reventón de un
+    neumático mientras conduce?
+  choices:
+    A: Frenar repentinamente para detener el vehículo lo más rápido posible.
+    B: Retirar abruptamente el pie del acelerador.
+    C: Sujetar el volante con ambas manos y soltar gradualmente el acelerador.
+    D: Girar el volante bruscamente hacia el acotamiento de la carretera.
+  answer: C
+  explanation: Si se le revienta un neumático, debe sujetar el volante con ambas manos,
+    mantener su velocidad si es posible y soltar gradualmente el acelerador. Frenar
+    repentinamente o retirar el pie del acelerador de forma abrupta puede provocar
+    la pérdida de control.
+- id: 169
+  category: defensive_driving
+  question: 'Si sus ruedas se salen del pavimento, debe hacer todo lo siguiente EXCEPTO:'
+  choices:
+    A: Sujetar el volante con firmeza.
+    B: Frenar suavemente.
+    C: Tirar del volante con fuerza para volver a la carretera.
+    D: Retirar el pie del acelerador.
+  answer: C
+  explanation: Si sus ruedas se salen del pavimento, no tire ni gire el volante con
+    demasiada fuerza, ya que esto podría causar que se dirija hacia el tráfico en
+    sentido contrario. Debe sujetar el volante con firmeza, retirar el pie del acelerador
+    y frenar suavemente.
+- id: 170
+  category: safe_driving_rules
+  question: Si su vehículo queda averiado en la autopista y debe salir de él, ¿por
+    qué lado debe salir?
+  choices:
+    A: El lado izquierdo
+    B: El lado derecho
+    C: El lado del conductor
+    D: Cualquier lado que tenga una puerta que funcione
+  answer: B
+  explanation: Si su vehículo deja de funcionar en la autopista, debe orillarse de
+    manera segura en el acotamiento derecho y salir por el lado derecho para estar
+    alejado del tráfico.
+- id: 171
+  category: vehicle_information
+  question: ¿Cuál de los siguientes servicios NO proporcionará la Patrulla de Servicio
+    de Autopistas (FSP) de la Patrulla de Caminos de California?
+  choices:
+    A: Proporcionar un galón de gasolina si se le acaba.
+    B: Pasar corriente a su vehículo si la batería está descargada.
+    C: Remolcar su vehículo a un servicio de reparación privado.
+    D: Cambiar una llanta ponchada.
+  answer: C
+  explanation: La FSP proporcionará gasolina, pasará corriente y cambiará llantas
+    ponchadas, pero no remolcará su vehículo a un servicio de reparación privado o
+    a una residencia.
+- id: 172
+  category: safe_driving_rules
+  question: Si su vehículo se apaga en una vía de tren y se aproxima un tren con las
+    luces de advertencia parpadeando, ¿qué debe hacer de inmediato?
+  choices:
+    A: Permanecer en su vehículo y llamar al 911.
+    B: Salir de su vehículo y correr diagonalmente lejos de las vías en la dirección
+      de donde viene el tren.
+    C: Salir de su vehículo y correr en la misma dirección en la que viaja el tren.
+    D: Intentar reiniciar el motor mientras toca la bocina.
+  answer: B
+  explanation: Si su vehículo se apaga con un tren acercándose y las luces de advertencia
+    parpadeando, salga inmediatamente de su vehículo y corra lejos de las vías diagonalmente
+    en la dirección de donde viene el tren, luego llame al 911.
+- id: 173
+  category: safe_driving_rules
+  question: ¿Cómo debe usar un teléfono celular un conductor adulto mientras conduce?
+  choices:
+    A: Puede sostener el teléfono si solo está hablando, no enviando mensajes de texto.
+    B: Solo debe usar el teléfono celular en modo de manos libres.
+    C: Puede usar un teléfono de mano si conduce a menos de 30 mph.
+    D: Está completamente prohibido usar cualquier teléfono celular, incluso en modo
+      de manos libres.
+  answer: B
+  explanation: Conducir mientras se usa un teléfono celular de mano es inseguro e
+    ilegal. Los conductores adultos solo deben usar un teléfono celular en modo de
+    manos libres cuando sea necesario.
+- id: 174
+  category: safe_driving_rules
+  question: ¿Bajo qué circunstancia se le permite legalmente a un menor usar un teléfono
+    celular mientras conduce?
+  choices:
+    A: Cuando habla con un padre o tutor.
+    B: Cuando usa un dispositivo de manos libres.
+    C: Para hacer una llamada de asistencia de emergencia.
+    D: Cuando está detenido en un semáforo en rojo.
+  answer: C
+  explanation: Es contra la ley que un menor use un teléfono celular mientras conduce,
+    con la excepción de que los menores pueden usar un teléfono celular para hacer
+    una llamada de asistencia de emergencia.
+- id: 175
+  category: vehicle_information
+  question: ¿Cuál de los siguientes es un síntoma de intoxicación por monóxido de
+    carbono?
+  choices:
+    A: Zumbido en los oídos
+    B: Sed excesiva
+    C: Visión borrosa
+    D: Calambres musculares
+  answer: A
+  explanation: Los síntomas de intoxicación por monóxido de carbono incluyen cansancio,
+    bostezos, mareos, náuseas, dolor de cabeza y zumbido en los oídos.
+- id: 176
+  category: vehicle_information
+  question: ¿Qué debe hacer si conduce en condiciones de calor extremo para prevenir
+    o manejar el sobrecalentamiento?
+  choices:
+    A: Encender el aire acondicionado en su configuración máxima.
+    B: Conducir a altas velocidades para aumentar el flujo de aire al motor.
+    C: Apagar el aire acondicionado.
+    D: Abrir ligeramente las ventanas y usar el desempañador.
+  answer: C
+  explanation: En condiciones de calor extremo, debe vigilar el indicador de temperatura,
+    evitar conducir a altas velocidades durante periodos prolongados y apagar el aire
+    acondicionado.
+- id: 177
+  category: alcohol_drugs_health
+  question: ¿Cuál es la sanción si se niega a hacerse una prueba de sangre u orina
+    cuando un oficial de la ley sospecha que conduce bajo la influencia (DUI)?
+  choices:
+    A: Recibirá una multa de advertencia.
+    B: El DMV suspenderá o revocará su privilegio de conducir por un año.
+    C: Se le multará con $1,000 de inmediato.
+    D: Su vehículo será confiscado por 6 meses.
+  answer: B
+  explanation: El manual establece que si se niega a hacerse una prueba de sangre
+    u orina, el DMV suspenderá o revocará su privilegio de conducir por un año.
+- id: 178
+  category: penalties_and_points
+  question: Si tiene entre 13 y 20 años y es condenado por operar una bicicleta bajo
+    la influencia del alcohol o drogas, ¿qué podría suceder?
+  choices:
+    A: Se le requerirá pagar una multa de $500.
+    B: Debe completar 100 horas de servicio comunitario.
+    C: Su privilegio de conducir puede ser suspendido o retrasado por un año una vez
+      que sea elegible para conducir.
+    D: Su bicicleta será confiscada permanentemente por el estado.
+  answer: C
+  explanation: Si tiene entre 13 y 20 años y es condenado por operar una bicicleta
+    bajo la influencia, su privilegio de conducir puede ser suspendido o retrasado
+    por un año una vez que sea elegible para conducir.
+- id: 179
+  category: alcohol_drugs_health
+  question: ¿Dónde debe guardar un recipiente de alcohol abierto en su vehículo?
+  choices:
+    A: En la guantera.
+    B: Debajo del asiento del conductor.
+    C: En el maletero o en un lugar donde no se sienten los pasajeros.
+    D: En la consola central.
+  answer: C
+  explanation: Si un recipiente de alcohol está abierto, debe guardarlo en el maletero
+    o en un lugar donde no se sienten los pasajeros. Es ilegal guardar un recipiente
+    abierto en la guantera.
+- id: 180
+  category: alcohol_drugs_health
+  question: 'Es ilegal que una persona de 21 años o más conduzca con una concentración
+    de alcohol en sangre (BAC) de:'
+  choices:
+    A: 0.04% o superior
+    B: 0.05% o superior
+    C: 0.08% o superior
+    D: 0.10% o superior
+  answer: C
+  explanation: Es ilegal que usted conduzca si tiene un BAC de 0.08% o superior si
+    es mayor de 21 años.
+- id: 181
+  category: alcohol_drugs_health
+  question: ¿Cuál es el límite legal de concentración de alcohol en sangre (BAC) para
+    alguien que conduce un vehículo que requiere una licencia de conducir comercial?
+  choices:
+    A: 0.01% o más
+    B: 0.02% o más
+    C: 0.04% o más
+    D: 0.08% o más
+  answer: C
+  explanation: Es ilegal conducir con un BAC de 0.04% o más si conduce un vehículo
+    que requiere una licencia de conducir comercial.
+- id: 182
+  category: penalties_and_points
+  question: Si es arrestado por conducir bajo los efectos del alcohol o drogas (DUI),
+    ¿cuántos días tiene para solicitar una audiencia administrativa del DMV?
+  choices:
+    A: 5 días
+    B: 10 días
+    C: 14 días
+    D: 30 días
+  answer: B
+  explanation: Si es arrestado por DUI, puede solicitar una audiencia administrativa
+    del DMV dentro de los 10 días a partir de la fecha de su arresto.
+- id: 183
+  category: penalties_and_points
+  question: ¿Cuánto tiempo permanece una condena por DUI en su expediente de conductor?
+  choices:
+    A: 3 años
+    B: 5 años
+    C: 7 años
+    D: 10 años
+  answer: D
+  explanation: Todas las condenas por DUI permanecen en su expediente de conductor
+    durante 10 años.
+- id: 184
+  category: alcohol_drugs_health
+  question: 'Si es menor de 21 años, puede llevar una bebida alcohólica dentro de
+    un vehículo ÚNICAMENTE si:'
+  choices:
+    A: Está guardada en la guantera.
+    B: Una persona de 21 años o más lo acompaña.
+    C: Se dirige a una fiesta privada.
+    D: El envase está vacío.
+  answer: B
+  explanation: Si es menor de 21 años, no puede llevar ninguna bebida alcohólica dentro
+    de un vehículo a menos que lo acompañe una persona de 21 años o más, y el envase
+    debe estar lleno, sellado y sin abrir.
+- id: 185
+  category: penalties_and_points
+  question: Si es menor de 21 años y lo sorprenden con alcohol en su vehículo, ¿por
+    cuánto tiempo pueden las autoridades confiscar su vehículo?
+  choices:
+    A: Hasta 10 días
+    B: Hasta 30 días
+    C: Hasta 60 días
+    D: Hasta 90 días
+  answer: B
+  explanation: Si es menor de 21 años y lo sorprenden con alcohol en su vehículo,
+    las autoridades pueden confiscar su vehículo por hasta 30 días.
+- id: 186
+  category: safe_driving_rules
+  question: ¿Cuál es la cobertura mínima de seguro requerida para daños a la propiedad
+    en California?
+  choices:
+    A: $5,000
+    B: $10,000
+    C: $15,000
+    D: $30,000
+  answer: C
+  explanation: Su seguro debe cubrir al menos $15,000 por daños a la propiedad.
+- id: 187
+  category: penalties_and_points
+  question: ¿Cuál es la sanción por estar involucrado en una colisión sin la cobertura
+    de seguro adecuada?
+  choices:
+    A: Una multa de $500.
+    B: Su privilegio de conducir será suspendido por hasta cuatro años.
+    C: Tiempo de cárcel obligatorio de 30 días.
+    D: Su vehículo será confiscado por un año.
+  answer: B
+  explanation: Su privilegio de conducir será suspendido por hasta cuatro años si
+    se ve involucrado en una colisión y no tiene la cobertura de seguro adecuada,
+    independientemente de quién haya tenido la culpa.
+- id: 188
+  category: alcohol_drugs_health
+  question: ¿Cómo considera la ley de California el conducir bajo la influencia de
+    medicamentos recetados en comparación con las drogas ilegales?
+  choices:
+    A: Los medicamentos recetados están exentos de las leyes de DUI.
+    B: La ley no ve diferencia entre las drogas ilegales y los medicamentos que obtiene
+      de un médico o farmacia.
+    C: Los medicamentos recetados solo resultan en una advertencia.
+    D: Los medicamentos de venta libre son legales para usar mientras conduce sin
+      importar los efectos secundarios.
+  answer: B
+  explanation: La ley no ve diferencia entre las drogas ilegales y los medicamentos
+    que obtiene de un médico o farmacia. Todos pueden afectar su capacidad para conducir
+    de manera segura.
+- id: 189
+  category: penalties_and_points
+  question: ¿Cuál de los siguientes es un requisito si es condenado por un DUI?
+  choices:
+    A: Debe vender su vehículo.
+    B: Debe entregar su pasaporte.
+    C: Debe presentar un Certificado de Prueba de Seguro de California (SR 22/SR 1P).
+    D: Debe volver a tomar el examen de conducir escrito de inmediato.
+  answer: C
+  explanation: Si es condenado por un DUI, debe completar un programa de DUI, presentar
+    un Certificado de Prueba de Seguro de California (SR 22/SR 1P), pagar tarifas
+    y es posible que se le solicite instalar un dispositivo de bloqueo de encendido.
+- id: 190
+  category: vehicle_information
+  question: Cuando compra un vehículo, ¿cuántos días tiene para transferir la propiedad
+    a su nombre?
+  choices:
+    A: 5 días
+    B: 10 días
+    C: 15 días
+    D: 20 días
+  answer: B
+  explanation: Según el manual, cuando compra un vehículo, tiene 10 días para transferir
+    la propiedad a su nombre.
+- id: 191
+  category: vehicle_information
+  question: ¿Dentro de cuántos días debe notificar al DMV cuando vende un vehículo?
+  choices:
+    A: 5 días
+    B: 10 días
+    C: 15 días
+    D: 30 días
+  answer: A
+  explanation: Cuando vende un vehículo, debe notificar al DMV dentro de los cinco
+    días completando un Aviso de Transferencia y Liberación de Responsabilidad (Notice
+    of Transfer and Release of Liability).
+- id: 192
+  category: vehicle_information
+  question: Después de convertirse en residente o conseguir un trabajo en California,
+    ¿cuánto tiempo tiene para registrar su vehículo de fuera del estado?
+  choices:
+    A: 10 días
+    B: 20 días
+    C: 30 días
+    D: 60 días
+  answer: B
+  explanation: Tiene 20 días para registrar su vehículo después de convertirse en
+    residente o conseguir un trabajo en California.
+- id: 193
+  category: driver_responsibility
+  question: 'Debe reportar una colisión al DMV dentro de los 10 días si:'
+  choices:
+    A: La colisión causó más de $500 en daños a la propiedad.
+    B: La colisión causó más de $1,000 en daños a la propiedad o alguien resultó herido.
+    C: Usted tuvo la culpa de la colisión.
+    D: La colisión ocurrió en una carretera pública y causó retrasos en el tráfico.
+  answer: B
+  explanation: Si se ve involucrado en una colisión, debe reportarla al DMV dentro
+    de los 10 días si la colisión causó más de $1,000 en daños a la propiedad, o si
+    alguien resultó herido o falleció.
+- id: 194
+  category: penalties_and_points
+  question: 'No detenerse o abandonar la escena de una colisión en la que usted está
+    involucrado se conoce como:'
+  choices:
+    A: Una reexaminación prioritaria.
+    B: Un choque y fuga (hit-and-run).
+    C: Una violación del derecho de paso.
+    D: Una violación del SR-1.
+  answer: B
+  explanation: No detenerse o abandonar la escena de un accidente se llama choque
+    y fuga (hit-and-run), y el castigo es severo si es condenado.
+- id: 195
+  category: driver_responsibility
+  question: Si su vehículo choca contra un automóvil estacionado y no puede encontrar
+    al dueño, ¿qué debe hacer?
+  choices:
+    A: Esperar junto al vehículo hasta que regrese el dueño.
+    B: Dejar una nota con su nombre, número de teléfono y dirección, y reportar la
+      colisión a las autoridades.
+    C: Llamar a su compañía de seguros y abandonar la escena.
+    D: Mover el auto estacionado fuera del camino y dejar una nota en el parabrisas.
+  answer: B
+  explanation: Si no puede encontrar al dueño, deje una nota con su nombre, número
+    de teléfono y dirección bien sujeta al vehículo o propiedad, y reporte la colisión
+    a las autoridades.
+- id: 196
+  category: safe_driving_rules
+  question: ¿Qué debe hacer si hiere accidentalmente a un animal mientras conduce?
+  choices:
+    A: Mover al animal herido a un lado de la carretera.
+    B: Llamar a la sociedad protectora de animales (humane society) o a las autoridades
+      más cercanas.
+    C: Poner al animal en su auto y llevarlo a un veterinario.
+    D: Abandonar la escena inmediatamente para evitar el tráfico.
+  answer: B
+  explanation: Si mata o hiere a un animal, llame a la sociedad protectora de animales
+    (humane society) o a las autoridades más cercanas. No intente mover a un animal
+    herido.
+- id: 197
+  category: driver_responsibility
+  question: 'Si alguien resulta herido o muere en una colisión, debe presentar un
+    informe a las autoridades dentro de:'
+  choices:
+    A: 24 horas.
+    B: 48 horas.
+    C: 5 días.
+    D: 10 días.
+  answer: A
+  explanation: Debe presentar un informe a las autoridades dentro de las 24 horas
+    posteriores a la colisión si alguien resulta herido o muere.
+- id: 198
+  category: driver_testing
+  question: Si recibe un Aviso de Reexaminación Prioritaria del Conductor (Notice
+    of Priority Reexamination of Driver), ¿cuántos días hábiles tiene para comunicarse
+    con el DMV antes de que su privilegio de conducir sea suspendido automáticamente?
+  choices:
+    A: 3 días hábiles.
+    B: 5 días hábiles.
+    C: 10 días hábiles.
+    D: 14 días hábiles.
+  answer: B
+  explanation: Tiene cinco días hábiles para comunicarse con el DMV para iniciar el
+    proceso o su privilegio de conducir será suspendido automáticamente.
+- id: 199
+  category: driver_testing
+  question: ¿Cuál de los siguientes NO puede utilizarse como base para una reexaminación
+    de conductor del DMV?
+  choices:
+    A: Una condición física.
+    B: Una condición mental.
+    C: Un mal historial de conductor.
+    D: La edad del conductor.
+  answer: D
+  explanation: Una condición física o mental o un mal historial de conductor pueden
+    ser la base para una reexaminación, no la edad del conductor.
+- id: 200
+  category: driver_responsibility
+  question: ¿Quién está obligado a presentar un Informe de Accidente de Tráfico Ocurrido
+    en California (SR 1) ante el DMV si una colisión cumple con los requisitos de
+    informe?
+  choices:
+    A: Solo el conductor que causó la colisión.
+    B: Solo el conductor que no tuvo la culpa.
+    C: Cada conductor involucrado, independientemente de quién causó la colisión.
+    D: Solo los oficiales de la ley.
+  answer: C
+  explanation: Cada conductor debe presentar un Informe de Accidente de Tráfico Ocurrido
+    en California (SR 1) ante el DMV. Debe presentar un informe independientemente
+    de si causó o no la colisión.
+- id: 201
+  category: safe_driving_rules
+  question: Si usted está involucrado en una colisión y nadie resulta herido, ¿qué
+    es lo primero que debe hacer?
+  choices:
+    A: Llamar al 911 inmediatamente mientras deja su vehículo en el carril.
+    B: Mover su vehículo fuera del tráfico y luego llamar al 911.
+    C: Presentar un formulario SR 1 ante el DMV.
+    D: Esperar a que lleguen las autoridades antes de mover su vehículo.
+  answer: B
+  explanation: Si está involucrado en una colisión, mueva su vehículo fuera del tráfico
+    si nadie está herido. Luego llame al 911.
+- id: 202
+  category: defensive_driving
+  question: Según el manual, ¿cuál de las siguientes es una causa común de colisiones?
+  choices:
+    A: Conducir un vehículo con transmisión manual.
+    B: Un vehículo que circula más rápido o más lento que el flujo del tráfico.
+    C: Usar dispositivos de manos libres.
+    D: Conducir durante las horas del día.
+  answer: B
+  explanation: Las causas más comunes de colisiones incluyen un vehículo que circula
+    más rápido o más lento que el flujo del tráfico.
+- id: 203
+  category: driver_responsibility
+  question: Si usted está involucrado en una colisión que resulta en daños por $1,000,
+    ¿cómo afectará esto su historial de manejo?
+  choices:
+    A: Solo se agregará a su historial si usted causó la colisión.
+    B: Se agregará a su historial de manejo independientemente de quién haya causado
+      la colisión.
+    C: No se agregará a su historial si ocurrió en una propiedad privada.
+    D: Solo se agregará si las autoridades presentan el informe por usted.
+  answer: B
+  explanation: Si está involucrado en una colisión que resulta en daños por $1,000...
+    el DMV lo agregará a su historial de manejo. No importa quién haya causado la
+    colisión.
+- id: 204
+  category: license_system
+  question: ¿Cuál de las siguientes afirmaciones es verdadera con respecto a las restricciones
+    de la licencia de conducir para conductores mayores?
+  choices:
+    A: Los conductores mayores de 70 años tienen restringido conducir en autopistas.
+    B: No hay restricciones específicas basadas en la edad, solo en las condiciones.
+    C: Los conductores mayores deben usar lentes correctivos después de los 65 años.
+    D: Los conductores mayores tienen restringido automáticamente conducir de noche.
+  answer: B
+  explanation: Según el manual, no hay restricciones específicas para personas mayores.
+    Todas las restricciones impuestas a una licencia de conducir se basan en las condiciones,
+    no en la edad.
+- id: 205
+  category: safe_driving_rules
+  question: ¿Cuál de las siguientes se considera una señal de advertencia de un conductor
+    inseguro?
+  choices:
+    A: Conducir durante horas de poco tráfico.
+    B: Perderse en lugares familiares.
+    C: Elegir una ruta bien iluminada por la noche.
+    D: Instalar un espejo adicional en el lado derecho.
+  answer: B
+  explanation: El manual enumera perderse en lugares familiares, abolladuras y raspaduras
+    en el automóvil o propiedad, y situaciones de riesgo frecuente o colisiones como
+    señales de advertencia de un conductor inseguro.
+- id: 206
+  category: license_system
+  question: 'Si usted tiene 70 años o más cuando su licencia de conducir expira, se
+    le requiere:'
+  choices:
+    A: Volver a tomar el examen de manejo al volante.
+    B: Renovar su licencia en persona y aprobar un examen de la vista.
+    C: Entregar su licencia a cambio de una tarjeta de identificación para personas
+      mayores.
+    D: Completar un Programa para Conductores Maduros de ocho horas.
+  answer: B
+  explanation: Si tiene 70 años o más al momento en que expira su licencia de conducir,
+    se le requiere renovar su licencia de conducir en persona y aprobar un examen
+    de la vista.
+- id: 207
+  category: license_system
+  question: ¿Aproximadamente cuántos días antes de que expire su licencia de conducir
+    envía el DMV un aviso de renovación a su dirección registrada?
+  choices:
+    A: 30 días
+    B: 60 días
+    C: 90 días
+    D: 120 días
+  answer: C
+  explanation: El DMV envía un aviso de renovación a su dirección registrada aproximadamente
+    90 días antes de que expire su licencia de conducir.
+- id: 208
+  category: driver_responsibility
+  question: ¿Cuál es una limitación del Enlace Comunitario (Community Liaison) del
+    DMV?
+  choices:
+    A: No pueden representarlo en una audiencia o reexamen del DMV.
+    B: No pueden proporcionarle herramientas e información útiles.
+    C: No pueden ayudar a adolescentes o conductores mayores.
+    D: No pueden asegurar que los conductores sean tratados de manera justa.
+  answer: A
+  explanation: Si bien el Enlace Comunitario puede ayudar como intermediario para
+    asegurar un trato justo, no pueden representarlo en una audiencia o reexamen del
+    DMV.
+- id: 209
+  category: safe_driving_rules
+  question: 'El Programa de Perfeccionamiento para Conductores Maduros es un curso
+    de ocho horas diseñado para conductores que tienen al menos:'
+  choices:
+    A: 50 años
+    B: 55 años
+    C: 62 años
+    D: 70 años
+  answer: B
+  explanation: El Programa de Perfeccionamiento para Conductores Maduros es un curso
+    de ocho horas para conductores de 55 años o más.
+- id: 210
+  category: license_system
+  question: ¿Por cuánto tiempo es válido el certificado de finalización del Programa
+    de Perfeccionamiento para Conductores Maduros?
+  choices:
+    A: Un año
+    B: Dos años
+    C: Tres años
+    D: Cinco años
+  answer: C
+  explanation: Su certificado por completar el Programa de Perfeccionamiento para
+    Conductores Maduros es válido por tres años y puede renovarse completando otro
+    curso de cuatro horas.
+- id: 211
+  category: license_system
+  question: ¿A qué edad es elegible para una tarjeta de identificación para personas
+    mayores sin costo?
+  choices:
+    A: 55 años
+    B: 60 años
+    C: 62 años
+    D: 65 años
+  answer: C
+  explanation: Si tiene 62 años o más, es elegible para una tarjeta de identificación
+    para personas mayores sin costo.
+- id: 212
+  category: license_system
+  question: 'Los conductores de cualquier edad que no puedan seguir conduciendo de
+    manera segura debido a una condición física o mental pueden ser elegibles para:'
+  choices:
+    A: Recibir una exención permanente de las tarifas de renovación.
+    B: Canjear su licencia de conducir por una tarjeta de identificación sin costo.
+    C: Conducir solo durante las horas del día sin restricciones.
+    D: Conservar su licencia si completan un curso de ocho horas.
+  answer: B
+  explanation: Los conductores de cualquier edad que no puedan seguir conduciendo
+    de manera segura debido a una condición física o mental pueden ser elegibles para
+    canjear su licencia de conducir por una tarjeta de identificación sin costo.
+- id: 213
+  category: alcohol_drugs_health
+  question: ¿Qué significa una concentración de alcohol en sangre (BAC) del 0.10%?
+  choices:
+    A: Tiene 0.10 gramos de alcohol en 100 mililitros de sangre.
+    B: Tiene 0.10 onzas de alcohol en 100 onzas de sangre.
+    C: Tiene 1.0 gramo de alcohol en 10 mililitros de sangre.
+    D: Tiene 10 gramos de alcohol en 100 mililitros de sangre.
+  answer: A
+  explanation: Según el glosario, un BAC del 0.10% significa que tiene 0.10 gramos
+    de alcohol en 100 mililitros de sangre.
+- id: 214
+  category: sharing_the_road
+  question: Según el glosario del DMV, ¿cuál de los siguientes se considera un peatón?
+  choices:
+    A: Una persona que conduce un scooter motorizado en la autopista.
+    B: Una persona con una discapacidad que utiliza una silla de ruedas para transportarse.
+    C: Una persona que monta una bicicleta en un carril para bicicletas designado.
+    D: Una persona que opera una barredora de calles.
+  answer: B
+  explanation: Un peatón es una persona que camina y también puede ser una persona
+    con una discapacidad que utiliza un triciclo, cuadriciclo o silla de ruedas para
+    transportarse.
+- id: 215
+  category: defensive_driving
+  question: 'La "regla de los tres segundos" es una regla de conducción que le ayuda
+    a estimar:'
+  choices:
+    A: Cuánto tiempo detenerse en una señal de alto.
+    B: Qué tan cerca debe seguir a otros vehículos.
+    C: Cuándo ceder el derecho de paso en una intersección.
+    D: Cuánto tiempo mirar por los espejos antes de cambiar de carril.
+  answer: B
+  explanation: La regla de los tres segundos es una regla de conducción que le ayuda
+    a estimar qué tan cerca debe seguir a otros vehículos.
+- id: 216
+  category: sharing_the_road
+  question: ¿A qué se refiere el término "usuarios vulnerables de la vía pública"
+    (VRU)?
+  choices:
+    A: Conductores de vehículos comerciales que transportan materiales peligrosos.
+    B: Usuarios de la vía no motorizados, como ciclistas y peatones.
+    C: Conductores que han recibido recientemente una citación de tráfico.
+    D: Conductores mayores de 70 años.
+  answer: B
+  explanation: Los VRU son usuarios de la vía no motorizados, como ciclistas, peatones
+    y personas con discapacidades o movilidad reducida que utilizan una silla de ruedas,
+    triciclo o cuadriciclo.
+- id: 217
+  category: signs_and_signals
+  question: ¿Qué significa "ceder el paso" (yield) en la carretera?
+  choices:
+    A: Acelerar para incorporarse suavemente al tráfico.
+    B: Esperar, reducir la velocidad y estar listo para detenerse para permitir que
+      otros con el derecho de paso avancen.
+    C: Detenerse por completo durante al menos tres segundos.
+    D: Reclamar el derecho de paso sobre peatones y ciclistas.
+  answer: B
+  explanation: Ceder el paso significa esperar, reducir la velocidad y estar listo
+    para detenerse (si es necesario) para permitir que otros vehículos o peatones
+    que tengan el derecho de paso avancen.
+- id: 218
+  category: driver_responsibility
+  question: Cuando una persona mayor sufre de demencia progresiva y pierde su capacidad
+    para conducir de manera segura, ¿quién es a menudo responsable de impedir que
+    conduzca y organizar un transporte alternativo?
+  choices:
+    A: El enlace comunitario del DMV.
+    B: Cuidadores, médicos y las fuerzas del orden.
+    C: Los instructores del Programa de Mejora para Conductores Adultos.
+    D: La compañía de seguros del conductor mayor.
+  answer: B
+  explanation: El manual establece que a menudo depende de los cuidadores, médicos
+    y las fuerzas del orden impedir que las personas mayores con demencia progresiva
+    conduzcan y organizar un transporte alternativo.
 - image: stop.png
   category: signs_and_signals
   question: ¿Qué significa esta señal?
   choices:
-    A: Reducir la velocidad y proceder con precaución
+    A: Reducir la velocidad y avanzar con precaución
     B: Detenerse por completo
     C: Ceder el paso al tráfico que viene en sentido contrario
     D: Detenerse solo si hay otros vehículos presentes
   answer: B
-  explanation: Una señal roja octagonal de PARE (STOP) significa que debe detenerse
-    por completo en la línea de parada, el cruce peatonal o antes de entrar en la
+  explanation: Una señal de ALTO (STOP) roja y octagonal significa que debe detenerse
+    por completo en la línea de parada, el paso de peatones o antes de entrar en la
     intersección. Verifique el tráfico y los peatones antes de continuar.
-  id: 67
+  id: 219
 - image: yield.png
   category: signs_and_signals
-  question: ¿Qué le exige hacer esta señal?
+  question: ¿Qué le obliga a hacer esta señal?
   choices:
     A: Detenerse por completo
-    B: Aumentar la velocidad para incorporarse al tráfico
-    C: Reducir la velocidad y ceder el paso al tráfico y a los peatones
+    B: Acelerar para incorporarse al tráfico
+    C: Reducir la velocidad y ceder el derecho de paso al tráfico y a los peatones
     D: Continuar sin detenerse
   answer: C
-  explanation: Una señal triangular roja y blanca de CEDA EL PASO (YIELD) significa
-    que debe reducir la velocidad y ceder el paso al tráfico y a los peatones. Debe
-    detenerse si es necesario para dejar que otros pasen de manera segura.
-  id: 68
+  explanation: Una señal de CEDA EL PASO (YIELD) triangular roja y blanca significa
+    que debe reducir la velocidad y ceder el derecho de paso al tráfico y a los peatones.
+    Debe detenerse si es necesario para dejar pasar a otros de forma segura.
+  id: 220
+- image: do_not_enter.png
+  category: signs_and_signals
+  question: ¿Qué significa esta señal?
+  choices:
+    A: Camino cerrado más adelante
+    B: No se permite estacionar
+    C: No entre en esta vía
+    D: Calle sin salida más adelante
+  answer: C
+  explanation: Una señal roja y blanca de NO ENTRAR (DO NOT ENTER) significa que no
+    debe entrar en la carretera o rampa donde está colocada esta señal. Generalmente
+    se ve en las rampas de salida de las autopistas o en calles de un solo sentido
+    donde entrar lo pondría en la trayectoria del tráfico en sentido contrario.
+  id: 221
 - image: wrong_way.png
   category: signs_and_signals
-  question: Si ve esta señal, ¿qué debería hacer?
+  question: Si ve esta señal, ¿qué debe hacer?
   choices:
-    A: Realizar un giro en U
+    A: Hacer un giro en U
     B: Continuar conduciendo con cuidado
     C: Detenerse y retroceder o dar la vuelta; va en sentido contrario
-    D: Aumentar la velocidad para salir del área rápidamente
+    D: Acelerar para salir del área rápidamente
   answer: C
   explanation: Una señal roja y blanca de SENTIDO CONTRARIO (WRONG WAY) significa
-    que está viajando en contra del tráfico en una calle de sentido único o en una
-    rampa de autopista. Deténgase inmediatamente y dé la vuelta o retroceda de manera
-    segura.
-  id: 69
+    que está viajando contra el tráfico en una calle de un solo sentido o en una rampa
+    de autopista. Deténgase de inmediato y dé la vuelta o retroceda de manera segura.
+  id: 222
+- image: one_way_left.png
+  category: signs_and_signals
+  question: ¿Qué indica esta señal?
+  choices:
+    A: Solo giro a la izquierda
+    B: 'El tráfico fluye en una sola dirección: hacia la izquierda'
+    C: Manténgase a la izquierda de la mediana
+    D: Salida de la autopista a la izquierda
+  answer: B
+  explanation: 'Una señal de un solo sentido (ONE WAY) en blanco y negro con una flecha
+    indica que el tráfico en esta calle se mueve en una sola dirección: la dirección
+    que señala la flecha.'
+  id: 223
+- image: no_u_turn.png
+  category: signs_and_signals
+  question: ¿Qué prohíbe esta señal?
+  choices:
+    A: Giros a la derecha
+    B: Giros a la izquierda
+    C: Giros en U
+    D: Rebasar a otros vehículos
+  answer: C
+  explanation: Una señal reglamentaria blanca con una flecha de giro en U tachada
+    significa que los giros en U están prohibidos en este lugar.
+  id: 224
 - image: no_left_turn.png
   category: signs_and_signals
-  question: ¿Qué acción está prohibida por esta señal?
+  question: ¿Qué acción prohíbe esta señal?
   choices:
     A: Girar a la derecha
     B: Girar a la izquierda
-    C: Realizar un giro en U
+    C: Hacer un giro en U
     D: Seguir recto
   answer: B
   explanation: Una señal reglamentaria blanca que muestra una flecha de giro a la
     izquierda tachada significa que no se permiten giros a la izquierda en esta intersección.
-  id: 70
+  id: 225
+- image: no_right_turn.png
+  category: signs_and_signals
+  question: ¿Qué significa esta señal?
+  choices:
+    A: No se permite el giro en U
+    B: No se permite el giro a la izquierda
+    C: No se permite el giro a la derecha
+    D: No se permite rebasar
+  answer: C
+  explanation: Una señal reglamentaria blanca que muestra una flecha de giro a la
+    derecha tachada significa que los giros a la derecha están prohibidos en este
+    lugar.
+  id: 226
+- image: no_passing.png
+  category: signs_and_signals
+  question: ¿Qué indica esta señal?
+  choices:
+    A: El camino se estrecha más adelante
+    B: No rebase a otros vehículos en esta zona
+    C: Tráfico de doble sentido más adelante
+    D: Manténgase a la derecha
+  answer: B
+  explanation: Una señal en forma de banderín en blanco y negro de ZONA DE NO REBASAR
+    (NO PASSING ZONE) significa que no se le permite rebasar a otros vehículos en
+    esta área. Marca el inicio de una zona donde está prohibido adelantar.
+  id: 227
+- image: keep_right.png
+  category: signs_and_signals
+  question: ¿Qué instruye esta señal a los conductores?
+  choices:
+    A: Incorporarse a la derecha
+    B: Solo giro a la derecha
+    C: Manténgase a la derecha de un divisor u obstrucción
+    D: El carril derecho termina más adelante
+  answer: C
+  explanation: Una señal reglamentaria blanca de MANTÉNGASE A LA DERECHA (KEEP RIGHT)
+    con una flecha significa que debe mantenerse en el lado derecho de una isla de
+    tráfico, mediana u obstrucción.
+  id: 228
 - image: speed_limit_25.png
   category: signs_and_signals
   question: ¿Qué tipo de señal es esta, según su forma y color?
@@ -913,9 +2924,9 @@ questions:
     D: Una señal de construcción
   answer: C
   explanation: Las señales rectangulares blancas con letras negras son señales reglamentarias.
-    Las señales de límite de velocidad indican la velocidad máxima legal para el área
-    en condiciones ideales.
-  id: 71
+    Las señales de límite de velocidad le indican la velocidad máxima legal para el
+    área en condiciones ideales.
+  id: 229
 - image: deer_crossing.png
   category: signs_and_signals
   question: ¿De qué le advierte esta señal amarilla en forma de diamante?
@@ -927,8 +2938,21 @@ questions:
   answer: B
   explanation: Una señal amarilla en forma de diamante con la silueta de un ciervo
     advierte que estos animales cruzan la carretera con frecuencia en esta zona. Reduzca
-    la velocidad y esté atento a los animales, especialmente al amanecer y al anochecer.
-  id: 72
+    la velocidad y esté atento a los animales, especialmente al amanecer y al atardecer.
+  id: 230
+- image: pedestrian_crossing.png
+  category: signs_and_signals
+  question: ¿De qué le advierte esta señal?
+  choices:
+    A: Zona escolar más adelante
+    B: Cruce de peatones más adelante
+    C: Sendero de excursión cercano
+    D: Parada de autobús más adelante
+  answer: B
+  explanation: Una señal amarilla en forma de rombo con una figura de peatón advierte
+    de un cruce de peatones más adelante. Esté preparado para detenerse ante los peatones
+    que crucen la calle.
+  id: 231
 - image: school_zone.png
   category: signs_and_signals
   question: ¿Qué indica la forma de esta señal?
@@ -938,10 +2962,23 @@ questions:
     C: Una zona escolar o cruce escolar
     D: Una zona de hospital
   answer: C
-  explanation: Una señal pentagonal (de 5 lados) de color amarillo verdoso fluorescente
+  explanation: Una señal en forma de pentágono (5 lados) de color amarillo-verde fluorescente
     indica una zona escolar o un cruce escolar. Reduzca la velocidad y esté atento
     a los niños.
-  id: 73
+  id: 232
+- image: railroad_crossing.png
+  category: signs_and_signals
+  question: ¿De qué le advierte esta señal circular amarilla?
+  choices:
+    A: Una rotonda más adelante
+    B: Una zona de hospital
+    C: Un cruce de ferrocarril más adelante
+    D: Una zona de no rebasar
+  answer: C
+  explanation: Una señal circular amarilla con una X negra y dos letras R es la señal
+    de advertencia anticipada de un cruce de ferrocarril más adelante. Reduzca la
+    velocidad, mire y escuche si vienen trenes.
+  id: 233
 - image: railroad_crossbuck.png
   category: signs_and_signals
   question: ¿Dónde vería normalmente esta señal?
@@ -951,9 +2988,23 @@ questions:
     C: En la entrada de un hospital
     D: En un puente peatonal
   answer: B
-  explanation: La señal blanca en forma de X (aspa) se coloca en los cruces de ferrocarril.
-    Significa que debe ceder el paso a los trenes. Si se acerca un tren, debe detenerse.
-  id: 74
+  explanation: La señal blanca en forma de X (aspa) de ferrocarril se coloca en los
+    cruces ferroviarios. Significa que debe ceder el paso a los trenes. Si se aproxima
+    un tren, debe detenerse.
+  id: 234
+- image: curve_right.png
+  category: signs_and_signals
+  question: ¿Qué indica esta señal amarilla en forma de rombo?
+  choices:
+    A: La carretera termina más adelante
+    B: Giro a la derecha obligatorio
+    C: Una curva a la derecha más adelante
+    D: Desvío más adelante
+  answer: C
+  explanation: Una señal amarilla en forma de rombo con una flecha curva advierte
+    de una curva en el camino más adelante. Reduzca la velocidad antes de entrar en
+    la curva.
+  id: 235
 - image: sharp_turn_right.png
   category: signs_and_signals
   question: ¿En qué se diferencia esta señal de una señal de curva?
@@ -966,12 +3017,65 @@ questions:
   explanation: Una señal de giro brusco (con una flecha más angulada) indica un giro
     más cerrado que una señal de curva. Debe reducir su velocidad de manera más significativa
     antes de este giro.
-  id: 75
+  id: 236
+- image: reverse_curve.png
+  category: signs_and_signals
+  question: ¿Sobre qué condición de la carretera advierte esta señal?
+  choices:
+    A: Un camino sinuoso
+    B: Una sola curva más adelante
+    C: Una serie de dos curvas en direcciones opuestas
+    D: Una rotonda más adelante
+  answer: C
+  explanation: Una señal de curva inversa advierte de dos curvas en direcciones opuestas
+    más adelante. Reduzca la velocidad y esté preparado para que el camino gire primero
+    en un sentido y luego en el otro.
+  id: 237
+- image: winding_road.png
+  category: signs_and_signals
+  question: ¿Qué le advierte esta señal que debe esperar?
+  choices:
+    A: Una sola curva pronunciada
+    B: Una superficie de carretera resbaladiza
+    C: Una serie de curvas o giros más adelante
+    D: Una colina más adelante
+  answer: C
+  explanation: Una señal de camino sinuoso advierte de una serie de curvas o giros
+    más adelante. Reduzca su velocidad y esté alerta a los cambios en las condiciones
+    de la carretera.
+  id: 238
+- image: merge.png
+  category: signs_and_signals
+  question: ¿Para qué le indica esta señal que debe prepararse?
+  choices:
+    A: El fin de un carril
+    B: Tráfico que se incorpora desde otra carretera
+    C: Inicio de una autopista dividida
+    D: Una carretera que se estrecha a un solo carril
+  answer: B
+  explanation: Una señal amarilla de incorporación en forma de rombo advierte que
+    el tráfico de otra carretera se incorporará a su carril. Esté preparado para ajustar
+    su velocidad y posición.
+  id: 239
+- image: road_narrows.png
+  category: signs_and_signals
+  question: ¿De qué advierte esta señal?
+  choices:
+    A: Puente más adelante
+    B: La carretera se estrecha más adelante
+    C: El carril termina
+    D: Termina la autopista dividida
+  answer: B
+  explanation: Esta señal de advertencia indica que la carretera más adelante se vuelve
+    más estrecha. Esté preparado para una reducción del ancho de la vía y ajuste su
+    posición en el carril.
+  id: 240
 - image: divided_highway.png
   category: signs_and_signals
-  question: ¿Qué indica esta señal que hay más adelante?
+  id: 241
+  question: ¿Qué indica que hay más adelante esta señal?
   choices:
-    A: Fin de la carretera
+    A: La carretera termina
     B: Tráfico de doble sentido
     C: Comienza una carretera dividida
     D: Salida de la autopista
@@ -979,10 +3083,138 @@ questions:
   explanation: Esta señal advierte que la carretera más adelante se convierte en una
     carretera dividida con una mediana o barrera que separa el tráfico opuesto. Manténgase
     a la derecha.
-  id: 76
+- image: divided_highway_ends.png
+  category: signs_and_signals
+  id: 242
+  question: ¿De qué le advierte esta señal?
+  choices:
+    A: Comienza una carretera dividida
+    B: La carretera dividida termina y se reanuda el tráfico de doble sentido
+    C: Un área de incorporación más adelante
+    D: Construcción de carreteras más adelante
+  answer: B
+  explanation: Esta señal advierte que la carretera dividida está terminando. El tráfico
+    opuesto ya no estará separado por una mediana. Esté preparado para el tráfico
+    de doble sentido.
+- image: two_way_traffic.png
+  category: signs_and_signals
+  id: 243
+  question: ¿De qué le advierte esta señal?
+  choices:
+    A: Comienza una carretera dividida
+    B: Una zona de adelantamiento más adelante
+    C: 'Tráfico de doble sentido más adelante: el tráfico se mueve en ambas direcciones'
+    D: Un cambio de carril más adelante
+  answer: C
+  explanation: Esta señal advierte de tráfico de doble sentido más adelante. Es posible
+    que esté saliendo de una carretera de un solo sentido o de una carretera dividida
+    y se encuentre con vehículos que viajan en la dirección opuesta.
+- image: slippery_when_wet.png
+  category: signs_and_signals
+  id: 244
+  question: ¿Sobre qué condición de la carretera advierte esta señal?
+  choices:
+    A: Condiciones de carretera con hielo
+    B: La carretera puede estar resbaladiza cuando está mojada
+    C: Carretera sinuosa más adelante
+    D: Pavimento irregular
+  answer: B
+  explanation: Una señal de "resbaladizo cuando está mojado" advierte que la superficie
+    de la carretera puede volverse muy resbaladiza durante la lluvia o condiciones
+    de humedad. Reduzca su velocidad y evite frenar o girar bruscamente.
+- image: hill.png
+  category: signs_and_signals
+  id: 245
+  question: ¿De qué le advierte esta señal?
+  choices:
+    A: Un bache en la carretera
+    B: Una superficie de carretera irregular
+    C: Una colina o pendiente pronunciada más adelante
+    D: Construcción de carreteras
+  answer: C
+  explanation: Esta señal advierte de una colina o pendiente pronunciada más adelante.
+    Es posible que deba ajustar su velocidad y cambiar a una marcha más baja, especialmente
+    en camiones o al remolcar.
+- image: signal_ahead.png
+  category: signs_and_signals
+  id: 246
+  question: ¿Para qué le advierte esta señal que se prepare?
+  choices:
+    A: Una señal de alto (STOP) más adelante
+    B: Un semáforo más adelante
+    C: Un cruce escolar
+    D: Un control policial
+  answer: B
+  explanation: Esta señal advierte de un semáforo más adelante. Esté preparado para
+    detenerse si la luz está en rojo o amarillo. Esta señal a menudo se coloca donde
+    el semáforo puede no ser visible desde la distancia.
+- image: stop_ahead.png
+  category: signs_and_signals
+  id: 247
+  question: ¿Qué le indica esta señal que espere más adelante?
+  choices:
+    A: Una señal de ceda el paso
+    B: Un semáforo
+    C: Una señal de alto (STOP) donde debe detenerse
+    D: Un reductor de velocidad (resalto)
+  answer: C
+  explanation: Esta señal advierte que hay una señal de alto (STOP) más adelante.
+    Comience a reducir la velocidad y prepárese para detenerse por completo en la
+    señal de alto.
+- image: cross_road.png
+  category: signs_and_signals
+  id: 248
+  question: ¿Sobre qué advierte esta señal?
+  choices:
+    A: Un cruce de ferrocarril más adelante
+    B: Un cruce de caminos o intersección más adelante
+    C: Un hospital más adelante
+    D: Un cruce de peatones
+  answer: B
+  explanation: Esta señal advierte que hay un cruce de caminos o una intersección
+    de 4 vías más adelante. Esté atento al tráfico que entra desde las carreteras
+    laterales.
+- image: side_road.png
+  category: signs_and_signals
+  id: 249
+  question: ¿De qué le advierte esta señal?
+  choices:
+    A: Una intersección en T más adelante
+    B: Una carretera lateral que entra por la derecha
+    C: Una curva en la carretera
+    D: Un callejón sin salida
+  answer: B
+  explanation: Esta señal advierte de una carretera lateral que entra por la derecha.
+    Esté atento a los vehículos que entran a la carretera desde la vía lateral.
+- image: added_lane.png
+  category: signs_and_signals
+  id: 250
+  question: ¿Qué significa esta señal?
+  choices:
+    A: Los carriles se están fusionando
+    B: Un carril está terminando
+    C: Se está añadiendo un nuevo carril; no es necesario incorporarse
+    D: Se requiere giro a la derecha
+  answer: C
+  explanation: Una señal de carril añadido significa que un nuevo carril se une a
+    la carretera sin necesidad de incorporarse. El tráfico que entra desde la rampa
+    tiene su propio carril nuevo.
+- image: no_parking.png
+  category: signs_and_signals
+  question: ¿Qué prohíbe esta señal?
+  choices:
+    A: Detenerse en cualquier momento
+    B: Estacionarse en esta área
+    C: Detenerse brevemente o permanecer con el motor encendido
+    D: Cargar o descargar
+  answer: B
+  explanation: Una señal roja y blanca de NO ESTACIONAR (NO PARKING) significa que
+    no puede estacionar su vehículo en esta área. Puede detenerse brevemente para
+    subir o bajar pasajeros.
+  id: 251
 - image: handicap_parking.png
   category: signs_and_signals
-  question: ¿Quién tiene permitido estacionar en un espacio marcado con esta señal?
+  question: ¿Quién tiene permitido estacionarse en un espacio marcado con esta señal?
   choices:
     A: Cualquier persona por menos de 15 minutos
     B: Solo personas de la tercera edad
@@ -991,2619 +3223,7 @@ questions:
   answer: C
   explanation: Una señal azul con el símbolo de la silla de ruedas marca el estacionamiento
     reservado para personas con discapacidades. Solo los vehículos que exhiban un
-    cartel o placa de matrícula de estacionamiento para discapacitados válida pueden
-    estacionar en estos espacios. Las infracciones conllevan multas elevadas.
-  id: 77
-- id: 78
-  category: safe_driving_rules
-  question: Al estacionar junto a un bordillo (acera), ¿a qué distancia del bordillo
-    deben estar las ruedas?
-  choices:
-    A: A no más de 6 pulgadas
-    B: A no más de 12 pulgadas
-    C: A no más de 18 pulgadas
-    D: A no más de 24 pulgadas
-  answer: C
-  explanation: Cuando estacione junto a un bordillo en una calle nivelada, las ruedas
-    delanteras y traseras deben estar paralelas y a menos de 18 pulgadas del bordillo.
-- id: 79
-  category: sharing_the_road
-  question: Usted conduce por una carretera con un carril marcado para vehículos de
-    alta ocupación (HOV). ¿Cuál es el propósito principal de este carril?
-  choices:
-    A: Permitir que los conductores rebasen el tráfico más lento
-    B: Proporcionar un carril exclusivo para vehículos de emergencia
-    C: Fomentar el uso compartido de vehículos y reducir la congestión del tráfico
-    D: Servir como carril adicional durante la hora pico para todos los vehículos
-  answer: C
-  explanation: El propósito de los carriles HOV es promover el uso compartido de vehículos
-    (carpooling) para trasladar a más personas con menos vehículos, reduciendo así
-    la congestión del tráfico.
-- id: 80
-  category: safe_driving_rules
-  question: ¿A cuántos pies de un hidrante de incendios es ilegal estacionar su vehículo?
-  choices:
-    A: 10 pies
-    B: 15 pies
-    C: 20 pies
-    D: 25 pies
-  answer: B
-  explanation: Nunca estacione a menos de 15 pies de un hidrante de incendios. Esto
-    garantiza que los vehículos de emergencia tengan un acceso adecuado.
-- id: 81
-  category: safe_driving_rules
-  question: ¿Cuál es el procedimiento adecuado para usar un carril central para girar
-    a la izquierda?
-  choices:
-    A: Entrar en el carril lo antes posible para esperar un espacio en el tráfico
-    B: Usar el carril para rebasar vehículos más lentos antes de realizar su giro
-    C: Conducir en el carril por no más de 200 pies antes de realizar su giro
-    D: Entrar en el carril solo después de detenerse por completo en el carril de
-      circulación normal
-  answer: C
-  explanation: El carril central para girar a la izquierda no debe usarse para circular.
-    Solo puede conducir durante 200 pies en el carril central para girar a la izquierda
-    antes de realizar su giro.
-- id: 82
-  category: license_system
-  question: Un conductor con una licencia provisional (menor de 18 años) ¿qué restricción
-    tiene con respecto a los pasajeros durante los primeros 12 meses?
-  choices:
-    A: No puede transportar a ningún pasajero
-    B: No puede transportar pasajeros menores de 20 años, a menos que un padre o tutor
-      con licencia también esté en el vehículo
-    C: Solo puede transportar a miembros de su familia inmediata
-    D: Puede transportar a cualquier persona siempre que sea durante las horas del
-      día
-  answer: B
-  explanation: Durante los primeros 12 meses, un conductor provisional no puede transportar
-    pasajeros menores de 20 años, a menos que esté acompañado por un padre, tutor
-    u otro adulto especificado que tenga licencia.
-- id: 83
-  category: safe_driving_rules
-  question: ¿Qué indica un bordillo pintado de azul?
-  choices:
-    A: Zona de carga solo para vehículos comerciales
-    B: Estacionamiento por tiempo limitado, según lo indique una señal
-    C: Estacionamiento para personas con un cartel de discapacidad o placas de matrícula
-      especiales
-    D: Prohibido detenerse, pararse o estacionarse
-  answer: C
-  explanation: Los bordillos azules indican que el estacionamiento está permitido
-    solo para una persona con discapacidad que exhiba un cartel (placard) o placas
-    de matrícula especiales para personas con discapacidad.
-- id: 84
-  category: right_of_way
-  question: En una intersección en "T" sin señales ni semáforos, ¿qué vehículo tiene
-    el derecho de paso?
-  choices:
-    A: El vehículo en la carretera que termina debe ceder el paso a los vehículos
-      en la carretera principal
-    B: El vehículo en la carretera principal debe ceder el paso a los vehículos en
-      la carretera que termina
-    C: El vehículo que llegó primero tiene el derecho de paso
-    D: El vehículo que gira a la izquierda tiene el derecho de paso
-  answer: A
-  explanation: En una intersección en "T" donde una carretera termina, el tráfico
-    en la carretera que termina debe ceder el derecho de paso a todo el tráfico en
-    la carretera principal o transversal.
-- id: 85
-  category: safe_driving_rules
-  question: 'Al conducir con niebla densa, debe usar sus:'
-  choices:
-    A: Luces altas (high-beam)
-    B: Luces bajas (low-beam)
-    C: Solo las luces de estacionamiento
-    D: Luces de emergencia
-  answer: B
-  explanation: En caso de niebla densa, use las luces bajas. Las luces altas se reflejarán
-    en la niebla y causarán un resplandor, lo que dificultará la visión.
-- id: 86
-  category: penalties_and_points
-  question: ¿Por cuánto tiempo permanecen generalmente la mayoría de los puntos por
-    infracciones de tráfico en su registro de conducir?
-  choices:
-    A: 12 meses
-    B: 24 meses
-    C: 39 meses
-    D: 60 meses
-  answer: C
-  explanation: Una condena de tráfico por una infracción menor generalmente permanecerá
-    en su registro durante 39 meses (3 años y 3 meses).
-- id: 87
-  category: right_of_way
-  question: Cuando dos vehículos se encuentran en una carretera de montaña empinada
-    y estrecha donde ninguno puede pasar, ¿quién tiene el derecho de paso?
-  choices:
-    A: El vehículo que sube
-    B: El vehículo que baja
-    C: El vehículo que sea más grande
-    D: El vehículo que llegó primero al lugar estrecho
-  answer: A
-  explanation: El vehículo que circula cuesta abajo debe ceder el derecho de paso
-    retrocediendo hasta que el vehículo que sube pueda pasar. El vehículo que va cuesta
-    abajo tiene mayor control al retroceder.
-- id: 88
-  category: defensive_driving
-  question: 'Para mantener un margen de seguridad adecuado y ver más lejos en el camino,
-    debe escanear su entorno mirando hacia adelante:'
-  choices:
-    A: 1-2 segundos
-    B: 3-5 segundos
-    C: 5-8 segundos
-    D: 10-15 segundos
-  answer: D
-  explanation: Para evitar maniobras de último momento, debe escanear la carretera
-    entre 10 y 15 segundos por delante de su vehículo para poder ver los peligros
-    antes de llegar a ellos.
-- id: 89
-  category: sharing_the_road
-  question: Cuando vea una "zona de seguridad" marcada con botones o marcadores elevados
-    en la calzada, ¿qué debe hacer?
-  choices:
-    A: Puede conducir a través de ella si no hay peatones presentes
-    B: No debe conducir a través de la zona de seguridad en ningún momento
-    C: Puede usarla para hacer un giro a la izquierda
-    D: Puede conducir a través de ella a una velocidad no superior a 10 mph
-  answer: B
-  explanation: Una zona de seguridad es un área reservada para peatones. Es ilegal
-    conducir a través de una zona de seguridad en cualquier momento o por cualquier
-    motivo.
-- id: 90
-  category: license_system
-  question: A un menor (menor de 18 años) con una licencia provisional no se le permite
-    conducir entre qué horas, con algunas excepciones?
-  choices:
-    A: 10 p.m. y 6 a.m.
-    B: 11 p.m. y 5 a.m.
-    C: Medianoche y 6 a.m.
-    D: 9 p.m. y 5 a.m.
-  answer: B
-  explanation: Durante los primeros 12 meses de tener una licencia provisional, un
-    menor no puede conducir entre las 11 p.m. y las 5 a.m., a menos que esté acompañado
-    por un adulto especificado o por excepciones válidas.
-- id: 91
-  category: safe_driving_rules
-  question: ¿Qué significa un bordillo pintado de verde?
-  choices:
-    A: No detenerse ni estacionarse
-    B: Estacionamiento por tiempo limitado
-    C: Carga y descarga de pasajeros o mercancía
-    D: Estacionamiento solo para personas con discapacidad
-  answer: B
-  explanation: Un bordillo verde indica que se permite estacionar por un tiempo limitado.
-    El límite de tiempo puede estar publicado en una señal o pintado en el bordillo.
-- id: 92
-  category: defensive_driving
-  question: 'Si su vehículo comienza a deslizarse sobre el agua (hidroplaneo) en una
-    carretera mojada, usted debe:'
-  choices:
-    A: Frenar firmemente para recuperar la tracción
-    B: Acelerar para pasar por el agua rápidamente
-    C: Reducir la velocidad gradualmente levantando el pie del pedal del acelerador
-    D: Girar el volante bruscamente en la dirección opuesta al derrape
-  answer: C
-  explanation: Si su vehículo comienza a deslizarse sobre el agua (hidroplaneo), no
-    frene ni gire repentinamente. Levante el pie del acelerador hasta que el vehículo
-    disminuya la velocidad y pueda sentir la carretera de nuevo.
-- id: 93
-  category: vehicle_information
-  question: 'Es legal usar la bocina de su vehículo para:'
-  choices:
-    A: Instar a un conductor lento a que acelere
-    B: Alertar a otros conductores de que cometieron un error
-    C: Ayudar a evitar una colisión
-    D: Saludar a un amigo que ve en la acera
-  answer: C
-  explanation: La bocina solo debe usarse para garantizar una conducción segura, como
-    para evitar colisiones, alertar a otro conductor de un peligro o alertar al tráfico
-    que viene en sentido contrario en carreteras de montaña estrechas.
-- id: 94
-  category: right_of_way
-  question: 'Si llega a una intersección donde los semáforos no funcionan, debe:'
-  choices:
-    A: Reducir la velocidad y avanzar con precaución
-    B: Detenerse y luego avanzar cuando sea seguro
-    C: Tratar la intersección como una intersección no controlada y ceder el paso
-      a la derecha
-    D: Tratar la intersección como una parada de cuatro vías (four-way stop)
-  answer: D
-  explanation: Si los semáforos no funcionan, debe tratar la intersección como si
-    fuera una parada de cuatro vías (four-way stop). Deténgase, ceda el paso a los
-    vehículos y peatones que ya estén en la intersección y luego avance cuando sea
-    su turno.
-- id: 95
-  category: penalties_and_points
-  question: ¿Cuál es la sanción por abandonar a un animal en una autopista?
-  choices:
-    A: Una advertencia de un oficial de paz
-    B: Una multa pequeña de hasta $100
-    C: Una multa de hasta $1,000 y/o seis meses de cárcel
-    D: Solo servicio comunitario
-  answer: C
-  explanation: Abandonar a un animal en una autopista es un delito menor castigado
-    con una multa de hasta $1,000, hasta seis meses de cárcel, o ambos.
-- id: 96
-  category: safe_driving_rules
-  question: 'Al girar a la izquierda desde una calle de doble sentido hacia una calle
-    de un solo sentido, debe comenzar su giro desde:'
-  choices:
-    A: El carril del extremo derecho
-    B: Cualquier carril, siempre que ponga la señal
-    C: El carril más cercano a la línea central
-    D: El carril de giro a la derecha
-  answer: C
-  explanation: Comience el giro desde el carril más cercano al centro de la calle
-    (la línea central). Gire hacia cualquier carril de la calle de un solo sentido
-    que esté abierto de forma segura.
-- id: 97
-  category: sharing_the_road
-  question: 'Al compartir la carretera con un vehículo de tren ligero o un tranvía,
-    debe tener en cuenta que:'
-  choices:
-    A: Pueden detenerse más rápido que un vehículo estándar
-    B: Siempre tienen el derecho de paso
-    C: Puede rebasarlos por el lado izquierdo o derecho
-    D: Pueden interrumpir los semáforos
-  answer: D
-  explanation: Tenga en cuenta que los vehículos de tren ligero pueden interrumpir
-    los semáforos para asegurarse de que puedan pasar por las intersecciones sin detenerse.
-- id: 98
-  category: defensive_driving
-  question: Si el acelerador se queda atascado y su vehículo sigue acelerando, ¿qué
-    es una de las primeras cosas que debe hacer?
-  choices:
-    A: Apagar el motor inmediatamente
-    B: Cambiar a punto muerto (neutral) y aplicar los frenos
-    C: Bombear el pedal del acelerador varias veces
-    D: Intentar desatascar el pedal con la mano
-  answer: B
-  explanation: Si el acelerador se atasca, debe poner el vehículo en punto muerto
-    (neutral) y aplicar los frenos. Esto desconectará el motor de las ruedas, permitiéndole
-    reducir la velocidad y detenerse de forma segura.
-- id: 99
-  category: safe_driving_rules
-  question: ¿Qué significa 'estacionarse en doble fila' y es legal?
-  choices:
-    A: Estacionar en un espacio para dos autos; es legal
-    B: Estacionar en el lado equivocado de la calle; es ilegal
-    C: Estacionar en la calle junto a un automóvil que ya está estacionado junto al
-      bordillo; es ilegal
-    D: Estacionar por el doble del límite de tiempo publicado; es ilegal
-  answer: C
-  explanation: Estacionarse en doble fila es cuando se estaciona en la calle al lado
-    de otro vehículo que está detenido o estacionado junto al bordillo. Es ilegal
-    y bloquea el flujo normal del tráfico.
-- id: 100
-  category: vehicle_information
-  question: ¿Cuál es la profundidad mínima legal de la banda de rodadura de los neumáticos
-    en un vehículo de pasajeros en California?
-  choices:
-    A: 1/32 de pulgada
-    B: 1/16 de pulgada
-    C: 3/32 de pulgada
-    D: 4/32 de pulgada
-  answer: A
-  explanation: La ley exige que sus neumáticos tengan una profundidad mínima de banda
-    de rodadura de 1/32 de pulgada en cualquier par de ranuras adyacentes. Una profundidad
-    de banda de rodadura insuficiente es insegura.
-- id: 101
-  category: alcohol_drugs_health
-  question: 'Si es condenado por un primer DUI (conducir bajo la influencia), un tribunal
-    puede sentenciarlo a cumplir hasta:'
-  choices:
-    A: 48 horas de cárcel
-    B: 30 días de cárcel
-    C: 6 meses de cárcel
-    D: 1 año de cárcel
-  answer: C
-  explanation: Las sanciones por una primera condena por DUI pueden incluir hasta
-    6 meses de cárcel, junto con multas, cargos y una suspensión obligatoria de la
-    licencia de conducir.
-- id: 102
-  category: signs_and_signals
-  question: ¿Qué indica una señal amarilla redonda con una 'X' negra y las letras
-    'RR'?
-  choices:
-    A: Un cruce de caminos más adelante
-    B: Una zona de hospital más adelante
-    C: Se está acercando a un cruce de ferrocarril
-    D: Un cierre de carretera más adelante
-  answer: C
-  explanation: Una señal amarilla redonda con una 'X' negra y 'RR' es una señal de
-    advertencia anticipada de que se está acercando a un cruce de ferrocarril. Debe
-    reducir la velocidad, mirar y escuchar si viene un tren.
-- id: 103
-  category: sharing_the_road
-  question: ¿Cuál es una regla de seguridad clave al compartir la carretera con vehículos
-    de tren ligero?
-  choices:
-    A: Puede girar frente a un vehículo de tren ligero que se aproxima si tiene la
-      luz verde.
-    B: Nunca gire frente a un vehículo de tren ligero que se aproxima.
-    C: Es seguro conducir sobre las vías del tren ligero si no hay ningún tren a la
-      vista.
-    D: Los vehículos de tren ligero deben ceder el paso a los automóviles en las intersecciones.
-  answer: B
-  explanation: El manual enfatiza que nunca debe girar frente a un vehículo de tren
-    ligero que se aproxima, ya que se mueven más rápido que los trenes de carga y
-    no pueden detenerse rápidamente.
-- id: 104
-  category: license_system
-  question: 'Durante los primeros 12 meses de tener una licencia de conducir provisional,
-    un menor no puede conducir entre las 11 p.m. y las 5 a.m. ni transportar pasajeros
-    menores de 20 años a menos que:'
-  choices:
-    A: Esté conduciendo a un evento patrocinado por la escuela.
-    B: Tenga una nota firmada por un padre o tutor.
-    C: Esté acompañado por un padre, tutor u otro adulto especificado de California
-      de 25 años de edad o más que tenga licencia.
-    D: Haya completado 10 horas adicionales de práctica de manejo.
-  answer: C
-  explanation: Un menor con una licencia provisional tiene restricciones estrictas
-    de horario y pasajeros durante el primer año, las cuales se omiten si está acompañado
-    por un padre, tutor u otro adulto especificado de 25 años de edad o más que tenga
-    licencia.
-- id: 105
-  category: signs_and_signals
-  question: 'Un bordillo (curb) pintado de azul indica un espacio de estacionamiento
-    reservado para:'
-  choices:
-    A: Carga y descarga de pasajeros o correo únicamente.
-    B: Estacionamiento de corta duración, con el límite de tiempo indicado en una
-      señal.
-    C: Carga y descarga de mercancías únicamente.
-    D: Personas con un cartel (placard) de persona con discapacidad o placas de matrícula
-      especiales.
-  answer: D
-  explanation: Un bordillo azul indica que el estacionamiento está reservado para
-    personas con discapacidades que tengan un cartel (placard) válido o placas de
-    matrícula especiales.
-- id: 106
-  category: alcohol_drugs_health
-  question: Si está tomando medicamentos recetados o de venta libre, ¿cuál es su responsabilidad
-    antes de conducir?
-  choices:
-    A: Asumir que es seguro conducir a menos que la etiqueta diga explícitamente 'No
-      operar maquinaria pesada'.
-    B: Leer las etiquetas de advertencia y estar al tanto de cualquier posible efecto
-      secundario que pueda afectar su conducción.
-    C: Tomar solo la mitad de la dosis recetada si planea conducir.
-    D: Siempre es legal conducir después de tomar cualquier medicamento recetado.
-  answer: B
-  explanation: Es su responsabilidad conocer los efectos de cualquier medicamento
-    que tome. Muchos medicamentos recetados y de venta libre pueden causar somnolencia
-    o mareos, lo que hace que sea inseguro conducir.
-- id: 107
-  category: sharing_the_road
-  question: ¿Cuándo se le permite legalmente conducir en un carril para bicicletas?
-  choices:
-    A: Cuando se encuentre a menos de 200 pies de un giro que deba realizar.
-    B: Cuando los carriles de tráfico principales estén bloqueados o congestionados.
-    C: Para rebasar a un vehículo más lento que esté delante de usted.
-    D: Nunca, es solo para bicicletas.
-  answer: A
-  explanation: Puede entrar en un carril para bicicletas para estacionar (donde esté
-    permitido), para entrar o salir de la carretera, o para prepararse para un giro
-    dentro de los 200 pies antes de la intersección.
-- id: 108
-  category: penalties_and_points
-  question: Bajo el Sistema de Tratamiento de Operadores Negligentes (NOTS), ¿se le
-    puede considerar un operador negligente si obtiene cuántos puntos en su historial
-    de manejo en 12 meses?
-  choices:
-    A: 2 puntos
-    B: 4 puntos
-    C: 6 puntos
-    D: 8 puntos
-  answer: B
-  explanation: El DMV puede considerarlo un operador negligente si acumula 4 puntos
-    en 12 meses, 6 puntos en 24 meses u 8 puntos en 36 meses, lo que puede llevar
-    a la libertad condicional o suspensión de la licencia.
-- id: 109
-  category: safe_driving_rules
-  question: ¿En cuál de las siguientes situaciones debería usar su bocina (claxon)?
-  choices:
-    A: Para expresar enojo o frustración hacia otro conductor.
-    B: Para hacer que un conductor lento acelere.
-    C: Para ayudar a evitar una colisión alertando a otro conductor de su presencia.
-    D: Para saludar a un amigo que ve en la acera.
-  answer: C
-  explanation: Su bocina solo debe usarse como una advertencia de seguridad para ayudar
-    a evitar colisiones. Por ejemplo, use su bocina para alertar a otro conductor
-    que esté en peligro de golpearlo, o en carreteras de montaña estrechas donde no
-    pueda ver al menos a 200 pies de distancia.
-- id: 110
-  category: sharing_the_road
-  question: Con respecto a los motociclistas que realizan el 'lane splitting' (circular
-    entre carriles de tráfico), ¿qué afirmación es verdadera en California?
-  choices:
-    A: Siempre es ilegal y altamente peligroso.
-    B: Es legal, pero los motociclistas deben hacerlo de manera segura y prudente.
-    C: Solo es legal en autopistas con más de cuatro carriles.
-    D: Solo es legal cuando el tráfico se mueve a más de 30 mph.
-  answer: B
-  explanation: La ley de California permite que las motocicletas circulen entre carriles
-    o filtren el tráfico, siempre que se haga de manera segura y prudente. Los conductores
-    de otros vehículos deben estar atentos a esto y revisar sus puntos ciegos para
-    detectar motocicletas.
-- id: 111
-  category: signs_and_signals
-  question: 'Al entrar en una glorieta (roundabout), debe ceder el paso a:'
-  choices:
-    A: Vehículos a su derecha.
-    B: Todos los vehículos, peatones y ciclistas que ya se encuentren en la glorieta.
-    C: Todos los vehículos que esperan para entrar en la glorieta.
-    D: Vehículos a su izquierda que están señalizando para salir.
-  answer: B
-  explanation: Al acercarse a una glorieta, debe reducir la velocidad y ceder el paso
-    a todo el tráfico, incluidos peatones y ciclistas, que ya esté circulando dentro
-    de la glorieta.
-- id: 112
-  category: safe_driving_rules
-  question: Para mantener el mejor control de su vehículo, especialmente uno equipado
-    con bolsas de aire (airbags), ¿dónde debe colocar las manos en el volante?
-  choices:
-    A: En las posiciones de las 10 y las 2 en punto.
-    B: En las posiciones de las 8 y las 4 en punto.
-    C: Ambas manos en la parte superior del volante.
-    D: Una mano en la posición de las 12 en punto.
-  answer: B
-  explanation: Las posiciones recomendadas para las manos son las 9 y las 3 en punto
-    o, para reducir el riesgo de lesiones en manos y brazos por una bolsa de aire,
-    una posición más baja como las 8 y las 4 en punto. Esto proporciona mejor estabilidad
-    y seguridad.
-- id: 113
-  category: signs_and_signals
-  question: 'Un bordillo (curb) pintado de verde significa que puede estacionarse
-    por:'
-  choices:
-    A: Un tiempo limitado, según lo indicado por una señal o marca colocada.
-    B: Todo el tiempo que desee, siempre que permanezca en su vehículo.
-    C: Únicamente para cargar o descargar pasajeros o correo.
-    D: Únicamente para paradas de emergencia.
-  answer: A
-  explanation: Un bordillo verde indica que el estacionamiento está permitido por
-    un tiempo limitado. El límite de tiempo suele mostrarse en una señal cercana o
-    pintado en el propio bordillo.
-- id: 114
-  category: driver_responsibility
-  question: 'Si se muda, debe notificar al DMV su nueva dirección en un plazo de:'
-  choices:
-    A: 5 días.
-    B: 10 días.
-    C: 30 días.
-    D: 60 días.
-  answer: B
-  explanation: La ley de California exige que notifique al DMV un cambio de dirección
-    dentro de los 10 días posteriores a la mudanza. Esto se puede hacer en línea,
-    por correo o en persona.
-- id: 115
-  category: safe_driving_rules
-  question: ¿Con cuántos pies de antelación, como mínimo, debe señalizar su intención
-    de girar antes de realizar el giro?
-  choices:
-    A: 50 pies
-    B: 100 pies
-    C: 200 pies
-    D: 300 pies
-  answer: B
-  explanation: Para alertar a otros conductores, debe señalizar durante los últimos
-    100 pies antes de girar. Señalizar antes o después puede confundir a los demás
-    conductores.
-- id: 116
-  category: sharing_the_road
-  question: Al encontrarse con un cortejo fúnebre, ¿cuál es la acción adecuada y respetuosa
-    que debe tomar?
-  choices:
-    A: Debe ceder el derecho de paso a todos los vehículos del cortejo.
-    B: Puede interrumpir o atravesar el cortejo si tiene el semáforo en verde.
-    C: Debe tocar la bocina para mostrar respeto.
-    D: Puede unirse al final del cortejo para avanzar más rápido entre el tráfico.
-  answer: A
-  explanation: Por respeto y seguridad, los conductores deben ceder el derecho de
-    paso a todos los vehículos de un cortejo fúnebre. No interrumpa, no se una ni
-    interfiera de ninguna otra manera con el cortejo.
-- id: 117
-  category: signs_and_signals
-  question: 'Una señal de tráfico con una flecha amarilla intermitente significa:'
-  choices:
-    A: Deténgase y espere a una flecha verde.
-    B: El periodo de tiempo de giro protegido está a punto de terminar.
-    C: Puede girar en la dirección de la flecha, pero primero debe ceder el paso al
-      tráfico en sentido contrario y a los peatones.
-    D: La señal de tráfico está averiada; trátela como una señal de pare (stop).
-  answer: C
-  explanation: Una flecha amarilla intermitente indica que los giros están permitidos
-    (no protegidos), pero primero debe ceder el paso al tráfico en sentido contrario
-    y a los peatones antes de avanzar.
-- id: 118
-  category: alcohol_drugs_health
-  question: 'La ley de ''Consentimiento Implícito'' (Implied Consent) de California
-    significa que, al conducir un vehículo motorizado, usted ha aceptado:'
-  choices:
-    A: Llevar siempre consigo su licencia de conducir.
-    B: Someterse a una prueba química (aliento, sangre u orina) para detectar alcohol
-      o drogas si lo solicita un oficial de la paz.
-    C: Consentir el registro de su vehículo en cualquier momento.
-    D: Ser automáticamente culpable en cualquier colisión en la que esté involucrado.
-  answer: B
-  explanation: La ley de Consentimiento Implícito establece que si es arrestado legalmente
-    por un DUI, ha dado su consentimiento para realizarse una prueba química para
-    determinar su concentración de alcohol en sangre (BAC) o la presencia de drogas.
-    Rechazar esta prueba tiene consecuencias graves e independientes.
-- id: 119
-  category: driver_testing
-  question: Durante su examen de conducir al volante, se le pedirá que localice y
-    demuestre el uso de ciertos controles del vehículo. ¿Cuál de los siguientes NO
-    es un elemento requerido en esta lista de verificación previa a la conducción?
-  choices:
-    A: Limpiaparabrisas
-    B: Desempañador (defroster)
-    C: Luces de emergencia (intermitentes)
-    D: Radio o sistema de audio
-  answer: D
-  explanation: Antes de que comience el examen de conducir, el examinador le pedirá
-    que demuestre el funcionamiento de equipos críticos para la seguridad, como faros,
-    limpiaparabrisas, desempañador, bocina y luces de emergencia. El sistema de radio/audio
-    no es un elemento de seguridad requerido.
-- id: 120
-  category: sharing_the_road
-  question: ¿Cuál es una característica clave de los Vehículos Eléctricos de Vecindario
-    (NEV) que otros conductores deben tener en cuenta?
-  choices:
-    A: Están permitidos en todas las autopistas de California.
-    B: Alcanzan una velocidad máxima de solo 25 mph.
-    C: Son más pesados y se detienen más lentamente que los autos estándar.
-    D: Solo se les permite conducir durante las horas del día.
-  answer: B
-  explanation: Los NEV están restringidos a carreteras con un límite de velocidad
-    de 35 mph o menos y solo pueden alcanzar una velocidad máxima de 25 mph. Otros
-    conductores deben estar atentos a su menor velocidad y a la posibilidad de que
-    causen congestión en el tráfico que se mueve más rápido.
-- id: 121
-  category: driver_testing
-  question: Según el código CSS del sitio web, ¿cuál es el valor en píxeles asignado
-    al ajuste preestablecido de tamaño de fuente 'huge' (enorme)?
-  choices:
-    A: 32px
-    B: 40px
-    C: 42px
-    D: 50px
-  answer: B
-  explanation: 'El CSS proporcionado define la variable como `--wp--preset--font-size--huge:
-    40px;`.'
-- id: 122
-  category: driver_responsibility
-  question: El código del sitio web incluye un script para cargar una fuente específica
-    de Google. ¿Cómo se llama esta familia de fuentes?
-  choices:
-    A: Arial
-    B: Times New Roman
-    C: Playfair Display
-    D: Courier New
-  answer: C
-  explanation: 'El fragmento de JavaScript contiene `WebFontConfig = { google: { families:
-    [ ''Playfair+Display:400,700'' ] } };`, lo que indica que se está cargando la
-    familia de fuentes ''Playfair Display''.'
-- id: 123
-  category: signs_and_signals
-  question: En el CSS del sitio web, ¿cuál es el nombre del degradado preestablecido
-    que realiza la transición de `rgb(2,3,129)` a `rgb(40,116,252)`?
-  choices:
-    A: Pale Ocean
-    B: Luminous Dusk
-    C: Midnight
-    D: Cool to Warm Spectrum
-  answer: C
-  explanation: 'El código CSS define `--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129)
-    0%,rgb(40,116,252) 100%);`.'
-- id: 124
-  category: driver_responsibility
-  question: ¿Cuál es el atributo `id` del elemento de botón HTML diseñado para mostrar
-    el chatbot del sitio web?
-  choices:
-    A: chatbot__show-btn
-    B: js-chatbot-dialog
-    C: js-chatbot-show
-    D: GTM-KHCVGH4
-  answer: C
-  explanation: El HTML proporcionado para el botón es `<button id="js-chatbot-show"
-    ...>`.
-- id: 125
-  category: vehicle_information
-  question: El código del sitio web incluye un iframe para Google Tag Manager. ¿Cuál
-    es el ID especificado para este servicio?
-  choices:
-    A: GTM-KHCVGH4
-    B: GTM-1234567
-    C: UA-XXXXX-Y
-    D: G-ABCDEFG
-  answer: A
-  explanation: El atributo `src` del iframe es 'https://www.googletagmanager.com/ns.html?id=GTM-KHCVGH4'.
-- id: 126
-  category: driver_testing
-  question: ¿Cuál es el valor definido para la variable de espaciado preestablecida
-    de CSS `--wp--preset--spacing--50`?
-  choices:
-    A: 1rem
-    B: 1.5rem
-    C: 2.25rem
-    D: 0.67rem
-  answer: B
-  explanation: 'El código CSS proporcionado incluye la definición: `--wp--preset--spacing--50:
-    1.5rem;`.'
-- id: 127
-  category: signs_and_signals
-  question: El CSS define un color preestablecido llamado 'luminous-vivid-amber'.
-    ¿Cuál es su valor de color hexadecimal correspondiente?
-  choices:
-    A: '#f78da7'
-    B: '#ff6900'
-    C: '#fcb900'
-    D: '#00d084'
-  answer: C
-  explanation: 'El CSS proporcionado define la variable `--wp--preset--color--luminous-vivid-amber:
-    #fcb900;`.'
-- id: 128
-  category: signs_and_signals
-  question: Según los estilos CSS, ¿cuál es el nombre del ajuste preestablecido de
-    sombra definido como `12px 12px 50px rgba(0, 0, 0, 0.4)`?
-  choices:
-    A: Natural
-    B: Sharp
-    C: Outlined
-    D: Deep
-  answer: D
-  explanation: La variable CSS `--wp--preset--shadow--deep` se define como `12px 12px
-    50px rgba(0, 0, 0, 0.4);`.
-- id: 129
-  category: driver_testing
-  question: ¿Cuál es el valor en píxeles para el ajuste preestablecido de tamaño de
-    fuente CSS llamado 'normal'?
-  choices:
-    A: 18px
-    B: 21px
-    C: 28px
-    D: 32px
-  answer: B
-  explanation: 'El código CSS define el tamaño de fuente preestablecido como `--wp--preset--font-size--normal:
-    21px;`.'
-- id: 130
-  category: signs_and_signals
-  question: ¿Qué degradado preestablecido de CSS se define como una transición de
-    `rgb(202,248,128)` a `rgb(113,206,126)`?
-  choices:
-    A: Electric Grass
-    B: Pale Ocean
-    C: Light Green Cyan to Vivid Green Cyan
-    D: Luminous Dusk
-  answer: A
-  explanation: 'El CSS define `--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128)
-    0%,rgb(113,206,126) 100%);`.'
-- id: 131
-  category: driver_responsibility
-  question: Un fragmento de JavaScript en el código está diseñado para modificar el
-    elemento `<html>` al cargar. ¿Qué nombre de clase reemplaza?
-  choices:
-    A: js
-    B: no-js
-    C: wf-active
-    D: is-layout-flex
-  answer: B
-  explanation: El script contiene la línea `document.documentElement.className = document.documentElement.className.replace('no-js',
-    " ");`, la cual elimina la clase 'no-js'.
-- id: 132
-  category: signs_and_signals
-  question: ¿Cuál es el código de color hexadecimal para el color predeterminado llamado
-    'vivid-red'?
-  choices:
-    A: '#cf2e2e'
-    B: '#ff6900'
-    C: '#fcb900'
-    D: '#72aee6'
-  answer: A
-  explanation: 'El CSS proporcionado define la variable `--wp--preset--color--vivid-red:
-    #cf2e2e;`.'
-- id: 133
-  category: driver_testing
-  question: El código CSS define un ajuste predeterminado para el tamaño de fuente
-    'x-large'. ¿Cuál es su valor en píxeles?
-  choices:
-    A: 28px
-    B: 32px
-    C: 40px
-    D: 42px
-  answer: D
-  explanation: 'La variable CSS se define como `--wp--preset--font-size--x-large:
-    42px;`.'
-- id: 134
-  category: signs_and_signals
-  question: ¿Cuál es la definición del ajuste predeterminado de sombra 'crisp' en
-    el CSS del sitio web?
-  choices:
-    A: 6px 6px 9px rgba(0, 0, 0, 0.2)
-    B: 12px 12px 50px rgba(0, 0, 0, 0.4)
-    C: 6px 6px 0px rgb(0, 0, 0)
-    D: 6px 6px 0px -3px rgb(255, 255, 255), 6px 6px rgb(0, 0, 0)
-  answer: C
-  explanation: 'El CSS define el ajuste predeterminado como `--wp--preset--shadow--crisp:
-    6px 6px 0px rgb(0, 0, 0);`.'
-- id: 135
-  category: driver_responsibility
-  question: El código JavaScript en el texto proporcionado carga un script de fuentes
-    web (webfont). ¿Desde qué protocolo de origen carga el script?
-  choices:
-    A: Siempre 'https'
-    B: Siempre 'http'
-    C: Cualquier protocolo que la página esté utilizando actualmente
-    D: FTP
-  answer: C
-  explanation: 'El script construye la URL de origen utilizando `(''https:'' == document.location.protocol
-    ? ''https'' : ''http'') + ''://ajax.googleapis.com/...''`, lo cual coincide con
-    el protocolo de la página actual.'
-- id: 136
-  category: signs_and_signals
-  question: ¿Qué degradado predeterminado está definido por un degradado lineal que
-    comienza en `rgb(255,205,210)` y termina en `rgb(198,40,40)`?
-  choices:
-    A: blush-light-purple
-    B: luminous-dusk
-    C: blush-bordeaux
-    D: luminous-vivid-orange-to-vivid-red
-  answer: C
-  explanation: 'El código CSS define `--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(255,205,210)
-    0%,rgb(198,40,40) 100%);`.'
-- id: 137
-  category: driver_testing
-  question: ¿Cuál es el valor del ajuste predeterminado de espaciado más pequeño,
-    `--wp--preset--spacing--20`?
-  choices:
-    A: 0.44rem
-    B: 0.5em
-    C: 0.67rem
-    D: 1rem
-  answer: A
-  explanation: 'El código CSS define la variable como `--wp--preset--spacing--20:
-    0.44rem;`.'
-- id: 138
-  category: driver_testing
-  question: ¿Cuál es el valor en píxeles del ajuste predeterminado de tamaño de fuente
-    'large' definido en el CSS del sitio web?
-  choices:
-    A: 21px
-    B: 28px
-    C: 32px
-    D: 40px
-  answer: C
-  explanation: 'El CSS define el ajuste predeterminado como `--wp--preset--font-size--large:
-    32px;`.'
-- id: 139
-  category: signs_and_signals
-  question: El CSS define un ajuste predeterminado de sombra llamado 'outlined'. ¿Cuál
-    es su definición específica de CSS?
-  choices:
-    A: 6px 6px 9px rgba(0, 0, 0, 0.2)
-    B: 12px 12px 50px rgba(0, 0, 0, 0.4)
-    C: 6px 6px 0px rgb(0, 0, 0)
-    D: 6px 6px 0px -3px rgb(255, 255, 255), 6px 6px rgb(0, 0, 0)
-  answer: D
-  explanation: 'La variable CSS se define como `--wp--preset--shadow--outlined: 6px
-    6px 0px -3px rgb(255, 255, 255), 6px 6px rgb(0, 0, 0);`.'
-- id: 140
-  category: signs_and_signals
-  question: ¿A qué ajuste predeterminado de color CSS se le asigna el código hexadecimal
-    `#abb8c3`?
-  choices:
-    A: white
-    B: black
-    C: cyan-bluish-gray
-    D: pale-cyan-blue
-  answer: C
-  explanation: 'El código CSS incluye la definición: `--wp--preset--color--cyan-bluish-gray:
-    #abb8c3;`.'
-- id: 141
-  category: driver_testing
-  question: El código CSS define un valor de espaciado preestablecido de `5.06rem`.
-    ¿Cuál es el nombre de este ajuste preestablecido de espaciado?
-  choices:
-    A: --wp--preset--spacing--60
-    B: --wp--preset--spacing--70
-    C: --wp--preset--spacing--80
-    D: --wp--preset--spacing--90
-  answer: C
-  explanation: 'El CSS define `--wp--preset--spacing--80: 5.06rem;`.'
-- id: 142
-  category: signs_and_signals
-  question: ¿Entre qué dos tipos de colores transiciona el ajuste preestablecido de
-    degradado 'pale-ocean'?
-  choices:
-    A: Un amarillo pálido a tonos de azul verdoso
-    B: Un verde claro a un verde más oscuro
-    C: Un púrpura claro a un azul oscuro
-    D: Un gris claro a un gris oscuro
-  answer: A
-  explanation: El CSS define `--wp--preset--gradient--pale-ocean` con `rgb(255,245,203)`
-    (un amarillo pálido) y `rgb(182,227,212)` / `rgb(51,167,181)` (tonos de azul verdoso).
-- id: 143
-  category: driver_responsibility
-  question: Según el fragmento de JavaScript, ¿a qué valor establece el código la
-    propiedad `async` del nuevo elemento de script?
-  choices:
-    A: 'false'
-    B: 'true'
-    C: '1'
-    D: No establece la propiedad async.
-  answer: B
-  explanation: El JavaScript proporcionado contiene la línea `wf.async = 'true';`,
-    que establece la propiedad asíncrona para el script del cargador de fuentes web
-    (webfont loader).
-- id: 144
-  category: driver_responsibility
-  question: Según el Mensaje del Secretario, ¿en cuántos idiomas diferentes está disponible
-    el Manual del Automovilista de California para ayudar a la diversa población de
-    conductores?
-  choices:
-    A: Tres
-    B: Cinco
-    C: Siete
-    D: Nueve
-  answer: D
-  explanation: 'El Mensaje del Secretario en el manual establece: ''El Manual del
-    Automovilista de California está disponible en nueve idiomas y ofrece información
-    valiosa para los californianos...'''
-- id: 145
-  category: penalties_and_points
-  question: ¿Cuál de los siguientes tipos de pago específicos se puede realizar a
-    través del portal en línea 'Realizar un pago' del DMV?
-  choices:
-    A: Multas por boletas de estacionamiento
-    B: Pagos de cheques sin fondos
-    C: Restitución ordenada por el tribunal
-    D: Tarifas de confiscación de vehículos
-  answer: B
-  explanation: El texto enumera 'Pago de cheque sin fondos' (Dishonored Check Payment)
-    como una opción específica bajo el menú 'Realizar un pago' en el sitio web del
-    DMV.
-- id: 146
-  category: license_system
-  question: El sitio web del DMV invita a los usuarios a participar en un programa
-    piloto para ¿qué nuevo tipo de licencia bajo la sección 'Licencias de conducir
-    e identificaciones'?
-  choices:
-    A: Una REAL ID digital
-    B: Una licencia de conducir móvil (mDL)
-    C: Un permiso de conducir internacional
-    D: Una licencia temporal de papel
-  answer: B
-  explanation: Bajo el menú 'Licencias de conducir e identificaciones', se enumera
-    la opción 'Unirse al piloto de mDL', refiriéndose al programa piloto de la licencia
-    de conducir móvil (mDL).
-- id: 147
-  category: driver_testing
-  question: Además de los manuales del conductor y los exámenes de práctica, ¿qué
-    otro recurso se ofrece bajo el menú 'Exámenes' (Testing) en el sitio web del DMV
-    para ayudar a preparar a los conductores?
-  choices:
-    A: Sesiones de preguntas y respuestas con instructores en vivo
-    B: Un simulador de conducción
-    C: Videos instructivos (How-To Videos)
-    D: Una lista de escuelas de manejo certificadas
-  answer: C
-  explanation: El menú 'Exámenes' (Testing) en el sitio web del DMV enumera 'Videos
-    instructivos' (How-To Videos) como un recurso para los conductores, además de
-    los manuales y los exámenes de práctica.
-- id: 148
-  category: license_system
-  question: ¿Cuál de los siguientes es un estado de caso específico que puede verificar
-    utilizando los servicios en línea del DMV?
-  choices:
-    A: Estado de finalización de la escuela de tránsito
-    B: Estado de la verificación de smog del vehículo
-    C: Estado del caso de seguridad del conductor (Driver Safety Case Status)
-    D: Estado de una reclamación de seguro
-  answer: C
-  explanation: El menú 'Verificar estado' en el sitio web del DMV incluye una opción
-    para verificar el 'Estado del caso de seguridad del conductor' (Driver Safety
-    Case Status).
-- id: 149
-  category: driver_responsibility
-  question: Al usar el Asistente Virtual del DMV, ¿qué tipo específico de información
-    se le advierte explícitamente que NO incluya en su chat?
-  choices:
-    A: Su número de licencia de conducir
-    B: Cualquier información personal
-    C: El número de placa de su vehículo
-    D: Preguntas sobre multas de tránsito
-  answer: B
-  explanation: 'El descargo de responsabilidad general para el Asistente Virtual del
-    DMV establece: ''...por favor no incluya ninguna información personal''.'
-- id: 150
-  category: vehicle_information
-  question: Según el menú de servicios en línea del DMV, ¿cuál de estas tareas relacionadas
-    con el registro de vehículos se puede completar en línea?
-  choices:
-    A: Enviar comprobante de seguro
-    B: Obtener una inspección de seguridad del vehículo
-    C: Disputar una tarifa de registro
-    D: Solicitar un título de salvamento
-  answer: A
-  explanation: El menú 'Registro de vehículos' en el sitio web del DMV enumera 'Enviar
-    comprobante de seguro' como un servicio en línea disponible.
-- id: 151
-  category: sharing_the_road
-  question: ¿Qué sección del Manual del Automovilista de California aborda específicamente
-    temas relevantes para los conductores mayores?
-  choices:
-    A: 'Sección 8: Conducción segura'
-    B: 'Sección 12: Seguridad del conductor'
-    C: 'Sección 13: Personas mayores y la conducción'
-    D: 'Sección 14: Glosario'
-  answer: C
-  explanation: 'El índice muestra que la ''Sección 13: Personas mayores y la conducción''
-    está dedicada a este tema.'
-- id: 152
-  category: penalties_and_points
-  question: Bajo la sección 'Realizar un pago' (Make a Payment) del sitio web del
-    DMV, ¿qué cargo se indica específicamente como pagable en línea?
-  choices:
-    A: Un cargo por curso de educación vial
-    B: Una multa judicial por infracción de tráfico
-    C: Un cargo por restablecimiento de la licencia
-    D: Una citación de estacionamiento privado
-  answer: C
-  explanation: El menú 'Realizar un pago' en el sitio web del DMV enumera explícitamente
-    'Pagar cargo por restablecimiento' como un servicio en línea.
-- id: 153
-  category: vehicle_information
-  question: Si necesita una copia oficial del historial de su vehículo, ¿qué opción
-    debe seleccionar en el menú en línea 'Registro de vehículos' (Vehicle Registration)
-    del DMV?
-  choices:
-    A: Nuevo registro
-    B: Solicitar expediente del vehículo
-    C: Renovar registro
-    D: Placas, calcomanías, carteles
-  answer: B
-  explanation: El menú 'Registro de vehículos' incluye la opción 'Solicitar expediente
-    del vehículo' para obtener el historial de un vehículo.
-- id: 154
-  category: driver_responsibility
-  question: El Mensaje del Secretario establece que una licencia de conducir brinda
-    la oportunidad de viajar a varios lugares. ¿Cuál de los siguientes NO se menciona
-    específicamente como destino?
-  choices:
-    A: Servicios esenciales
-    B: Un lugar de vacaciones favorito
-    C: Fronteras internacionales
-    D: Educación
-  answer: C
-  explanation: El Mensaje del Secretario menciona que una licencia ofrece viajar a
-    'servicios esenciales, un lugar de vacaciones favorito, educación, seres queridos',
-    pero no menciona fronteras internacionales.
-- id: 155
-  category: license_system
-  question: ¿Cuál es el título de la Sección 12 del Manual del Automovilista de California?
-  choices:
-    A: Personas mayores y la conducción
-    B: Requisitos de registro de vehículos
-    C: Seguridad del conductor
-    D: Alcohol y drogas
-  answer: C
-  explanation: 'El índice enumera la ''Sección 12: Seguridad del conductor''.'
-- id: 156
-  category: driver_responsibility
-  question: Según el descargo de responsabilidad, ¿cuál es el propósito principal
-    de los servicios de traducción automática utilizados para el chatbot del DMV?
-  choices:
-    A: Para cumplimiento legal y aplicación de la ley
-    B: Para proporcionar un registro de conversación legalmente vinculante
-    C: Solo para fines de información y conveniencia
-    D: Para garantizar la precisión de todo el contenido traducido
-  answer: C
-  explanation: 'El Descargo de responsabilidad de traducción de terceros establece:
-    ''La traducción automática se proporciona solo con fines de información y conveniencia''.'
-- id: 157
-  category: driver_testing
-  question: Además de los Manuales del Automovilista, ¿qué otro tipo de material escrito
-    está disponible bajo el menú 'Exámenes' (Testing) en el sitio web del DMV?
-  choices:
-    A: Biografías del personal del DMV
-    B: Guías especializadas para conductores
-    C: Manuales de mantenimiento de vehículos
-    D: Una lista de leyes de tránsito por condado
-  answer: B
-  explanation: El menú 'Exámenes' en el sitio web del DMV enumera las 'Guías especializadas
-    para conductores' como un recurso disponible.
-- id: 158
-  category: license_system
-  question: Según el menú 'Verificar estado' (Check Status), ¿cuál de los siguientes
-    NO es un estado que pueda verificar en línea?
-  choices:
-    A: Estado de cambio de dirección
-    B: Estado de renovación de DL/ID
-    C: Estado de caso de oficina virtual
-    D: Estado de acreditación de escuela de manejo
-  answer: D
-  explanation: El menú 'Verificar estado' enumera los estados de Cambio de dirección,
-    Renovación de DL/ID y Caso de oficina virtual, pero no menciona la Acreditación
-    de escuela de manejo.
-- id: 159
-  category: driver_responsibility
-  question: ¿Qué advertencia proporciona el DMV con respecto a guardar una transcripción
-    de chat del Asistente Virtual?
-  choices:
-    A: Las transcripciones se eliminan automáticamente después de 24 horas.
-    B: Las transcripciones no son documentos legalmente admisibles.
-    C: Tenga precaución al usar una computadora o dispositivo público.
-    D: Debe pagar un cargo para guardar la transcripción.
-  answer: C
-  explanation: 'El Descargo de responsabilidad general para el Asistente Virtual establece:
-    ''Cuando termine su chat, puede guardar la transcripción. Tenga precaución al
-    usar una computadora o dispositivo público''.'
-- id: 160
-  category: license_system
-  question: Si necesita una copia de su propio historial de manejo, ¿qué opción elegiría
-    en el menú 'Licencias de conducir e identificaciones' (Driver's Licenses & IDs)?
-  choices:
-    A: Solicitud de nueva tarjeta de DL/ID
-    B: Solicitar expediente del conductor
-    C: Unirse al programa piloto de mDL
-    D: Renovar DL/ID
-  answer: B
-  explanation: El menú 'Licencias de conducir e identificaciones' enumera 'Solicitar
-    expediente del conductor' como el servicio para obtener una copia de su historial
-    de manejo.
-- id: 161
-  category: safe_driving_rules
-  question: El Mensaje del Secretario enfatiza que todos los que usan las carreteras
-    deben seguir las reglas. ¿Cuál de los siguientes usuarios de la vía NO se menciona
-    específicamente en este contexto?
-  choices:
-    A: Motociclistas
-    B: Peatones
-    C: Conductores de vehículos comerciales
-    D: Ciclistas
-  answer: B
-  explanation: 'El Mensaje del Secretario establece: ''Ya sea que conduzca un automóvil,
-    una motocicleta, un vehículo comercial o una bicicleta, es fundamental que cumplamos
-    con las reglas...'' Los peatones no se enumeran explícitamente en esta oración.'
-- id: 162
-  category: driver_responsibility
-  question: 'Según el Índice del manual, ¿qué sección sigue inmediatamente a la ''Sección
-    9: Alcohol y drogas''?'
-  choices:
-    A: 'Sección 8: Conducción segura (continuación)'
-    B: 'Sección 11: Requisitos de registro de vehículos'
-    C: 'Sección 12: Seguridad del conductor'
-    D: 'Sección 10: Responsabilidad financiera, requisitos de seguro y colisiones'
-  answer: D
-  explanation: El Índice muestra que la Sección 10, que cubre la responsabilidad financiera
-    y las colisiones, viene directamente después de la Sección 9 sobre alcohol y drogas.
-- id: 163
-  category: vehicle_information
-  question: ¿Bajo qué menú principal en el sitio web del DMV encontraría información
-    sobre el reemplazo de placas, calcomanías o carteles de estacionamiento (placards)?
-  choices:
-    A: Licencias de conducir e identificaciones
-    B: Realizar un pago
-    C: Registro de vehículos
-    D: Verificar estado
-  answer: C
-  explanation: El menú 'Registro de vehículos' contiene el submenú 'Placas, calcomanías,
-    carteles'.
-- id: 164
-  category: penalties_and_points
-  question: ¿Qué herramienta se proporciona en el menú 'Realizar un pago' para ayudarle
-    a determinar el costo del registro de su vehículo?
-  choices:
-    A: Carrito de compras
-    B: Calculadora de tarifas
-    C: Pagar tarifa de registro tardío
-    D: Pagos y reembolsos
-  answer: B
-  explanation: El menú 'Realizar un pago' incluye una 'Calculadora de tarifas' para
-    ayudar a los usuarios a determinar sus costos.
-- id: 165
-  category: driver_responsibility
-  question: ¿El mensaje introductorio en el Manual del Automovilista de California
-    es del Secretario de qué agencia?
-  choices:
-    A: Departamento de Vehículos Motorizados
-    B: Patrulla de Caminos de California
-    C: Agencia de Transporte del Estado de California
-    D: Departamento de Justicia
-  answer: C
-  explanation: El mensaje introductorio está firmado por Toks Omishakin, Secretario
-    de la Agencia de Transporte del Estado de California.
-- id: 166
-  category: alcohol_drugs_health
-  question: El mensaje del Secretario advierte que operar un vehículo mientras se
-    está distraído o bajo los efectos de sustancias podría significar la diferencia
-    entre ¿qué?
-  choices:
-    A: Una multa y una advertencia
-    B: La vida y la muerte
-    C: Mantener o perder su licencia
-    D: Un delito menor y un delito grave
-  answer: B
-  explanation: 'El manual establece: ''No opere un vehículo, motocicleta o bicicleta
-    mientras esté distraído o bajo los efectos de sustancias; podría significar la
-    diferencia entre la vida y la muerte''.'
-- id: 167
-  category: sharing_the_road
-  question: La advertencia de no operar mientras se está distraído o bajo los efectos
-    de sustancias se aplica a los conductores de vehículos, motocicletas y ¿qué más?
-  choices:
-    A: Motonetas
-    B: Patinetas
-    C: Camiones comerciales
-    D: Bicicletas
-  answer: D
-  explanation: 'El texto establece explícitamente: ''No opere un vehículo, motocicleta
-    o bicicleta mientras esté distraído o bajo los efectos de sustancias...'''
-- id: 168
-  category: license_system
-  question: ¿Por qué el DMV recomienda que 'Intente en línea primero' para servicios
-    como renovaciones?
-  choices:
-    A: Es la única forma de completar transacciones
-    B: Puede ahorrar tiempo
-    C: Es obligatorio para todos los conductores nuevos
-    D: Ofrece tarifas más bajas que los servicios en persona
-  answer: B
-  explanation: 'El manual aconseja: ''Intente en línea primero, ya que puede ahorrar
-    tiempo''.'
-- id: 169
-  category: driver_testing
-  question: Además de varios idiomas escritos, ¿en qué formato está disponible el
-    Manual del Automovilista de California como video?
-  choices:
-    A: Español con subtítulos
-    B: Chino mandarín
-    C: Lenguaje de Señas Americano (ASL)
-    D: Formato de audiolibro
-  answer: C
-  explanation: El manual ofrece una opción de 'Video en Lenguaje de Señas Americano'
-    disponible en YouTube.
-- id: 170
-  category: driver_testing
-  question: ¿Cuál de los siguientes NO es uno de los idiomas en los que la versión
-    en PDF del Manual del Automovilista de California está disponible oficialmente?
-  choices:
-    A: Vietnamita
-    B: Francés
-    C: Ruso
-    D: Panyabí
-  answer: B
-  explanation: La lista proporcionada de idiomas disponibles para el manual en PDF
-    incluye inglés, español, vietnamita, ruso, armenio, hindi, panyabí y chino, pero
-    no francés.
-- id: 171
-  category: driver_responsibility
-  question: Según el descargo de responsabilidad, ¿cuál es la posición del DMV con
-    respecto a la precisión de las traducciones proporcionadas por Google™ Translate?
-  choices:
-    A: El DMV garantiza un 95% de precisión
-    B: El DMV no puede garantizar la precisión
-    C: El DMV revisa manualmente todas las traducciones para asegurar su precisión
-    D: El DMV es responsable de cualquier imprecisión menor
-  answer: B
-  explanation: 'El descargo de responsabilidad establece: ''El DMV no puede garantizar
-    la precisión de ninguna traducción proporcionada por Google™ Translate y, por
-    lo tanto, no es responsable de ninguna información inexacta...'''
-- id: 172
-  category: driver_responsibility
-  question: Si surge alguna duda relacionada con la información contenida en una versión
-    traducida del sitio web del DMV, ¿qué debe hacer?
-  choices:
-    A: Contactar al soporte de Google™ Translate
-    B: Asumir que la traducción es correcta
-    C: Presentar una queja formal ante el DMV
-    D: Consultar la versión en inglés
-  answer: D
-  explanation: 'El descargo de responsabilidad aconseja: ''Si surge alguna duda relacionada
-    con la información contenida en el sitio web traducido, consulte la versión en
-    inglés''.'
-- id: 173
-  category: safe_driving_rules
-  question: ¿Cuál es la principal instrucción de seguridad proporcionada por el DMV
-    al interactuar con su chatbot de Asistente Virtual?
-  choices:
-    A: Hable clara y pausadamente
-    B: No incluya ninguna información personal
-    C: Solo pregunte sobre el registro de vehículos
-    D: Tenga a mano su número de licencia de conducir
-  answer: B
-  explanation: 'El descargo de responsabilidad del Asistente Virtual establece explícitamente:
-    ''Al interactuar con el Asistente Virtual del Departamento de Vehículos Motorizados
-    (DMV), no incluya ninguna información personal''.'
-- id: 174
-  category: license_system
-  question: ¿Quién proporciona la traducción automática para el chatbot del DMV y
-    los servicios de chat en vivo?
-  choices:
-    A: Traductores del personal del DMV
-    B: Exclusivamente Google™ Translate
-    C: Proveedores externos
-    D: Un sistema automatizado del DMV
-  answer: C
-  explanation: 'El descargo de responsabilidad establece: ''El chatbot del DMV y los
-    servicios de chat en vivo utilizan proveedores externos para proporcionar traducción
-    automática''.'
-- id: 175
-  category: driver_responsibility
-  question: 'El mensaje del Secretario en el manual enfatiza que conducir o manejar
-    es un(a):'
-  choices:
-    A: Derecho constitucional
-    B: Privilegio
-    C: Habilidad obligatoria
-    D: Requisito de por vida
-  answer: B
-  explanation: 'El texto establece: ''Recuerde que conducir o manejar es un privilegio
-    y, por encima de todo, la seguridad debe ser la prioridad''.'
-- id: 176
-  category: safe_driving_rules
-  question: El mensaje del Secretario aconseja a los conductores dejar el teléfono
-    celular cuando estén al volante o ¿qué otra cosa?
-  choices:
-    A: En un estacionamiento
-    B: Detenido en un semáforo en rojo
-    C: El manubrio (handlebars)
-    D: En una zona escolar
-  answer: C
-  explanation: El mensaje aconseja 'dejar ese teléfono celular cuando esté detrás
-    del volante o del manubrio', refiriéndose tanto a automóviles como a motocicletas
-    o bicicletas.
-- id: 177
-  category: driver_responsibility
-  question: ¿Con qué propósito declarado se proporciona la herramienta de aplicación
-    de traducción en el sitio web del DMV?
-  choices:
-    A: Cumplimiento legal y aplicación de la ley
-    B: Mantenimiento de registros oficiales
-    C: Reemplazar a los traductores presenciales
-    D: Solo para fines de información y conveniencia
-  answer: D
-  explanation: 'El descargo de responsabilidad establece: ''Esta herramienta de aplicación
-    de traducción se proporciona únicamente con fines de información y conveniencia''.'
-- id: 178
-  category: penalties_and_points
-  question: Para fines de cumplimiento o aplicación de la ley, ¿qué se considera la
-    fuente oficial y precisa de información sobre los programas del DMV?
-  choices:
-    A: La versión traducida del sitio web
-    B: El Asistente Virtual del DMV
-    C: Las páginas web que actualmente están en inglés
-    D: Una copia impresa del manual
-  answer: C
-  explanation: 'El descargo de responsabilidad del manual aclara: ''Las páginas web
-    que actualmente están en inglés en el sitio web del DMV son la fuente oficial
-    y precisa de la información del programa y los servicios que ofrece el DMV''.'
-- id: 179
-  category: license_system
-  question: Según la información de derechos de autor en el pie de página de la página
-    web, ¿hasta qué año posee el Estado de California los derechos de autor del contenido?
-  choices:
-    A: '2024'
-    B: '2025'
-    C: '2026'
-    D: No hay un año de derechos de autor listado
-  answer: C
-  explanation: El pie de página del texto proporcionado incluye la línea 'Copyright
-    &copy; 2026 State of California'.
-- id: 180
-  category: license_system
-  question: ¿Cuál es el objetivo declarado de los esfuerzos del DMV para modernizar
-    sus interacciones con los clientes?
-  choices:
-    A: Eliminar todas las citas presenciales
-    B: Aumentar los ingresos por tarifas en línea
-    C: Hacer que la experiencia digital sea más fácil, rápida y conveniente
-    D: Rastrear el comportamiento del conductor a través de servicios en línea
-  answer: C
-  explanation: 'El texto establece: ''El DMV ha estado modernizando las interacciones
-    con sus clientes, haciendo que la experiencia digital de los californianos sea
-    más fácil, rápida y conveniente''.'
-- id: 181
-  category: penalties_and_points
-  question: ¿Según el descargo de responsabilidad del chatbot del DMV, qué efecto
-    legal tienen las discrepancias creadas en una traducción automática?
-  choices:
-    A: Son legalmente vinculantes si el usuario guarda la transcripción
-    B: Pueden usarse para cumplimiento pero no para ejecución
-    C: No son vinculantes y no tienen efecto legal
-    D: Deben reportarse al proveedor externo para su corrección
-  answer: C
-  explanation: 'El descargo de responsabilidad del chatbot establece: ''Cualquier
-    discrepancia o diferencia creada en la traducción no es vinculante y no tiene
-    efecto legal para fines de cumplimiento o ejecución''.'
-- id: 182
-  category: safe_driving_rules
-  question: El mensaje del Secretario de la Agencia de Transporte del Estado de California
-    establece que, por encima de todo, ¿cuál debe ser la prioridad al conducir?
-  choices:
-    A: La velocidad
-    B: La conveniencia
-    C: La seguridad
-    D: El derecho de paso
-  answer: C
-  explanation: 'El mensaje establece claramente: ''...por encima de todo, la seguridad
-    debe ser la prioridad''.'
-- id: 183
-  category: driver_responsibility
-  question: El DMV no es responsable de la información inexacta o de los cambios en
-    el formato de la página que resulten del uso de ¿qué herramienta?
-  choices:
-    A: El Asistente Virtual del DMV
-    B: La herramienta de aplicación Google™ Translate
-    C: El sistema de citas en línea
-    D: La aplicación móvil del DMV
-  answer: B
-  explanation: El descargo de responsabilidad dice que el DMV 'por lo tanto, no es
-    responsable de ninguna información inexacta o cambios en el formato de las páginas
-    que resulten del uso de la herramienta de aplicación de traducción'.
-- id: 184
-  category: license_system
-  question: El descargo de responsabilidad de la traducción especifica que Google™
-    Translate es un servicio de terceros gratuito que no está ________ por el DMV.
-  choices:
-    A: Avalado
-    B: Pagado
-    C: Controlado
-    D: Recomendado
-  answer: C
-  explanation: 'El texto establece: ''Google™ Translate es un servicio de terceros
-    gratuito, el cual no es controlado por el DMV''.'
-- id: 185
-  category: license_system
-  question: El sitio web del DMV proporciona enlaces a su presencia en redes sociales
-    en varias plataformas, ¿incluyendo cuál de las siguientes?
-  choices:
-    A: TikTok
-    B: Snapchat
-    C: Pinterest
-    D: LinkedIn
-  answer: D
-  explanation: El texto proporcionado muestra iconos de Facebook, X (Twitter), YouTube,
-    Instagram y LinkedIn.
-- id: 186
-  category: sharing_the_road
-  question: Según el mensaje del Secretario, una acción de seguridad clave es prestar
-    siempre atención a otros conductores, ciclistas y ¿a quién más?
-  choices:
-    A: Oficiales de la ley
-    B: Trabajadores de construcción de carreteras
-    C: Peatones
-    D: Vehículos de emergencia
-  answer: C
-  explanation: El mensaje aconseja a los conductores 'prestar atención a otros conductores,
-    ciclistas y peatones...'
-- id: 187
-  category: license_system
-  question: Los esfuerzos de modernización del DMV, como la expansión de los servicios
-    en línea, se centran en mejorar la experiencia ________ del cliente.
-  choices:
-    A: Presencial
-    B: Telefónica
-    C: Digital
-    D: Por correo
-  answer: C
-  explanation: El texto establece que el DMV está 'haciendo que la experiencia digital
-    de los californianos sea más fácil, rápida y conveniente'.
-- id: 188
-  category: sharing_the_road
-  question: Al conducir cerca de un camión grande, ¿dónde se encuentran sus puntos
-    ciegos más grandes, también conocidos como 'No-Zones'?
-  choices:
-    A: Directamente frente al camión solamente
-    B: Solo en el lado izquierdo (del conductor)
-    C: En ambos lados, directamente al frente y directamente detrás del camión
-    D: Solo en el lado derecho y directamente detrás del camión
-  answer: C
-  explanation: Los camiones grandes tienen puntos ciegos significativos en los cuatro
-    lados. Estas áreas, llamadas 'No-Zones', son donde su vehículo 'disaparece' de
-    la vista del conductor del camión.
-- id: 189
-  category: safe_driving_rules
-  question: En una intersección en 'T' que no tiene señales de pare (stop) o ceda
-    el paso (yield), ¿quién tiene el derecho de paso?
-  choices:
-    A: El vehículo en la carretera principal (que continúa)
-    B: El vehículo en la carretera que termina
-    C: El vehículo que llega primero
-    D: El vehículo que gira a la derecha
-  answer: A
-  explanation: En una intersección en 'T', el tráfico en la carretera principal tiene
-    el derecho de paso. Los vehículos en la carretera que termina deben ceder el paso
-    al tráfico y a los peatones en la carretera principal.
-- id: 190
-  category: license_system
-  question: 'Durante los primeros 12 meses, un menor con una licencia de conducir
-    provisional no tiene permitido transportar pasajeros menores de 20 años a menos
-    que:'
-  choices:
-    A: Estén conduciendo a un evento patrocinado por la escuela
-    B: Estén acompañados por un conductor con licencia de California de 25 años de
-      edad o más
-    C: Los pasajeros sean sus hermanos
-    D: Hayan mantenido un historial de manejo limpio durante 6 meses
-  answer: B
-  explanation: Las restricciones de la licencia provisional de un menor se anulan
-    si están acompañados por un padre o tutor con licencia, otro conductor con licencia
-    de 25 años de edad o más, o un instructor de manejo certificado.
-- id: 191
-  category: signs_and_signals
-  question: 'Un bordillo (curb) pintado de verde indica que el estacionamiento está:'
-  choices:
-    A: Permitido por tiempo ilimitado
-    B: Permitido por tiempo limitado, según lo indique una señal o la marca en el
-      bordillo
-    C: Reservado únicamente para la carga y descarga de pasajeros o mercancías
-    D: Reservado únicamente para vehículos de emergencia
-  answer: B
-  explanation: Un bordillo verde significa que puede estacionar por un tiempo limitado.
-    El límite de tiempo suele estar publicado en una señal o pintado directamente
-    en el bordillo.
-- id: 192
-  category: sharing_the_road
-  question: 'En California, es legal que los motociclistas realicen el ''lane split''
-    (división de carril), lo que significa que pueden:'
-  choices:
-    A: Conducir por el arcén (shoulder) de la carretera para rebasar el tráfico
-    B: Conducir entre dos carriles de tráfico detenido o que se mueve lentamente
-    C: Usar un carril para bicicletas designado si el tráfico está congestionado
-    D: Exceder el límite de velocidad por 10 mph para mantener la fluidez del tráfico
-  answer: B
-  explanation: La división de carril (lane splitting), definida como conducir una
-    motocicleta entre filas de vehículos detenidos o que se mueven lentamente en el
-    mismo carril, es legal en California, pero debe hacerse de manera segura y prudente.
-- id: 193
-  category: safe_driving_rules
-  question: 'Al incorporarse al tráfico desde una parada, como al salir de un bordillo
-    o de una entrada privada, necesita un espacio de al menos:'
-  choices:
-    A: Media cuadra en calles de la ciudad y una cuadra completa en la autopista
-    B: La longitud de un automóvil por cada 10 mph de velocidad del tráfico
-    C: Dos segundos para incorporarse de manera segura
-    D: La longitud de un autobús escolar
-  answer: A
-  explanation: Al incorporarse al tráfico, necesita suficiente espacio para alcanzar
-    la velocidad de los demás vehículos. El manual recomienda un espacio de aproximadamente
-    media cuadra en las calles de la ciudad y una cuadra completa en la autopista.
-- id: 194
-  category: safe_driving_rules
-  question: 'Usted puede rebasar legalmente a otro vehículo por el lado derecho:'
-  choices:
-    A: Cuando el conductor delante de usted está señalizando un giro a la derecha
-    B: En una calle de sentido único con dos o más carriles de tráfico que se mueven
-      en su dirección
-    C: Conduciendo por el arcén (shoulder) no pavimentado de la carretera
-    D: Cuando otro conductor se mueve demasiado lento en el carril rápido
-  answer: B
-  explanation: Puede rebasar por la derecha cuando una carretera abierta está claramente
-    marcada con dos o más carriles de circulación en su dirección, o en una calle
-    de sentido único. También puede rebasar por la derecha si el conductor de adelante
-    está señalizando un giro a la izquierda.
-- id: 195
-  category: signs_and_signals
-  question: 'Un bordillo pintado de blanco significa:'
-  choices:
-    A: Prohibido detenerse, pararse o estacionar en cualquier momento
-    B: Zona de carga solo para vehículos comerciales
-    C: Puede detenerse solo el tiempo suficiente para recoger o dejar pasajeros o
-      correo
-    D: Estacionamiento por tiempo limitado, según lo publicado en una señal
-  answer: C
-  explanation: Un bordillo blanco indica que puede detenerse solo el tiempo suficiente
-    para recoger o dejar pasajeros o para depositar correo en un buzón adyacente.
-- id: 196
-  category: vehicle_information
-  question: Si el pedal del acelerador se queda atascado mientras conduce, ¿cuál es
-    el primer paso que debe tomar?
-  choices:
-    A: Apagar el motor inmediatamente para cortar la energía del motor
-    B: Cambiar a punto muerto (neutral) y aplicar los frenos
-    C: Agacharse e intentar tirar del pedal hacia arriba con la mano
-    D: Bombear el pedal del acelerador rápidamente para intentar desatascarlo
-  answer: B
-  explanation: Si su acelerador se atasca, debe cambiar a punto muerto (neutral) para
-    desconectar el motor, aplicar los frenos con firmeza y buscar un lugar seguro
-    para detenerse a un lado. Apagar el motor mientras está en movimiento puede bloquear
-    el volante.
-- id: 197
-  category: defensive_driving
-  question: 'Para estar preparado ante los peligros de la carretera y evitar maniobras
-    de último momento, debe observar el camino delante de su vehículo a una distancia
-    equivalente a:'
-  choices:
-    A: 1-2 segundos
-    B: 3-5 segundos
-    C: 10-15 segundos
-    D: 20-25 segundos
-  answer: C
-  explanation: El Manual del Conductor de California recomienda observar el camino
-    10-15 segundos adelante para ver los peligros a tiempo. Esto le da tiempo para
-    reaccionar y evitar realizar maniobras repentinas o tardías.
-- id: 198
-  category: penalties_and_points
-  question: En California, una condena por una infracción de tráfico grave como un
-    DUI (conducir bajo los efectos del alcohol o drogas) o un choque y fuga (hit-and-run)
-    resultará en ¿cuántos puntos agregados a su historial de manejo?
-  choices:
-    A: Un punto
-    B: Dos puntos
-    C: Tres puntos
-    D: Cuatro puntos
-  answer: B
-  explanation: Infracciones como DUI, conducción temeraria, choque y fuga, y conducir
-    con una licencia suspendida se consideran graves y resultan en dos puntos en su
-    historial de manejo.
-- id: 199
-  category: sharing_the_road
-  question: 'Los Vehículos Eléctricos de Vecindario (NEV) y los Vehículos de Baja
-    Velocidad (LSV) generalmente están restringidos a carreteras con un límite de
-    velocidad de:'
-  choices:
-    A: 25 mph o menos
-    B: 35 mph o menos
-    C: 45 mph o menos
-    D: Cualquier carretera excepto una autopista
-  answer: B
-  explanation: Los NEV y LSV están restringidos a vías con un límite de velocidad
-    publicado de 35 mph o menos. No están diseñados para carreteras de alta velocidad.
-- id: 200
-  category: defensive_driving
-  question: 'Un vehículo de las fuerzas del orden circula en zigzag (en forma de S)
-    a través de todos los carriles de tráfico. Esto es un ''corte de tráfico'' (traffic
-    break). Usted debe:'
-  choices:
-    A: Rebasar al vehículo por el arcén (shoulder) derecho
-    B: Reducir la velocidad, encender las luces de emergencia y no rebasar al oficial
-    C: Continuar a su velocidad actual hasta que el oficial lo detenga
-    D: Detenerse inmediatamente a la derecha y parar
-  answer: B
-  explanation: Un corte de tráfico es utilizado por las fuerzas del orden para ralentizar
-    o detener el tráfico con el fin de eliminar peligros de la carretera. Debe reducir
-    la velocidad, seguir al oficial a una distancia segura y no intentar rebasarlo.
-- id: 201
-  category: penalties_and_points
-  question: 'Una primera condena por conducir bajo la influencia (DUI) de alcohol
-    o drogas puede resultar en:'
-  choices:
-    A: Una advertencia y una clase obligatoria de educación vial en línea
-    B: Una suspensión mínima de la licencia de 30 días y una multa pequeña
-    C: Hasta seis meses de cárcel y miles de dólares en multas y cargos
-    D: Una revocación de por vida de su licencia de conducir
-  answer: C
-  explanation: Incluso una primera condena por DUI es un delito penal grave con consecuencias
-    significativas, que incluyen posible tiempo en la cárcel, suspensión de la licencia,
-    programas obligatorios de DUI y costos financieros sustanciales.
-- id: 202
-  category: sharing_the_road
-  question: 'Si ve animales o ganado en la calzada o cerca de ella, debe:'
-  choices:
-    A: Tocar la bocina repetidamente para asustarlos y que salgan de la carretera
-    B: Reducir la velocidad, proceder con precaución y seguir las instrucciones de
-      la persona a cargo de ellos
-    C: Acelerar para pasarlos lo más rápido posible
-    D: Asumir que los animales no entrarán en la carretera y mantener su velocidad
-  answer: B
-  explanation: Cuando encuentre animales en la carretera, reduzca la velocidad y prepárese
-    para detenerse. Si hay una persona dirigiendo a los animales, siga sus instrucciones.
-    No haga ruidos fuertes que puedan asustar a los animales y hacer que actúen de
-    manera impredecible.
-- id: 203
-  category: driver_responsibility
-  question: 'La Ley de Responsabilidad Financiera Obligatoria de California exige
-    que cada conductor y propietario de vehículo:'
-  choices:
-    A: Pague una tarifa anual de 'uso de carretera' al DMV
-    B: Mantenga un seguro de responsabilidad civil u otra forma de responsabilidad
-      financiera
-    C: Tenga una tarjeta de crédito válida en el vehículo en todo momento
-    D: Pase una prueba de smog cada año, independientemente de la antigüedad del vehículo
-  answer: B
-  explanation: Esta ley exige que los conductores y propietarios de vehículos puedan
-    pagar por los daños que causen. Esto se hace típicamente manteniendo un seguro
-    de responsabilidad civil, aunque también son aceptables otras formas como una
-    fianza o un certificado de autoseguro emitido por el DMV.
-- id: 204
-  category: license_system
-  question: Según la capa de datos (data layer) de la página web, ¿cuál es la 'tarea'
-    (task) definida asociada con la página del Manual del Conductor de California?
-  choices:
-    A: informational,testing
-    B: educational,licensing
-    C: renewal,payment
-    D: vehicle_registration,forms
-  answer: B
-  explanation: El código JavaScript `dataLayer` en la página especifica `dataLayer.push({"task":"educational,licensing",...})`,
-    lo que indica que la función de la página está relacionada con la educación y
-    las licencias.
-- id: 205
-  category: driver_responsibility
-  question: En el guion de seguimiento (tracking script) de la página web, ¿qué valor
-    se asigna a la variable 'conLang' para especificar el idioma del contenido?
-  choices:
-    A: en-CA
-    B: eng
-    C: en_US
-    D: english
-  answer: C
-  explanation: El guion `dataLayer` incluye el par clave-valor `"conLang":"en_US"`,
-    que designa el idioma del contenido como inglés de los Estados Unidos.
-- id: 206
-  category: signs_and_signals
-  question: ¿Cuál es el código de color hexadecimal para la variable CSS `--wp-admin-theme-color`
-    utilizada en el estilo del sitio web?
-  choices:
-    A: '#7a00df'
-    B: '#313131'
-    C: '#005a87'
-    D: '#007cba'
-  answer: D
-  explanation: Las definiciones de estilo `:root` en el CSS especifican que `--wp-admin-theme-color`
-    está configurado como `#007cba`.
-- id: 207
-  category: defensive_driving
-  question: ¿Cuál es el ancho de borde estándar, en píxeles, definido por la variable
-    CSS `--wp-admin-border-width-focus` para los elementos enfocados?
-  choices:
-    A: 1px
-    B: 1.5px
-    C: 2px
-    D: 3px
-  answer: C
-  explanation: El código CSS define la variable `--wp-admin-border-width-focus` con
-    un valor de `2px`.
-- id: 208
-  category: signs_and_signals
-  question: ¿Qué código de color hexadecimal se aplica a los elementos con la clase
-    `.has-very-dark-gray-background-color`?
-  choices:
-    A: '#eee'
-    B: '#313131'
-    C: '#444'
-    D: '#ddd'
-  answer: B
-  explanation: Las reglas de CSS establecen que `.has-very-dark-gray-background-color`
-    configura el `background-color` (color de fondo) a `#313131`.
-- id: 209
-  category: signs_and_signals
-  question: La clase `.has-midnight-gradient-background` crea un degradado lineal.
-    ¿Cuáles son los dos colores principales entre los que transiciona?
-  choices:
-    A: '#330968 y #31cdcf'
-    B: '#fdd79a y #004a59'
-    C: '#020381 y #2874fc'
-    D: '#faaca8 y #dad0ec'
-  answer: C
-  explanation: El CSS para `.has-midnight-gradient-background` se define como `linear-gradient(135deg,#020381,#2874fc)`.
-- id: 210
-  category: driver_testing
-  question: Según el CSS, ¿qué estilo de cursor se aplica a los elementos con la clase
-    `.wp-element-button`?
-  choices:
-    A: default
-    B: pointer
-    C: wait
-    D: text
-  answer: B
-  explanation: La regla CSS `.wp-element-button{cursor:pointer}` indica que el cursor
-    debe cambiar a un puntero (icono de mano) al pasar sobre estos elementos.
-- id: 211
-  category: safe_driving_rules
-  question: ¿Cuando el elemento `.screen-reader-text` tiene el foco, qué valor de
-    `z-index` se le asigna para asegurar que aparezca por encima de otro contenido?
-  choices:
-    A: '100'
-    B: '1000'
-    C: '10000'
-    D: '100000'
-  answer: D
-  explanation: El CSS para el estado enfocado de `.screen-reader-text` incluye `z-index:100000`.
-- id: 212
-  category: vehicle_information
-  question: ¿Qué relleno (padding) se aplica a un elemento de encabezado `<h1>` que
-    también tiene un fondo, según el CSS proporcionado?
-  choices:
-    A: 1em 2em
-    B: 1.25em 2.375em
-    C: 15px 23px 14px
-    D: 0.5em 1em 0.5em 0
-  answer: B
-  explanation: La regla CSS `h1:where(.wp-block-heading).has-background` especifica
-    un `padding` de `1.25em 2.375em`.
-- id: 213
-  category: signs_and_signals
-  question: Para una imagen con el estilo `is-style-circle-mask`, ¿qué valor de `border-radius`
-    se utiliza para crear la forma circular?
-  choices:
-    A: 50%
-    B: 100px
-    C: 9999px
-    D: inherit
-  answer: C
-  explanation: La regla CSS `.wp-block-image.is-style-circle-mask img` establece el
-    `border-radius` en `9999px`, una técnica común para asegurar que un elemento se
-    represente como un círculo.
-- id: 214
-  category: safe_driving_rules
-  question: ¿Cuáles son los ajustes de margen para un bloque de imagen con la clase
-    `.alignright`?
-  choices:
-    A: 0.5em arriba, 0 a la derecha, 0.5em abajo, 1em a la izquierda
-    B: 1em arriba, 0.5em a la derecha, 1em abajo, 0.5em a la izquierda
-    C: 0.5em en todos los lados
-    D: 1em arriba y abajo, 0.5em a la izquierda y derecha
-  answer: A
-  explanation: El CSS para `.wp-block-image .alignright` define el margen como `margin:.5em
-    0 .5em 1em`, lo cual corresponde a los márgenes superior, derecho, inferior e
-    izquierdo respectivamente.
-- id: 215
-  category: vehicle_information
-  question: Para imágenes específicas con un tamaño calculado automáticamente, ¿qué
-    `contain-intrinsic-size` se define en el CSS para ayudar al navegador a reservar
-    espacio?
-  choices:
-    A: 1920px 1080px
-    B: 1024px 768px
-    C: 3000px 1500px
-    D: 800px 600px
-  answer: C
-  explanation: La primera regla CSS proporcionada establece `contain-intrinsic-size:3000px
-    1500px` para las imágenes que coinciden con el selector.
-- id: 216
-  category: signs_and_signals
-  question: ¿En qué ángulo se establece el degradado lineal para la clase `.has-hazy-dawn-gradient-background`?
-  choices:
-    A: 90deg
-    B: 120deg
-    C: 135deg
-    D: 180deg
-  answer: C
-  explanation: El CSS para `.has-hazy-dawn-gradient-background` se define como `linear-gradient(135deg,...)`,
-    lo que indica un ángulo de 135 grados.
-- id: 217
-  category: safe_driving_rules
-  question: ¿Qué propiedad `white-space` se aplica a la clase `.has-fit-text` para
-    evitar que el texto se divida en varias líneas?
-  choices:
-    A: normal
-    B: pre
-    C: nowrap
-    D: pre-wrap
-  answer: C
-  explanation: La regla CSS para `.has-fit-text` establece `white-space:nowrap!important`,
-    lo que obliga al texto a permanecer en una sola línea.
-- id: 218
-  category: vehicle_information
-  question: Según las reglas CSS globales, si un elemento tiene su `border-width`
-    establecido mediante un estilo en línea, ¿qué `border-style` se aplica automáticamente?
-  choices:
-    A: solid
-    B: dotted
-    C: dashed
-    D: none
-  answer: A
-  explanation: La regla `html :where([style*=border-width]){border-style:solid}` asegura
-    que cualquier elemento con un ancho de borde especificado tendrá un estilo de
-    borde sólido por defecto.
-- id: 219
-  category: defensive_driving
-  question: ¿Cuál es la opacidad predeterminada del botón dentro de un `.wp-lightbox-container`
-    antes de que un usuario interactúe con él?
-  choices:
-    A: 1 (completamente visible)
-    B: 0.5 (semitransparente)
-    C: 0 (completamente transparente/oculto)
-    D: 0.2 (mayormente transparente)
-  answer: C
-  explanation: El CSS para `.wp-lightbox-container button` establece su `opacity`
-    predeterminada en `0`, haciéndolo invisible hasta que un evento como pasar el
-    ratón (hover) lo cambie.
-- id: 220
-  category: alcohol_drugs_health
-  question: El botón dentro de un contenedor de caja de luz (lightbox) tiene un efecto
-    visual especial aplicado al área detrás de él. ¿Cuál es el valor de desenfoque
-    (`blur`) para este efecto `backdrop-filter`?
-  choices:
-    A: 4px
-    B: 8px
-    C: 16px
-    D: 20px
-  answer: C
-  explanation: El CSS para el botón de la caja de luz especifica `backdrop-filter:blur(16px)
-    saturate(180%)`. El valor de desenfoque es `16px`.
-- id: 221
-  category: signs_and_signals
-  question: La clase `.has-atomic-cream-gradient-background` realiza una transición
-    de un color claro a uno oscuro. ¿Cuál es el color oscuro en este degradado?
-  choices:
-    A: '#31cdcf'
-    B: '#004a59'
-    C: '#2874fc'
-    D: '#67a671'
-  answer: B
-  explanation: El CSS para `.has-atomic-cream-gradient-background` se define como
-    `linear-gradient(135deg,#fdd79a,#004a59)`, siendo `#004a59` el segundo color (más
-    oscuro).
-- id: 222
-  category: penalties_and_points
-  question: En pantallas con un ancho máximo de 600px, ¿qué valor se asigna a la variable
-    `--wp-admin--admin-bar--position-offset` para los elementos fijos (sticky)?
-  choices:
-    A: var(--wp-admin--admin-bar--height,0px)
-    B: 0px
-    C: 32px
-    D: -1px
-  answer: B
-  explanation: La consulta de medios (media query) `@media screen and (max-width:600px)`
-    contiene una regla que establece `--wp-admin--admin-bar--position-offset` en `0px`
-    para pantallas más pequeñas.
-- id: 223
-  category: safe_driving_rules
-  question: En el código del sitio web, ¿cuál es el `border-radius` (radio del borde)
-    especificado para un enlace de botón estándar con la clase '.wp-block-button__link'?
-  choices:
-    A: 4px
-    B: 10px
-    C: 50%
-    D: 9999px
-  answer: D
-  explanation: La regla CSS para '.wp-block-button__link' incluye 'border-radius:9999px;',
-    lo que crea una forma de "píldora" u óvalo para el botón.
-- id: 224
-  category: driver_testing
-  question: El estilo del sitio web define una clase para texto grande llamada '.is-large-text'.
-    ¿Qué tamaño de fuente (font size) aplica esta clase?
-  choices:
-    A: 1em
-    B: 2.25em
-    C: 3em
-    D: 8.4em
-  answer: B
-  explanation: 'El texto del manual especifica la regla CSS: ''.is-large-text{font-size:2.25em}''.'
-- id: 225
-  category: vehicle_information
-  question: ¿Cuál es la relación de aspecto (aspect ratio) definida para el ajuste
-    preestablecido llamado '--wp--preset--aspect-ratio--16-9'?
-  choices:
-    A: 16/9
-    B: 9/16
-    C: 4/3
-    D: '1'
-  answer: A
-  explanation: 'Los estilos raíz en el texto proporcionado definen ''--wp--preset--aspect-ratio--16-9:
-    16/9;''.'
-- id: 226
-  category: penalties_and_points
-  question: ¿Cuál es el valor de orden de apilamiento, o `z-index`, asignado a la
-    clase de superposición de caja de luz (lightbox overlay) principal '.wp-lightbox-overlay'?
-  choices:
-    A: '100'
-    B: '1000'
-    C: '100000'
-    D: '5000000'
-  answer: C
-  explanation: La regla CSS para '.wp-lightbox-overlay' establece su propiedad 'z-index'
-    en '100000' para asegurar que aparezca por encima del resto del contenido de la
-    página.
-- id: 227
-  category: alcohol_drugs_health
-  question: El estilo para un párrafo con una letra capital, definido como '.has-drop-cap',
-    establece la primera letra en un tamaño de fuente muy grande. ¿Cuál es ese tamaño
-    de fuente?
-  choices:
-    A: 2.25em
-    B: 3em
-    C: 8.4em
-    D: 1.125em
-  answer: C
-  explanation: La regla CSS para '.has-drop-cap:not(:focus):first-letter' especifica
-    'font-size:8.4em;'.
-- id: 228
-  category: signs_and_signals
-  question: ¿Qué nombre de color preestablecido corresponde al código hexadecimal
-    '#00d084' en la paleta de colores del sitio web?
-  choices:
-    A: light-green-cyan
-    B: vivid-green-cyan
-    C: pale-cyan-blue
-    D: electric-grass
-  answer: B
-  explanation: 'El texto define la variable ''--wp--preset--color--vivid-green-cyan:
-    #00d084;''.'
-- id: 229
-  category: sharing_the_road
-  question: El sitio web define un degradado preestablecido llamado '--wp--preset--gradient--blush-bordeaux'.
-    ¿Cuál es el color inicial de este degradado?
-  choices:
-    A: rgb(254,205,165)
-    B: rgb(254,45,45)
-    C: rgb(107,0,62)
-    D: rgb(255,206,236)
-  answer: A
-  explanation: La definición para '--wp--preset--gradient--blush-bordeaux' es 'linear-gradient(135deg,rgb(254,205,165)
-    0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)'. El color inicial al 0% es rgb(254,205,165).
-- id: 230
-  category: defensive_driving
-  question: Para la animación de alejamiento (zoom-out) de la caja de luz, ¿cuál es
-    el estado final de la propiedad 'transform' en la regla '@keyframes lightbox-zoom-out'?
-  choices:
-    A: translate(-50%,-50%) scale(1)
-    B: translate(0,0) scale(0)
-    C: translate(calc((-100vw + var(--wp--lightbox-scrollbar-width))/2 + var(--wp--lightbox-initial-left-position)),calc(-50vh
-      + var(--wp--lightbox-initial-top-position))) scale(var(--wp--lightbox-scale))
-    D: scale(0)
-  answer: C
-  explanation: El estado 'to' (hacia) de la regla de animación '@keyframes lightbox-zoom-out'
-    establece la propiedad transform para devolver la imagen a su posición y escala
-    originales en la página.
-- id: 231
-  category: safe_driving_rules
-  question: ¿Cuál es la decoración de texto (`text-decoration`) especificada para
-    el enlace dentro de un botón, con el estilo de la clase '.wp-block-button__link'?
-  choices:
-    A: underline (subrayado)
-    B: overline (línea superior)
-    C: line-through (tachado)
-    D: none (ninguno)
-  answer: D
-  explanation: La regla CSS para '.wp-block-button__link' establece explícitamente
-    'text-decoration:none;' para eliminar el subrayado predeterminado del enlace.
-- id: 232
-  category: vehicle_information
-  question: ¿Cuál es el peso de fuente (`font-weight`) especificado para la letra
-    inicial en un párrafo con una letra capital ('.has-drop-cap')?
-  choices:
-    A: '100'
-    B: '400'
-    C: '700'
-    D: '900'
-  answer: A
-  explanation: La regla CSS para '.has-drop-cap:not(:focus):first-letter' incluye
-    'font-weight:100;', lo que indica un peso de fuente muy ligero o delgado.
-- id: 233
-  category: license_system
-  question: Según el código del sitio web, ¿cuál es el color de fondo de un botón
-    de descarga de archivos con el estilo de la clase '.wp-block-file__button'?
-  choices:
-    A: '#ffffff'
-    B: '#0077c8'
-    C: '#32373c'
-    D: '#cf2e2e'
-  answer: C
-  explanation: La regla CSS '.wp-block-file__button{background:#32373c;...}' establece
-    el color de fondo en un gris oscuro.
-- id: 234
-  category: driver_responsibility
-  question: ¿Cuál es la opacidad (`opacity`) del elemento '.scrim' dentro de la superposición
-    de la caja de luz (lightbox), que proporciona un fondo semitransparente?
-  choices:
-    A: '0.5'
-    B: '0.7'
-    C: '0.9'
-    D: '1.0'
-  answer: C
-  explanation: La regla CSS para '.wp-lightbox-overlay .scrim' establece la opacidad
-    en '.9', lo que hace que el fondo sea mayormente opaco pero aún ligeramente transparente.
-- id: 235
-  category: safe_driving_rules
-  question: ¿Cuál es la duración del efecto de transición para la opacidad del botón
-    de la caja de luz (lightbox), según se define en el CSS?
-  choices:
-    A: 0.2 segundos
-    B: 0.4 segundos
-    C: 1 segundo
-    D: No hay transición
-  answer: A
-  explanation: La regla '.wp-lightbox-container button{transition:opacity .2s ease}'
-    especifica una transición de 0.2 segundos para la propiedad de opacidad.
-- id: 236
-  category: sharing_the_road
-  question: El ajuste preestablecido de degradado '--wp--preset--gradient--pale-ocean'
-    transiciona entre tres colores. ¿Cuál es el color intermedio en este degradado?
-  choices:
-    A: rgb(255,245,203)
-    B: rgb(51,167,181)
-    C: rgb(182,227,212)
-    D: rgb(113,206,126)
-  answer: C
-  explanation: La definición de '--wp--preset--gradient--pale-ocean' es 'linear-gradient(135deg,rgb(255,245,203)
-    0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)'. El color en la marca del 50% es
-    rgb(182,227,212).
-- id: 237
-  category: penalties_and_points
-  question: ¿Cuál es el `z-index` del botón de cierre dentro de la superposición de
-    la caja de luz (lightbox), asegurando que aparezca por encima del contenedor de
-    la imagen?
-  choices:
-    A: '100'
-    B: '999999'
-    C: '5000000'
-    D: '9999999999'
-  answer: C
-  explanation: La regla CSS para '.wp-lightbox-overlay .close-button' establece el
-    'z-index' en '5000000', colocándolo por encima de la mayoría de los demás elementos
-    de la caja de luz.
-- id: 238
-  category: driver_testing
-  question: El CSS del sitio web define un tamaño de fuente para '.is-regular-text'.
-    ¿Cuál es este tamaño?
-  choices:
-    A: .875em
-    B: 1em
-    C: 1.125em
-    D: 2.25em
-  answer: B
-  explanation: El texto proporcionado incluye la regla '.is-regular-text{font-size:1em}',
-    que representa el tamaño de fuente estándar o base.
-- id: 239
-  category: safe_driving_rules
-  question: Cuando un párrafo tiene un color de fondo, ¿qué relleno (`padding`) se
-    le aplica según la regla ':root :where(p.has-background)'?
-  choices:
-    A: 1em 2em
-    B: 1.25em 2.375em
-    C: 0.5em 1em
-    D: No se aplica ningún relleno
-  answer: B
-  explanation: La regla CSS ':root :where(p.has-background){padding:1.25em 2.375em}'
-    especifica el relleno para los párrafos que tienen un estilo de fondo.
-- id: 240
-  category: signs_and_signals
-  question: ¿Cuál es el nombre del ajuste preestablecido de degradado que se define
-    como 'linear-gradient(135deg,rgb(6,147,227) 0%,rgb(155,81,224) 100%)'?
-  choices:
-    A: vivid-cyan-blue-to-vivid-purple
-    B: cool-to-warm-spectrum
-    C: blush-light-purple
-    D: pale-ocean
-  answer: A
-  explanation: El texto proporcionado define explícitamente '--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple'
-    con este valor específico de degradado lineal.
-- id: 241
-  category: driver_responsibility
-  question: ¿En las especificaciones de diseño del sitio web del DMV, cuál es la definición
-    del estilo '--wp--preset--gradient--midnight'?
-  choices:
-    A: Un degradado lineal de negro a azul oscuro
-    B: Un degradado lineal de rgb(2,3,129) a rgb(40,116,252)
-    C: Un degradado radial de púrpura oscuro a negro
-    D: Un degradado lineal de rgb(255,245,203) a rgb(51,167,181)
-  answer: B
-  explanation: 'El texto proporcionado define ''--wp--preset--gradient--midnight:
-    linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);''.'
-- id: 242
-  category: driver_responsibility
-  question: Al revisar el código de diseño del sitio web del DMV, ¿con qué valor se
-    define '--wp--preset--font-size--medium'?
-  choices:
-    A: 18px
-    B: 21px
-    C: 28px
-    D: 32px
-  answer: C
-  explanation: 'El texto proporcionado define el ajuste preestablecido de tamaño de
-    fuente mediano como ''--wp--preset--font-size--medium: 28px;''.'
-- id: 243
-  category: driver_responsibility
-  question: El CSS del sitio web del DMV incluye un ajuste preestablecido para un
-    tamaño de fuente 'tiny' (diminuto). ¿Cuál es su valor definido en píxeles?
-  choices:
-    A: 14px
-    B: 18px
-    C: 20px
-    D: 12px
-  answer: A
-  explanation: 'El texto proporcionado enumera el tamaño de fuente ''tiny'' como ''--wp--preset--font-size--tiny:
-    14px;''.'
-- id: 244
-  category: driver_responsibility
-  question: ¿En las especificaciones técnicas del sitio web, cuál es el valor del
-    ajuste preestablecido de espaciado '--wp--preset--spacing--30'?
-  choices:
-    A: 0.44rem
-    B: 1rem
-    C: 0.67rem
-    D: 1.5rem
-  answer: C
-  explanation: 'El texto proporcionado define este ajuste preestablecido de espaciado
-    como ''--wp--preset--spacing--30: 0.67rem;''.'
-- id: 245
-  category: driver_responsibility
-  question: Las reglas de diseño del sitio web del DMV definen un ajuste preestablecido
-    de espaciado llamado '--wp--preset--spacing--40'. ¿Cuál es su valor?
-  choices:
-    A: 0.67rem
-    B: 1rem
-    C: 1.5rem
-    D: 2.25rem
-  answer: B
-  explanation: 'Según el texto proporcionado, el valor para este ajuste preestablecido
-    de espaciado es ''--wp--preset--spacing--40: 1rem;''.'
-- id: 246
-  category: driver_responsibility
-  question: Según el código del sitio web proporcionado, ¿cuál es el valor definido
-    para la variable de espaciado '--wp--preset--spacing--50'?
-  choices:
-    A: 1rem
-    B: 1.5rem
-    C: 2.25rem
-    D: 3.38rem
-  answer: B
-  explanation: 'El texto proporcionado especifica ''--wp--preset--spacing--50: 1.5rem;''.'
-- id: 247
-  category: driver_responsibility
-  question: Según el código proporcionado, ¿cuál es la definición CSS para el efecto
-    '--wp--preset--shadow--deep'?
-  choices:
-    A: 6px 6px 9px rgba(0, 0, 0, 0.2)
-    B: 12px 12px 50px rgba(0, 0, 0, 0.4)
-    C: 6px 6px 0px rgba(0, 0, 0, 0.2)
-    D: 12px 12px 25px rgba(0, 0, 0, 0.5)
-  answer: B
-  explanation: 'El texto proporcionado define el ajuste preestablecido de sombra ''deep''
-    como ''--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);''.'
-- id: 248
-  category: driver_responsibility
-  question: La paleta de colores del sitio web del DMV incluye un ajuste preestablecido
-    llamado 'pale-pink'. ¿Cuál es su código de color hexadecimal correspondiente?
-  choices:
-    A: '#ffffff'
-    B: '#cf2e2e'
-    C: '#f78da7'
-    D: '#abb8c3'
-  answer: C
-  explanation: 'El texto proporcionado enumera el código hexadecimal para ''pale-pink''
-    en el CSS completo: ''--wp--preset--color--pale-pink: #f78da7;''.'
-- id: 249
-  category: driver_responsibility
-  question: Según el código proporcionado, ¿qué código hexadecimal se le asigna al
-    ajuste preestablecido de color 'light-green-cyan'?
-  choices:
-    A: '#7bdcb5'
-    B: '#00d084'
-    C: '#8ed1fc'
-    D: '#9b51e0'
-  answer: A
-  explanation: 'El texto proporcionado enumera el código hexadecimal para este color
-    en el CSS completo: ''--wp--preset--color--light-green-cyan: #7bdcb5;''.'
-- id: 250
-  category: driver_responsibility
-  question: Un script en el sitio web del DMV está diseñado para mejorar la funcionalidad
-    del navegador. ¿Qué nombre de clase elimina del elemento HTML principal al cargarse?
-  choices:
-    A: js
-    B: no-script
-    C: no-js
-    D: html-fallback
-  answer: C
-  explanation: 'El código JavaScript proporcionado incluye la línea: ''document.documentElement.className
-    = document.documentElement.className.replace(''no-js'', " ");'', la cual elimina
-    la clase ''no-js''.'
-- id: 251
-  category: driver_responsibility
-  question: ¿Cómo determina si debe usar 'https' o 'http' el script que carga las
-    fuentes web para el sitio web del DMV?
-  choices:
-    A: Siempre usa 'https' por defecto
-    B: Verifica si el navegador es una versión moderna
-    C: Verifica si el protocolo de la página actual es 'https'
-    D: Siempre usa 'http' por defecto
-  answer: C
-  explanation: 'El fragmento de código ''wf.src = (''https:'' == document.location.protocol
-    ? ''https'' : ''http'')'' muestra que verifica el protocolo de la ubicación del
-    documento actual.'
-- id: 252
-  category: driver_responsibility
-  question: El sitio web del DMV utiliza Google Tag Manager para análisis, el cual
-    se carga en un iframe oculto. ¿Qué propiedades de estilo se utilizan para ocultar
-    este elemento?
-  choices:
-    A: opacity:0; z-index:-1;
-    B: height:0; width:0;
-    C: display:none; visibility:hidden;
-    D: position:absolute; left:-9999px;
-  answer: C
-  explanation: El HTML proporcionado para el iframe incluye el atributo 'style="display:none;visibility:hidden"'.
-- id: 253
-  category: driver_responsibility
-  question: El botón para activar el chatbot del DMV tiene un atributo de accesibilidad,
-    'aria-controls'. ¿Qué valor se le asigna a este atributo?
-  choices:
-    A: js-chatbot-show
-    B: chatbot__show-btn
-    C: js-chatbot-dialog
-    D: GTM-KHCVGH4
-  answer: C
-  explanation: El código del elemento de botón proporcionado es '<button ... aria-controls="js-chatbot-dialog">',
-    lo que indica que controla el elemento de diálogo del chatbot.
-- id: 254
-  category: driver_responsibility
-  question: En las reglas de diseño CSS del sitio web, ¿cuál es el tamaño de espacio
-    (gap) definido para los bloques de columnas flexibles ('.wp-block-columns.is-layout-flex')?
-  choices:
-    A: 0.5em
-    B: 1.25em
-    C: 2em
-    D: 1rem
-  answer: C
-  explanation: 'El CSS proporcionado establece: '':where(.wp-block-columns.is-layout-flex){gap:
-    2em;}''.'
-- id: 255
-  category: driver_responsibility
-  question: Según el CSS proporcionado, ¿cuál es el tamaño de espacio (gap) especificado
-    para las cuadrículas de plantillas de publicaciones ('.wp-block-post-template.is-layout-grid')?
-  choices:
-    A: 2em
-    B: 1.25em
-    C: 0.5em
-    D: 1.5rem
-  answer: B
-  explanation: 'El CSS proporcionado especifica: '':where(.wp-block-post-template.is-layout-grid){gap:
-    1.25em;}''.'
-- id: 256
-  category: driver_responsibility
-  question: El elemento de botón utilizado para mostrar el chatbot del DMV tiene un
-    estilo que utiliza una clase CSS específica. ¿Cuál es el nombre de esa clase?
-  choices:
-    A: js-chatbot-show
-    B: chatbot__show-btn
-    C: js-chatbot-dialog
-    D: wp-block-button
-  answer: B
-  explanation: El HTML proporcionado para el botón incluye el atributo 'class="chatbot__show-btn"'.
-- id: 257
-  category: vehicle_information
-  question: Según el menú en línea de 'Registro de Vehículos' (Vehicle Registration)
-    del DMV, ¿cuál de los siguientes servicios se ofrece?
-  choices:
-    A: Calcular el impuesto sobre la propiedad del vehículo
-    B: Presentar comprobante de seguro
-    C: Reportar la venta de un vehículo
-    D: Solicitar un permiso de vehículo comercial
-  answer: B
-  explanation: El texto enumera 'Presentar comprobante de seguro' (Submit Proof of
-    Insurance) como una opción bajo el menú de 'Registro de Vehículos' en el sitio
-    web del DMV.
-- id: 258
-  category: driver_responsibility
-  question: Bajo el menú de 'Citas' (Appointments) en el sitio web del DMV, ¿qué servicio
-    le permite unirse a la fila en una oficina del DMV de forma remota antes de llegar?
-  choices:
-    A: Programar cita
-    B: Visita a la oficina virtual
-    C: Hacer fila ahora
-    D: Pruebas en línea
-  answer: C
-  explanation: El texto muestra 'Hacer fila ahora' (Get in Line Now) como un servicio
-    ofrecido bajo el menú de 'Citas', el cual permite a los clientes asegurar su lugar
-    en la fila en una oficina física.
-- id: 259
-  category: driver_testing
-  question: Además de los Manuales del Conductor y los Exámenes de Práctica, ¿qué
-    otro tipo de guía informativa está disponible bajo el menú de 'Pruebas' (Testing)
-    del DMV?
-  choices:
-    A: Manuales de mantenimiento de vehículos
-    B: Estudios de casos de leyes de tránsito
-    C: Guías para conductores especializados
-    D: Tablas comparativas de seguros
-  answer: C
-  explanation: El menú de 'Pruebas' en el sitio web del DMV enumera 'Guías para conductores
-    especializados' (Specialty Driver Guides) como un recurso disponible para los
-    conductores.
-- id: 260
-  category: driver_responsibility
-  question: El servicio en línea 'Verificar estado' (Check Status) del DMV le permite
-    verificar el estado de varias solicitudes y casos. ¿Cuál de los siguientes figura
-    como un estado verificable?
-  choices:
-    A: Estado de la solicitud de REAL ID
-    B: Estado de queja de la escuela de manejo
-    C: Estado del caso IBC
-    D: Estado de exención de la prueba de smog
-  answer: C
-  explanation: El menú 'Verificar estado' en el sitio web del DMV enumera específicamente
-    'Estado del caso IBC' (IBC Case Status) como una opción.
-- id: 261
-  category: driver_testing
-  question: ¿Cuál es la sección final del Manual del Automovilista de California,
-    según el Índice de contenido proporcionado?
-  choices:
-    A: Seguridad del conductor
-    B: Glosario
-    C: Índice
-    D: Derechos de autor
-  answer: B
-  explanation: 'El Índice de contenido enumera la "Sección 14: Glosario" como la última
-    sección numerada del manual.'
-- id: 262
-  category: driver_responsibility
-  question: El Mensaje del Secretario en el manual del automovilista establece que
-    el manual está disponible en ¿cuántos idiomas para servir a los californianos?
-  choices:
-    A: Tres
-    B: Cinco
-    C: Siete
-    D: Nueve
-  answer: D
-  explanation: 'El Mensaje del Secretario establece explícitamente: "El Manual del
-    Automovilista de California está disponible en nueve idiomas...".'
-- id: 263
-  category: sharing_the_road
-  question: En el Mensaje del Secretario, se señala que la licencia de conducir permite
-    a qué grupo de conductores transportar mercancías y apoyar la economía?
-  choices:
-    A: Conductores de entregas
-    B: Conductores de viajes compartidos
-    C: Camioneros
-    D: Conductores de furgonetas de cercanías
-  answer: C
-  explanation: 'El mensaje indica: "También permite a los camioneros transportar bienes
-    y servicios para apoyar nuestra economía".'
-- id: 264
-  category: driver_responsibility
-  question: ¿Qué tecnología utiliza el DMV para proporcionar traducción en sus servicios
-    de chatbot y chat en vivo?
-  choices:
-    A: Personal bilingüe interno
-    B: Un departamento estatal de traducción dedicado
-    C: Traducción automática de proveedores externos
-    D: Un programa de traducción de voluntarios de la comunidad
-  answer: C
-  explanation: El "Descargo de responsabilidad de traducción de terceros" establece
-    que "los servicios de chatbot y chat en vivo del DMV utilizan proveedores externos
-    para proporcionar traducción automática".
-- id: 265
-  category: driver_responsibility
-  question: Si existen discrepancias o diferencias entre la versión en inglés del
-    sitio web del DMV y una versión traducida, ¿cuál es el efecto legal?
-  choices:
-    A: La versión traducida tiene prioridad si es el idioma nativo del usuario.
-    B: Ambas versiones se consideran igualmente válidas.
-    C: Las discrepancias no son vinculantes y no tienen efecto legal.
-    D: Se requiere una revisión legal para determinar la información correcta.
-  answer: C
-  explanation: 'El descargo de responsabilidad establece: "Cualquier discrepancia
-    o diferencia creada en la traducción no es vinculante y no tiene efecto legal
-    para fines de cumplimiento o ejecución".'
-- id: 266
-  category: driver_responsibility
-  question: ¿Cuál de los siguientes aparece como un enlace principal en la barra de
-    navegación de utilidades en la parte superior del sitio web del DMV?
-  choices:
-    A: Citas
-    B: MyDMV
-    C: Ubicaciones y horarios
-    D: Contáctenos
-  answer: B
-  explanation: La barra de navegación de utilidades, etiquetada como "nav-utility"
-    en el texto, contiene los enlaces REAL ID, Servicios en línea, Traducir y MyDMV.
-- id: 267
-  category: safe_driving_rules
-  question: Según el Índice de contenido del manual, ¿qué sección es lo suficientemente
-    extensa como para estar dividida en varias partes de "Continuación"?
-  choices:
-    A: 'Sección 6: Navegando por las carreteras'
-    B: 'Sección 7: Leyes y reglas de la carretera'
-    C: 'Sección 8: Conducción segura'
-    D: Todas las anteriores
-  answer: D
-  explanation: El Índice de contenido proporcionado muestra entradas de "Continuación"
-    para la Sección 6, la Sección 7 y la Sección 8, lo que indica que todas son secciones
-    extensas.
-- id: 268
-  category: sharing_the_road
-  question: El Mensaje del Secretario enfatiza que las reglas de la carretera deben
-    ser seguidas por todos los usuarios, incluidos los conductores de automóviles,
-    vehículos comerciales y ¿qué otros dos grupos?
-  choices:
-    A: Peatones y patinadores
-    B: Motocicletas y bicicletas
-    C: Vehículos de tren ligero y autobuses
-    D: Scooters y ciclomotores
-  answer: B
-  explanation: 'El mensaje indica: "Ya sea que conduzca un automóvil, una motocicleta,
-    un vehículo comercial o ande en bicicleta, es fundamental que cumplamos con las
-    reglas...".'
-- id: 269
-  category: driver_responsibility
-  question: Cuando termina su conversación con el Asistente Virtual del DMV, ¿qué
-    opción se le da con respecto a la conversación?
-  choices:
-    A: Calificar la utilidad del asistente
-    B: Guardar la transcripción
-    C: Enviarse la conversación por correo electrónico
-    D: Eliminar la conversación permanentemente
-  answer: B
-  explanation: 'El Descargo de responsabilidad general para el Asistente Virtual establece:
-    "Cuando termine su chat, puede guardar la transcripción".'
-- id: 270
-  category: license_system
-  question: Según el menú "Verificar estado" (Check Status) en el sitio web del DMV,
-    ¿puede verificar el progreso de cuál de estas actualizaciones de información personal?
-  choices:
-    A: Estado de cambio de nombre
-    B: Estado de actualización de la categoría de género
-    C: Estado de registro de votantes
-    D: Estado de cambio de dirección
-  answer: D
-  explanation: El menú "Verificar estado" enumera explícitamente el "Estado de cambio
-    de dirección" como una opción para que los usuarios realicen el seguimiento.
-- id: 271
-  category: license_system
-  question: Según el Índice de Contenidos, ¿qué sección del Manual del Automovilista
-    de California cubre el proceso de 'Obtener un permiso de instrucción y una licencia
-    de conducir'?
-  choices:
-    A: Sección 1
-    B: Sección 2
-    C: Sección 3
-    D: Sección 4
-  answer: B
-  explanation: El Índice de Contenidos del manual titula claramente la 'Sección 2'
-    como 'Obtener un permiso de instrucción y una licencia de conducir'.
-- id: 272
-  category: driver_responsibility
-  question: ¿Cuál es la principal advertencia de seguridad que da el DMV con respecto
-    al uso de su Asistente Virtual?
-  choices:
-    A: No usarlo en una red Wi-Fi pública
-    B: No incluir ninguna información personal
-    C: No compartir la transcripción del chat
-    D: No usarlo para transacciones financieras
-  answer: B
-  explanation: 'El Descargo de Responsabilidad General para el Asistente Virtual del
-    DMV comienza con la instrucción: ''por favor, no incluya ninguna información personal''.'
-- id: 273
-  category: driver_responsibility
-  question: 'Según el Secretario de la Agencia de Transporte del Estado de California,
-    conducir o viajar en un vehículo se considera un(a):'
-  choices:
-    A: Derecho
-    B: Requisito
-    C: Privilegio
-    D: Pasatiempo
-  answer: C
-  explanation: 'El mensaje del Secretario establece: ''Recuerde que conducir o viajar
-    en un vehículo es un privilegio y, sobre todo, la seguridad debe ser la prioridad''.'
-- id: 274
-  category: safe_driving_rules
-  question: 'El mensaje del Secretario en el manual del automovilista enfatiza que
-    la prioridad número uno para todos los usuarios de la vía debe ser:'
-  choices:
-    A: La velocidad
-    B: La conveniencia
-    C: La seguridad
-    D: Seguir las instrucciones
-  answer: C
-  explanation: 'El texto del mensaje del Secretario establece claramente: ''...sobre
-    todo, la seguridad debe ser la prioridad''.'
-- id: 275
-  category: sharing_the_road
-  question: 'Además de otros conductores, el mensaje del Secretario le recuerda específicamente
-    prestar atención a:'
-  choices:
-    A: Construcciones en la carretera y animales
-    B: Solo señales de tráfico y semáforos
-    C: Ciclistas y peatones
-    D: Vehículos de emergencia y fuerzas del orden
-  answer: C
-  explanation: El mensaje aconseja a los conductores '...prestar atención a otros
-    conductores, ciclistas y peatones...'
-- id: 276
-  category: driver_testing
-  question: Además de inglés y español, ¿en cuál de los siguientes idiomas está disponible
-    el Manual del Automovilista de California en formato PDF?
-  choices:
-    A: Alemán
-    B: Francés
-    C: Coreano
-    D: Vietnamita
-  answer: D
-  explanation: El texto enumera los idiomas disponibles en PDF, que incluyen 'ngôn
-    ngữ tiếng Việt (vietnamita)' entre otros como ruso, armenio, hindi, punyabí y
-    chino.
-- id: 277
-  category: driver_testing
-  question: Para las personas que se comunican mediante el Lenguaje de Señas Americano
-    (ASL), ¿dónde se puede encontrar una versión en video del manual del automovilista?
-  choices:
-    A: En un DVD especial del DMV
-    B: En la página principal del sitio web del DMV
-    C: En YouTube
-    D: En las oficinas locales
-  answer: C
-  explanation: El texto incluye una sección para 'Video en Lenguaje de Señas Americano'
-    con un enlace para 'Reproducir video en YouTube'.
-- id: 278
-  category: driver_responsibility
-  question: Según el descargo de responsabilidad del DMV, ¿cuál es el propósito principal
-    de proporcionar la herramienta Google™ Translate en su sitio web?
-  choices:
-    A: Para traducción legal oficial
-    B: Solo para fines de información y conveniencia
-    C: Para reemplazar la necesidad de un intérprete
-    D: Para completar formularios oficiales en otros idiomas
-  answer: B
-  explanation: 'El descargo de responsabilidad establece: ''Esta herramienta de aplicación
-    de traducción se proporciona únicamente con fines de información y conveniencia''.'
-- id: 279
-  category: driver_responsibility
-  question: ¿Cuál es el efecto legal de cualquier discrepancia o diferencia creada
-    en una traducción automática del sitio web o del chatbot del DMV?
-  choices:
-    A: Son legalmente vinculantes
-    B: Pueden usarse para fines de cumplimiento
-    C: No son vinculantes y no tienen efecto legal
-    D: Deben reportarse al equipo legal del DMV
-  answer: C
-  explanation: 'Los descargos de responsabilidad tanto para el sitio web como para
-    el chatbot establecen: ''Cualquier discrepancia o diferencia creada en la traducción
-    no es vinculante y no tiene efecto legal para fines de cumplimiento o ejecución''.'
-- id: 280
-  category: license_system
-  question: 'El mensaje del Secretario anima a las personas a utilizar los servicios
-    en línea del DMV porque hacerlo puede ser un(a):'
-  choices:
-    A: Aprobación garantizada
-    B: Ahorro de tiempo
-    C: Forma de evitar todos los cargos
-    D: Método para obtener una licencia temporal
-  answer: B
-  explanation: 'El mensaje indica: ''Pruebe primero en línea, ya que puede ser un
-    ahorro de tiempo''.'
-- id: 281
-  category: driver_responsibility
-  question: 'Según el pie de página del sitio web, el contenido del sitio web del
-    DMV de California está protegido por derechos de autor de:'
-  choices:
-    A: El Departamento de Vehículos Motorizados
-    B: Google™
-    C: El Estado de California
-    D: La Agencia de Transporte del Estado de California
-  answer: C
-  explanation: El pie de página contiene el aviso 'Copyright &copy; 2026 State of
-    California'.
-- id: 282
-  category: driver_responsibility
-  question: ¿Cuál de las siguientes opciones aparece en el pie de página del sitio
-    web como una página de información legal o de políticas?
-  choices:
-    A: Registro de vehículos
-    B: Condiciones de uso
-    C: Exámenes de práctica
-    D: Ubicaciones de las oficinas
-  answer: B
-  explanation: La navegación del pie de página enumera 'Condiciones de uso' junto
-    con otras páginas de políticas como 'Política de privacidad' y 'Política de cookies'.
-- id: 283
-  category: vehicle_information
-  question: ¿Cuál de los siguientes tipos de documentos del DMV no se puede traducir
-    utilizando la herramienta de traducción automática del sitio web?
-  choices:
-    A: El Manual del Automovilista
-    B: Descargos de responsabilidad del sitio web
-    C: Comunicados de prensa
-    D: Publicaciones
-  answer: D
-  explanation: El Descargo de Responsabilidad de Google™ Translate enumera explícitamente
-    las 'Publicaciones' como uno de los tipos de páginas que no se pueden traducir.
-- id: 284
-  category: driver_responsibility
-  question: 'Los esfuerzos de modernización del DMV tienen como objetivo hacer que
-    la experiencia digital para los clientes sea:'
-  choices:
-    A: Más segura pero más lenta
-    B: Disponible solo durante el horario de atención
-    C: Completamente automatizada sin ayuda humana
-    D: Más fácil, rápida y conveniente
-  answer: D
-  explanation: 'El texto establece: ''El DMV ha estado modernizando las interacciones
-    con sus clientes, haciendo que la experiencia digital de los californianos sea
-    más fácil, rápida y conveniente''.'
+    cartel o placa de matrícula de estacionamiento para personas con discapacidad
+    válida pueden estacionarse en estos espacios. Las infracciones conllevan multas
+    elevadas.
+  id: 252


### PR DESCRIPTION
Resolves verifier PR #44 finding: 72 of 273 CA LLM questions were generated from the DMV website's HTML/CSS source instead of the real handbook (asking about CSS preset names, GTM iframe styling, lightbox z-index, etc.). Root cause: config.json manual_url pointed at the /portal/handbook/ HTML portal page. The catalog refresh already corrected the URL; this PR replaces data/states/ca/manual.pdf with the real PDF, re-extracts text, and regenerates the question bank end-to-end (LLM + sign + ES translation). Re-runs quiz_gates.py — Precision should be A vs the previous F.